### PR TITLE
Use integer response code values

### DIFF
--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -40,7 +40,7 @@ ns = Namespace("copr-builds", description="COPR builds")
 @ns.route("")
 class CoprBuildsList(Resource):
     @ns.expect(pagination_arguments)
-    @ns.response(HTTPStatus.PARTIAL_CONTENT, "Copr builds list follows")
+    @ns.response(HTTPStatus.PARTIAL_CONTENT.value, "Copr builds list follows")
     def get(self):
         """ List all Copr builds. """
 
@@ -72,7 +72,7 @@ class CoprBuildsList(Resource):
 
             result.append(build_dict)
 
-        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT,)
+        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT.value,)
         resp.headers["Content-Range"] = f"copr-builds {first + 1}-{last}/*"
         return resp
 
@@ -80,15 +80,15 @@ class CoprBuildsList(Resource):
 @ns.route("/<int:id>")
 @ns.param("id", "Copr build identifier")
 class InstallationItem(Resource):
-    @ns.response(HTTPStatus.OK, "OK, copr build details follow")
-    @ns.response(HTTPStatus.NO_CONTENT, "Copr build identifier not in db/hash")
+    @ns.response(HTTPStatus.OK.value, "OK, copr build details follow")
+    @ns.response(HTTPStatus.NO_CONTENT.value, "Copr build identifier not in db/hash")
     def get(self, id):
         """A specific copr build details. From copr_build hash, filled by worker."""
         builds_list = CoprBuildModel.get_all_by_build_id(str(id))
         if not bool(builds_list.first()):
             return response_maker(
                 {"error": "No info about build stored in DB"},
-                status=HTTPStatus.NOT_FOUND,
+                status=HTTPStatus.NOT_FOUND.value,
             )
 
         build = builds_list[0]

--- a/packit_service/service/api/healthz.py
+++ b/packit_service/service/api/healthz.py
@@ -34,12 +34,12 @@ ns = Namespace("healthz", description="Health checks")
 
 @ns.route("")
 class HealthCheck(Resource):
-    @ns.response(HTTPStatus.OK, "Healthy")
+    @ns.response(HTTPStatus.OK.value, "Healthy")
     def get(self):
         """Health check"""
         return "We are healthy!"
 
-    @ns.response(HTTPStatus.OK, "Healthy")
+    @ns.response(HTTPStatus.OK.value, "Healthy")
     def head(self):
         """Health check (no body)"""
         # HEAD is identical to GET except that it MUST NOT return a message-body in the response

--- a/packit_service/service/api/installations.py
+++ b/packit_service/service/api/installations.py
@@ -36,7 +36,7 @@ ns = Namespace("installations", description="Github App installations")
 
 @ns.route("")
 class InstallationsList(Resource):
-    @ns.response(HTTPStatus.OK, "OK, installations list follows")
+    @ns.response(HTTPStatus.OK.value, "OK, installations list follows")
     def get(self):
         """List all Github App installations"""
         return [installation.to_dict() for installation in InstallationModel.get_all()]
@@ -45,9 +45,13 @@ class InstallationsList(Resource):
 @ns.route("/<int:id>")
 @ns.param("id", "Installation identifier")
 class InstallationItem(Resource):
-    @ns.response(HTTPStatus.OK, "OK, installation details follow")
-    @ns.response(HTTPStatus.NO_CONTENT, "identifier not in whitelist")
+    @ns.response(HTTPStatus.OK.value, "OK, installation details follow")
+    @ns.response(HTTPStatus.NO_CONTENT.value, "identifier not in whitelist")
     def get(self, id):
         """A specific installation details"""
         installation = InstallationModel.get_by_id(id)
-        return installation.to_dict() if installation else ("", HTTPStatus.NO_CONTENT)
+        return (
+            installation.to_dict()
+            if installation
+            else ("", HTTPStatus.NO_CONTENT.value)
+        )

--- a/packit_service/service/api/koji_builds.py
+++ b/packit_service/service/api/koji_builds.py
@@ -65,7 +65,7 @@ class KojiBuildsList(Resource):
 class KojiBuildItem(Resource):
     @koji_builds_ns.response(HTTPStatus.OK, "OK, koji build details follow")
     @koji_builds_ns.response(
-        HTTPStatus.NO_CONTENT, "Koji build identifier not in db/hash"
+        HTTPStatus.NO_CONTENT.value, "Koji build identifier not in db/hash"
     )
     def get(self, id):
         """A specific koji build details. From koji_build hash, filled by worker."""
@@ -80,7 +80,7 @@ class KojiBuildItem(Resource):
             build = make_response(dumps(build_dict))
             build.headers["Content-Type"] = "application/json"
             build.headers["Access-Control-Allow-Origin"] = "*"
-            return build if build else ("", HTTPStatus.NO_CONTENT)
+            return build if build else ("", HTTPStatus.NO_CONTENT.value)
 
         else:
-            return "", HTTPStatus.NO_CONTENT
+            return "", HTTPStatus.NO_CONTENT.value

--- a/packit_service/service/api/projects.py
+++ b/packit_service/service/api/projects.py
@@ -20,8 +20,8 @@ ns = Namespace(
 @ns.route("")
 class ProjectsList(Resource):
     @ns.expect(pagination_arguments)
-    @ns.response(HTTPStatus.PARTIAL_CONTENT, "Projects list follows")
-    @ns.response(HTTPStatus.OK, "OK")
+    @ns.response(HTTPStatus.PARTIAL_CONTENT.value, "Projects list follows")
+    @ns.response(HTTPStatus.OK.value, "OK")
     def get(self):
         """List all GitProjects"""
 
@@ -43,7 +43,7 @@ class ProjectsList(Resource):
             }
             result.append(project_info)
 
-        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT,)
+        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT.value,)
         resp.headers["Content-Range"] = f"git-projects {first + 1}-{last}/*"
         return resp
 
@@ -53,7 +53,7 @@ class ProjectsList(Resource):
 @ns.param("namespace", "Namespace")
 @ns.param("repo_name", "Repo Name")
 class ProjectInfo(Resource):
-    @ns.response(HTTPStatus.OK, "Project details follow")
+    @ns.response(HTTPStatus.OK.value, "Project details follow")
     def get(self, forge, namespace, repo_name):
         """Project Details"""
         project = GitProjectModel.get_project(forge, namespace, repo_name)
@@ -78,7 +78,7 @@ class ProjectInfo(Resource):
 @ns.param("forge", "Git Forge")
 @ns.param("namespace", "Namespace")
 class ProjectsNamespace(Resource):
-    @ns.response(HTTPStatus.OK, "Projects details follow")
+    @ns.response(HTTPStatus.OK.value, "Projects details follow")
     def get(self, forge, namespace):
         """List of projects of given forge and namespace"""
         result = []
@@ -108,7 +108,7 @@ class ProjectsPRs(Resource):
     @ns.response(
         HTTPStatus.PARTIAL_CONTENT, "Project PRs handled by Packit Service follow"
     )
-    @ns.response(HTTPStatus.OK, "OK")
+    @ns.response(HTTPStatus.OK.value, "OK")
     def get(self, forge, namespace, repo_name):
         """List PRs"""
 
@@ -149,7 +149,7 @@ class ProjectsPRs(Resource):
 
             result.append(pr_info)
 
-        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT,)
+        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT.value,)
         resp.headers["Content-Range"] = f"git-project-prs {first + 1}-{last}/*"
         return resp
 
@@ -159,7 +159,9 @@ class ProjectsPRs(Resource):
 @ns.param("namespace", "Namespace")
 @ns.param("repo_name", "Repo Name")
 class ProjectIssues(Resource):
-    @ns.response(HTTPStatus.OK, "OK, project issues handled by Packit Service follow")
+    @ns.response(
+        HTTPStatus.OK.value, "OK, project issues handled by Packit Service follow"
+    )
     def get(self, forge, namespace, repo_name):
         """Project issues"""
         issues_list = GitProjectModel.get_project_issues(forge, namespace, repo_name)
@@ -176,7 +178,9 @@ class ProjectIssues(Resource):
 @ns.param("namespace", "Namespace")
 @ns.param("repo_name", "Repo Name")
 class ProjectReleases(Resource):
-    @ns.response(HTTPStatus.OK, "OK, project releases handled by Packit Service follow")
+    @ns.response(
+        HTTPStatus.OK.value, "OK, project releases handled by Packit Service follow"
+    )
     def get(self, forge, namespace, repo_name):
         """Project releases"""
         releases_list = GitProjectModel.get_project_releases(
@@ -199,7 +203,9 @@ class ProjectReleases(Resource):
 @ns.param("namespace", "Namespace")
 @ns.param("repo_name", "Repo Name")
 class ProjectBranches(Resource):
-    @ns.response(HTTPStatus.OK, "OK, project branches handled by Packit Service follow")
+    @ns.response(
+        HTTPStatus.OK.value, "OK, project branches handled by Packit Service follow"
+    )
     def get(self, forge, namespace, repo_name):
         """Project branches"""
         branches = GitProjectModel.get_project_branches(forge, namespace, repo_name)

--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -139,7 +139,7 @@ class TestingFarmResults(Resource):
         raise ValidationFailed(msg)
 
     @ns.expect(pagination_arguments)
-    @ns.response(HTTPStatus.PARTIAL_CONTENT, "Testing Farm Results follow")
+    @ns.response(HTTPStatus.PARTIAL_CONTENT.value, "Testing Farm Results follow")
     def get(self):
         """ List all Testing Farm  results. """
 
@@ -165,6 +165,6 @@ class TestingFarmResults(Resource):
 
             result.append(result_dict)
 
-        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT,)
+        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT.value,)
         resp.headers["Content-Range"] = f"test-results {first + 1}-{last}/*"
         return resp

--- a/packit_service/service/api/utils.py
+++ b/packit_service/service/api/utils.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 from json import dumps
 
 
-def response_maker(result, status=HTTPStatus.OK):
+def response_maker(result, status=HTTPStatus.OK.value):
     """response_maker is a wrapper around flask's make_response"""
     resp = make_response(dumps(result), status)
     resp.headers["Content-Type"] = "application/json"

--- a/packit_service/service/api/webhooks.py
+++ b/packit_service/service/api/webhooks.py
@@ -67,7 +67,7 @@ github_webhook_calls = Counter(
 
 @ns.route("/github")
 class GithubWebhook(Resource):
-    @ns.response(HTTPStatus.OK, "Webhook accepted, returning reply")
+    @ns.response(HTTPStatus.OK.value, "Webhook accepted, returning reply")
     @ns.response(HTTPStatus.ACCEPTED, "Webhook accepted, request is being processed")
     @ns.response(HTTPStatus.BAD_REQUEST, "Bad request data")
     @ns.response(HTTPStatus.UNAUTHORIZED, "X-Hub-Signature validation failed")
@@ -170,7 +170,7 @@ class GithubWebhook(Resource):
 
 @ns.route("/gitlab")
 class GitlabWebhook(Resource):
-    @ns.response(HTTPStatus.OK, "Webhook accepted, returning reply")
+    @ns.response(HTTPStatus.OK.value, "Webhook accepted, returning reply")
     @ns.response(HTTPStatus.ACCEPTED, "Webhook accepted, request is being processed")
     @ns.response(HTTPStatus.BAD_REQUEST, "Bad request data")
     @ns.response(HTTPStatus.UNAUTHORIZED, "X-Gitlab-Token validation failed")

--- a/packit_service/service/api/whitelist.py
+++ b/packit_service/service/api/whitelist.py
@@ -37,7 +37,7 @@ ns = Namespace("whitelist", description="Whitelisted FAS accounts")
 
 @ns.route("")
 class WhiteList(Resource):
-    @ns.response(HTTPStatus.OK, "OK, whitelist follows")
+    @ns.response(HTTPStatus.OK.value, "OK, whitelist follows")
     def get(self):
         """List all Whitelisted FAS accounts"""
         return [account.to_dict() for account in WhitelistModel.get_all()]
@@ -46,9 +46,9 @@ class WhiteList(Resource):
 @ns.route("/<string:login>")
 @ns.param("login", "Account login")
 class WhiteListItem(Resource):
-    @ns.response(HTTPStatus.OK, "OK, whitelisted account details follow")
-    @ns.response(HTTPStatus.NO_CONTENT, "login not in whitelist")
+    @ns.response(HTTPStatus.OK.value, "OK, whitelisted account details follow")
+    @ns.response(HTTPStatus.NO_CONTENT.value, "login not in whitelist")
     def get(self, login):
         """A specific whitelist item details"""
         account = WhitelistModel.get_account(login)
-        return account.to_dict() if account else ("", HTTPStatus.NO_CONTENT)
+        return account.to_dict() if account else ("", HTTPStatus.NO_CONTENT.value)

--- a/tests_requre/service/test_api.py
+++ b/tests_requre/service/test_api.py
@@ -290,3 +290,12 @@ def test_get_projects_branches(
     response_dict = response.json
     assert len(response_dict) == 1
     assert response_dict[0]["branch"] == SampleValues.branch
+
+
+def test_meta(client, clean_before_and_after, a_copr_build_for_pr):
+    """ Test meta info like headers, status etc """
+    response = client.get(url_for("api.copr-builds_copr_builds_list"))
+    assert response.status_code == 206
+    assert response.status == "206 PARTIAL CONTENT"
+    assert response.is_json
+    assert response.headers["Access-Control-Allow-Origin"] == "*"


### PR DESCRIPTION
Thanks to @Stranger6667   for reporting it in https://github.com/packit/packit-service/issues/368#issuecomment-668556357

Basically we were sending and documenting the response status object instead of the integer code as [required by RestX](https://flask-restx.readthedocs.io/en/latest/swagger.html?highlight=response#documenting-with-the-api-response-decorator) and the return value to a view [should also have](https://flask.palletsprojects.com/en/1.1.x/api/#flask.make_response) an integer code as status.

https://docs.python.org/3/library/http.html