### PR TITLE
Use job config from handler as a first choice

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -25,14 +25,13 @@ from pathlib import Path
 from typing import Union, List, Optional, Tuple, Set
 
 from kubernetes.client.rest import ApiException
+
 from ogr.abstract import GitProject, CommitStatus
 from packit.api import PackitAPI
 from packit.config import JobType, JobConfig
 from packit.config.package_config import PackageConfig
 from packit.local_project import LocalProject
 from packit.utils import PackitFormatter
-from sandcastle import SandcastleTimeoutReached
-
 from packit_service import sentry_integration
 from packit_service.config import ServiceConfig, Deployment
 from packit_service.models import SRPMBuildModel
@@ -42,6 +41,7 @@ from packit_service.trigger_mapping import (
     are_job_types_same,
 )
 from packit_service.worker.reporting import StatusReporter
+from sandcastle import SandcastleTimeoutReached
 
 logger = logging.getLogger(__name__)
 

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -156,7 +156,7 @@ class BaseBuildJobHelper:
         if not self.job_type_build:
             return None
         if not self._job_build:
-            for job in self.package_config.jobs:
+            for job in [self.job_config] + self.package_config.jobs:
                 if are_job_types_same(job.type, self.job_type_build) and (
                     (
                         self.db_trigger
@@ -190,7 +190,7 @@ class BaseBuildJobHelper:
             return None
 
         if not self._job_tests:
-            for job in self.package_config.jobs:
+            for job in [self.job_config] + self.package_config.jobs:
                 if are_job_types_same(job.type, self.job_type_test) and (
                     (
                         self.db_trigger

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -92,6 +92,9 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         if self.job_build and self.job_build.metadata.project:
             return self.job_build.metadata.project
 
+        if self.job_tests and self.job_tests.metadata.project:
+            return self.job_tests.metadata.project
+
         return self.default_project_name
 
     @property
@@ -101,6 +104,9 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         """
         if self.job_build and self.job_build.metadata.owner:
             return self.job_build.metadata.owner
+
+        if self.job_tests and self.job_tests.metadata.owner:
+            return self.job_tests.metadata.owner
 
         return self.api.copr_helper.copr_client.config.get("username")
 

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -295,7 +295,14 @@ def test_trigger_payload(
     db_trigger = flexmock()
 
     job_helper = TFJobHelper(
-        config, package_config, project, metadata, db_trigger, flexmock()
+        service_config=config,
+        package_config=package_config,
+        project=project,
+        metadata=metadata,
+        db_trigger=db_trigger,
+        job_config=JobConfig(
+            type=JobType.tests, trigger=JobConfigTriggerType.pull_request
+        ),
     )
     job_helper = flexmock(job_helper)
 


### PR DESCRIPTION
- Use job_config from handler as a first choice.
- Fix the copr-build tests.
- Fixes: https://github.com/packit/packit-service/issues/755