### PR TITLE
Reporting build status while no permission

### DIFF
--- a/files/docker/Dockerfile.tests
+++ b/files/docker/Dockerfile.tests
@@ -1,6 +1,6 @@
 # For running tests locally, see check_in_container target in Makefile
 
-FROM docker.io/usercont/packit-service-worker:dev
+FROM docker.io/usercont/packit-service-worker:stg
 
 ARG SOURCE_BRANCH
 RUN  if [[ -z $SOURCE_BRANCH ]]; then \

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -509,6 +509,13 @@ class MergeRequestGitlabEvent(AddPullRequestDbTrigger, AbstractGitlabEvent):
         result["action"] = result["action"].value
         return result
 
+    def get_base_project(self) -> GitProject:
+        fork = self.project.service.get_project(
+            namespace=self.source_repo_namespace,
+            repo=self.source_repo_name,
+        )
+        return fork
+
 
 class PullRequestGithubEvent(AddPullRequestDbTrigger, AbstractGithubEvent):
     def __init__(
@@ -584,6 +591,13 @@ class MergeRequestCommentGitlabEvent(AddPullRequestDbTrigger, AbstractGitlabEven
         result = super().get_dict()
         result["action"] = result["action"].value
         return result
+
+    def get_base_project(self) -> GitProject:
+        fork = self.project.service.get_project(
+            namespace=self.source_repo_namespace,
+            repo=self.source_repo_name,
+        )
+        return fork
 
 
 class PullRequestCommentGithubEvent(AddPullRequestDbTrigger, AbstractGithubEvent):

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -254,10 +254,12 @@ class TestEvents:
         assert isinstance(event_object.project, GitlabProject)
         assert event_object.project.full_repo_name == "testing-packit/hello-there"
 
+        assert event_object.base_project.full_repo_name == "testing-packit/hello-there"
+
         flexmock(PackageConfigGetter).should_receive(
             "get_package_config_from_repo"
         ).with_args(
-            base_project=None,
+            base_project=event_object.base_project,
             project=event_object.project,
             pr_id=1,
             reference="1f6a716aa7a618a9ffe56970d77177d99d100022",
@@ -278,10 +280,12 @@ class TestEvents:
         assert isinstance(event_object.project, GitlabProject)
         assert event_object.project.full_repo_name == "testing-packit/hello-there"
 
+        assert event_object.base_project.full_repo_name == "testing-packit/hello-there"
+
         flexmock(PackageConfigGetter).should_receive(
             "get_package_config_from_repo"
         ).with_args(
-            base_project=None,
+            base_project=event_object.base_project,
             project=event_object.project,
             pr_id=2,
             reference="45e272a57335e4e308f3176df6e9226a9e7805a9",
@@ -387,10 +391,13 @@ class TestEvents:
         assert isinstance(event_object.project, GitlabProject)
         assert event_object.project.full_repo_name == "testing-packit/hello-there"
 
+        assert isinstance(event_object.project, GitlabProject)
+        assert event_object.base_project.full_repo_name == "testing-packit/hello-there"
+
         flexmock(PackageConfigGetter).should_receive(
             "get_package_config_from_repo"
         ).with_args(
-            base_project=None,
+            base_project=event_object.base_project,
             project=event_object.project,
             pr_id=2,
             reference="45e272a57335e4e308f3176df6e9226a9e7805a9",

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -121,3 +121,37 @@ def test_set_status(
         )
 
     reporter.set_status(state, description, check_name, url)
+
+
+@pytest.mark.parametrize(
+    ("project,commit_sha," "pr_id,pr_object," "state,description,check_names,url,"),
+    [
+        pytest.param(
+            flexmock(),
+            "7654321",
+            "11",
+            flexmock(),
+            CommitStatus.success,
+            "We made it!",
+            "packit/pr-rpm-build",
+            "https://api.packit.dev/build/111/logs",
+        ),
+    ],
+)
+def test_report_status_by_comment(
+    project,
+    commit_sha,
+    pr_id,
+    pr_object,
+    state,
+    description,
+    check_names,
+    url,
+):
+    reporter = StatusReporter(project, commit_sha, pr_id)
+
+    project.should_receive("pr_comment").with_args(
+        pr_id, f"| [{check_names}]({url}) | SUCCESS |"
+    ).once()
+
+    reporter.report_status_by_comment(state, url, check_names)


### PR DESCRIPTION
In Gitlab while working with upstream-project we don't have access to the merge request commit coming from fork repos. To set commit status we need access to the repository. 

So, if the reporting fails we can report the state using the MR comment and request access to the forked repository ([docs](https://docs.gitlab.com/ee/api/access_requests.html)). 

- [x] Adding the functionality to report build status using MR comment.
- [x] Fixed enqueue error #741 
- [x] Requesting for project access (with right permissions).
