### PR TITLE
No updates of Copr boolean values for custom projects and request builder permission if needed

### DIFF
--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -235,14 +235,15 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             )
 
         try:
+            overwrite_booleans = owner == "packit"
             self.api.copr_helper.create_copr_project_if_not_exists(
                 project=self.job_project,
                 chroots=list(self.build_targets),
                 owner=owner,
                 description=None,
                 instructions=None,
-                list_on_homepage=self.list_on_homepage,
-                preserve_project=self.preserve_project,
+                list_on_homepage=self.list_on_homepage if overwrite_booleans else None,
+                preserve_project=self.preserve_project if overwrite_booleans else None,
                 additional_repos=self.additional_repos,
                 request_admin_if_needed=True,
             )

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -259,6 +259,29 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 for field, (old, new) in ex.fields_to_change.items():
                     table += f"| {field} | {old} | {new} |\n"
 
+                boolean_note = ""
+                if "unlisted_on_hp" in ex.fields_to_change:
+                    boolean_note += (
+                        "The `unlisted_on_hp` field is represented as `list_on_homepage`"
+                        " in the packit config."
+                        "By default we create projects with `list_on_homepage: False`.\n"
+                    )
+
+                if "delete_after_days" in ex.fields_to_change:
+                    boolean_note += (
+                        "The `delete_after_days` field is represented as `preserve_project`"
+                        " in the packit config (`True` is `-1` and `False` is `60`)."
+                        "By default we create projects with `preserve: True` "
+                        "which means `delete_after_days=60`.\n"
+                    )
+
+                permissions_url = self.api.copr_helper.get_copr_settings_url(
+                    owner, self.job_project, section="permissions"
+                )
+                settings_url = self.api.copr_helper.get_copr_settings_url(
+                    owner, self.job_project
+                )
+
                 msg = (
                     "Based on your Packit configuration the settings "
                     f"of the {owner}/{self.job_project} "
@@ -266,14 +289,17 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                     "\n"
                     f"{table}"
                     "\n"
+                    f"{boolean_note}"
+                    "\n"
                     "Packit was unable to update the settings above as it is missing `admin` "
                     f"permissions on the {owner}/{self.job_project} Copr project.\n"
                     "\n"
                     "To fix this you can do one of the following:\n"
                     "\n"
                     f"- Grant Packit `admin` permissions on the {owner}/{self.job_project} "
-                    "Copr project.\n"
+                    f"Copr project on the [permissions page]({permissions_url}).\n"
                     "- Change the above Copr project settings manually "
+                    f"on the [settings page]({settings_url}) "
                     "to match the Packit configuration.\n"
                     "- Update the Packit configuration to match the Copr project settings.\n"
                     "\n"

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -532,6 +532,7 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
         "| chroots | ['f30', 'f31'] | ['f31', 'f32'] |\n"
         "| description | old | new |\n"
         "\n"
+        "\n"
         "Packit was unable to update the settings above "
         "as it is missing `admin` permissions on the "
         "nobody/the-example-namespace-the-example-repo-342-stg Copr project.\n"
@@ -539,8 +540,13 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
         "To fix this you can do one of the following:\n"
         "\n"
         "- Grant Packit `admin` permissions on the "
-        "nobody/the-example-namespace-the-example-repo-342-stg Copr project.\n"
-        "- Change the above Copr project settings manually to match the Packit configuration.\n"
+        "nobody/the-example-namespace-the-example-repo-342-stg Copr project on the "
+        "[permissions page](https://copr.fedorainfracloud.org/"
+        "coprs/nobody/the-example-namespace-the-example-repo-342-stg/permissions/).\n"
+        "- Change the above Copr project settings manually on the "
+        "[settings page](https://copr.fedorainfracloud.org/"
+        "coprs/nobody/the-example-namespace-the-example-repo-342-stg/edit/) "
+        "to match the Packit configuration.\n"
         "- Update the Packit configuration to match the Copr project settings.\n"
         "\n"
         "Please re-trigger the build, once the issue above is fixed.\n",
@@ -548,6 +554,22 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
 
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
     # copr build
+    flexmock(CoprHelper).should_receive("get_copr_settings_url").with_args(
+        "nobody",
+        "the-example-namespace-the-example-repo-342-stg",
+        section="permissions",
+    ).and_return(
+        "https://copr.fedorainfracloud.org/"
+        "coprs/nobody/the-example-namespace-the-example-repo-342-stg/permissions/"
+    ).once()
+
+    flexmock(CoprHelper).should_receive("get_copr_settings_url").with_args(
+        "nobody", "the-example-namespace-the-example-repo-342-stg",
+    ).and_return(
+        "https://copr.fedorainfracloud.org/"
+        "coprs/nobody/the-example-namespace-the-example-repo-342-stg/edit/"
+    ).once()
+
     flexmock(CoprHelper).should_receive("create_copr_project_if_not_exists").and_raise(
         PackitCoprSettingsException,
         "Copr project update failed.",

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -115,6 +115,74 @@ def test_copr_build_check_names(github_pr_event):
     flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(
         event=github_pr_event,
+        metadata=JobMetadataConfig(targets=["bright-future-x86_64"], owner="packit"),
+        db_trigger=trigger,
+    )
+    # we need to make sure that pr_id is set
+    # so we can check it out and add it to spec's release field
+    assert helper.metadata.pr_id
+
+    flexmock(copr_build).should_receive(
+        "get_copr_build_info_url_from_flask"
+    ).and_return("https://test.url")
+    flexmock(StatusReporter).should_receive("set_status").with_args(
+        state=CommitStatus.pending,
+        description="Building SRPM ...",
+        check_name="packit-stg/rpm-build-bright-future-x86_64",
+        url="",
+    ).and_return()
+    flexmock(StatusReporter).should_receive("set_status").with_args(
+        state=CommitStatus.pending,
+        description="Starting RPM build...",
+        check_name="packit-stg/rpm-build-bright-future-x86_64",
+        url="https://test.url",
+    ).and_return()
+
+    flexmock(GitProject).should_receive("set_commit_status").and_return().never()
+    flexmock(SRPMBuildModel).should_receive("create").and_return(
+        SRPMBuildModel(success=True)
+    )
+    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
+        CoprBuildModel(id=1)
+    )
+    flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
+
+    flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
+
+    # copr build
+    flexmock(CoprHelper).should_receive("create_copr_project_if_not_exists").with_args(
+        project="the-example-namespace-the-example-repo-342-stg",
+        chroots=["bright-future-x86_64"],
+        owner="packit",
+        description=None,
+        instructions=None,
+        preserve_project=False,
+        list_on_homepage=False,
+        additional_repos=[],
+        request_admin_if_needed=True,
+    ).and_return(None)
+
+    flexmock(CoprHelper).should_receive("get_copr_client").and_return(
+        flexmock(
+            config={"copr_url": "https://copr.fedorainfracloud.org/"},
+            build_proxy=flexmock()
+            .should_receive("create_from_file")
+            .and_return(
+                flexmock(id=2, projectname="the-project-name", ownername="packit")
+            )
+            .mock(),
+        )
+    )
+
+    flexmock(Celery).should_receive("send_task").once()
+    assert helper.run_copr_build()["success"]
+
+
+def test_copr_build_check_names_custom_owner(github_pr_event):
+    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
+    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
+    helper = build_helper(
+        event=github_pr_event,
         metadata=JobMetadataConfig(targets=["bright-future-x86_64"], owner="nobody"),
         db_trigger=trigger,
     )
@@ -156,8 +224,8 @@ def test_copr_build_check_names(github_pr_event):
         owner="nobody",
         description=None,
         instructions=None,
-        preserve_project=False,
-        list_on_homepage=False,
+        preserve_project=None,
+        list_on_homepage=None,
         additional_repos=[],
         request_admin_if_needed=True,
     ).and_return(None)
@@ -168,7 +236,7 @@ def test_copr_build_check_names(github_pr_event):
             build_proxy=flexmock()
             .should_receive("create_from_file")
             .and_return(
-                flexmock(id=2, projectname="the-project-name", ownername="the-owner")
+                flexmock(id=2, projectname="the-project-name", ownername="nobody")
             )
             .mock(),
         )
@@ -576,8 +644,8 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
         owner="nobody",
         description=None,
         instructions=None,
-        preserve_project=False,
-        list_on_homepage=False,
+        preserve_project=None,
+        list_on_homepage=None,
         additional_repos=[],
         request_admin_if_needed=True,
     ).and_return(None)
@@ -588,7 +656,7 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
             build_proxy=flexmock()
             .should_receive("create_from_file")
             .and_return(
-                flexmock(id=2, projectname="the-project-name", ownername="the-owner")
+                flexmock(id=2, projectname="the-project-name", ownername="nobody")
             )
             .mock(),
         )


### PR DESCRIPTION
- Improve comment texts for copr settings edits.
- Request 'builder' permission for custom projects if we needed.
- Do not overwrite Copr boolean values if we don't own it.
- Requires: https://github.com/packit/packit/pull/938
- Fixes: https://github.com/packit/packit/issues/935