### PR TITLE
Remove GithubWebhook.interested()

### DIFF
--- a/packit_service/service/api/webhooks.py
+++ b/packit_service/service/api/webhooks.py
@@ -101,10 +101,6 @@ class GithubWebhook(Resource):
             github_webhook_calls.labels(result="invalid_signature").inc()
             return str(exc), HTTPStatus.UNAUTHORIZED
 
-        if not self.interested():
-            github_webhook_calls.labels(result="not_interested").inc()
-            return "Thanks but we don't care about this event", HTTPStatus.ACCEPTED
-
         # TODO: define task names at one place
         celery_app.send_task(
             name="task.steve_jobs.process_message", kwargs={"event": msg}
@@ -151,26 +147,6 @@ class GithubWebhook(Resource):
             logger.warning(msg)
             logger.debug(f"X-Hub-Signature: {sig!r} != computed: {mac.hexdigest()}")
             raise ValidationFailed(msg)
-
-    @staticmethod
-    def interested():
-        """
-        Check X-GitHub-Event header for events we know we give a f...
-        ...finely prepared response to.
-        :return: False if we are not interested in this kind of event
-        """
-        uninteresting_events = {
-            "integration_installation",
-            "integration_installation_repositories",
-        }
-        event_type = request.headers.get("X-GitHub-Event")
-        uuid = request.headers.get("X-GitHub-Delivery")
-        _interested = event_type not in uninteresting_events
-
-        logger.debug(
-            f"{event_type} {uuid}{' (not interested)' if not _interested else ''}"
-        )
-        return _interested
 
 
 @ns.route("/gitlab")


### PR DESCRIPTION
Those legacy events will no longer be sent after October 1 2020.
https://developer.github.com/changes/2020-04-15-replacing-the-installation-and-installation-repositories-events

Reverts ff431d9 which was added to fix #42.
Fixes #718 

Wait with merging this till October.