### PR TITLE
Follow new black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.6
   - repo: https://github.com/prettier/prettier
     rev: 2.0.5
     hooks:

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -61,7 +61,11 @@ def run_migrations_online():
     """
     cf = config.get_section(config.config_ini_section)
     cf["sqlalchemy.url"] = get_pg_url()
-    connectable = engine_from_config(cf, prefix="sqlalchemy.", poolclass=pool.NullPool,)
+    connectable = engine_from_config(
+        cf,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
 
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)

--- a/alembic/versions/258490f6e667_initial_schema.py
+++ b/alembic/versions/258490f6e667_initial_schema.py
@@ -28,7 +28,10 @@ def upgrade():
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column("pr_id", sa.Integer, index=True),
         sa.Column("project_id", sa.Integer, sa.ForeignKey("git_projects.id")),
-        sa.ForeignKeyConstraint(("project_id",), ["git_projects.id"],),
+        sa.ForeignKeyConstraint(
+            ("project_id",),
+            ["git_projects.id"],
+        ),
     )
     op.create_table(
         "srpm_builds",
@@ -40,9 +43,15 @@ def upgrade():
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column("build_id", sa.String, index=True),
         sa.Column("pr_id", sa.Integer, sa.ForeignKey("pull_requests.id")),
-        sa.ForeignKeyConstraint(("pr_id",), ["pull_requests.id"],),
+        sa.ForeignKeyConstraint(
+            ("pr_id",),
+            ["pull_requests.id"],
+        ),
         sa.Column("srpm_build_id", sa.Integer, sa.ForeignKey("srpm_builds.id")),
-        sa.ForeignKeyConstraint(("srpm_build_id",), ["srpm_builds.id"],),
+        sa.ForeignKeyConstraint(
+            ("srpm_build_id",),
+            ["srpm_builds.id"],
+        ),
         sa.Column("logs", sa.Text),
         sa.Column("commit_sha", sa.String),
         sa.Column("status", sa.String),

--- a/alembic/versions/521433a1fdb0_add_project_authentication_issue_model.py
+++ b/alembic/versions/521433a1fdb0_add_project_authentication_issue_model.py
@@ -23,7 +23,10 @@ def upgrade():
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("issue_created", sa.Boolean(), nullable=True),
         sa.Column("project_id", sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(["project_id"], ["git_projects.id"],),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["git_projects.id"],
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     # ### end Alembic commands ###

--- a/alembic/versions/7a43773ac926_add_bugzillas.py
+++ b/alembic/versions/7a43773ac926_add_bugzillas.py
@@ -24,7 +24,10 @@ def upgrade():
         sa.Column("bug_id", sa.Integer(), nullable=True),
         sa.Column("bug_url", sa.String(), nullable=True),
         sa.Column("pull_request_id", sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(["pull_request_id"], ["pull_requests.id"],),
+        sa.ForeignKeyConstraint(
+            ["pull_request_id"],
+            ["pull_requests.id"],
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(op.f("ix_bugzillas_bug_id"), "bugzillas", ["bug_id"], unique=False)

--- a/alembic/versions/d90948124e46_add_tables_for_triggers_koji_and_tests.py
+++ b/alembic/versions/d90948124e46_add_tables_for_triggers_koji_and_tests.py
@@ -194,7 +194,10 @@ def upgrade():
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("name", sa.String(), nullable=True),
         sa.Column("project_id", sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(["project_id"], ["git_projects.id"],),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["git_projects.id"],
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -212,8 +215,14 @@ def upgrade():
         sa.Column("build_start_time", sa.DateTime(), nullable=True),
         sa.Column("build_finished_time", sa.DateTime(), nullable=True),
         sa.Column("data", sa.JSON(), nullable=True),
-        sa.ForeignKeyConstraint(["job_trigger_id"], ["build_triggers.id"],),
-        sa.ForeignKeyConstraint(["srpm_build_id"], ["srpm_builds.id"],),
+        sa.ForeignKeyConstraint(
+            ["job_trigger_id"],
+            ["build_triggers.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["srpm_build_id"],
+            ["srpm_builds.id"],
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
@@ -224,7 +233,10 @@ def upgrade():
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("issue_id", sa.Integer(), nullable=True),
         sa.Column("project_id", sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(["project_id"], ["git_projects.id"],),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["git_projects.id"],
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
@@ -236,7 +248,10 @@ def upgrade():
         sa.Column("tag_name", sa.String(), nullable=True),
         sa.Column("commit_hash", sa.String(), nullable=True),
         sa.Column("project_id", sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(["project_id"], ["git_projects.id"],),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["git_projects.id"],
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
@@ -255,7 +270,10 @@ def upgrade():
         sa.Column("target", sa.String(), nullable=True),
         sa.Column("web_url", sa.String(), nullable=True),
         sa.Column("data", sa.JSON(), nullable=True),
-        sa.ForeignKeyConstraint(["job_trigger_id"], ["build_triggers.id"],),
+        sa.ForeignKeyConstraint(
+            ["job_trigger_id"],
+            ["build_triggers.id"],
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -476,7 +476,11 @@ class BugzillaModel(Base):
 
     @classmethod
     def get_by_pr(
-        cls, pr_id: int, namespace: str, repo_name: str, project_url: str,
+        cls,
+        pr_id: int,
+        namespace: str,
+        repo_name: str,
+        project_url: str,
     ) -> Optional["BugzillaModel"]:
         return cls.get_or_create(
             pr_id=pr_id,
@@ -540,7 +544,10 @@ class ProjectReleaseModel(Base):
 
 
 AbstractTriggerDbType = Union[
-    PullRequestModel, ProjectReleaseModel, GitBranchModel, IssueModel,
+    PullRequestModel,
+    ProjectReleaseModel,
+    GitBranchModel,
+    IssueModel,
 ]
 
 MODEL_FOR_TRIGGER: Dict[JobTriggerModelType, Type[AbstractTriggerDbType]] = {
@@ -941,10 +948,14 @@ class SRPMBuildModel(Base):
 
     @classmethod
     def create(
-        cls, logs: str, success: bool, trigger_model: AbstractTriggerDbType,
+        cls,
+        logs: str,
+        success: bool,
+        trigger_model: AbstractTriggerDbType,
     ) -> "SRPMBuildModel":
         job_trigger = JobTriggerModel.get_or_create(
-            type=trigger_model.job_trigger_model_type, trigger_id=trigger_model.id,
+            type=trigger_model.job_trigger_model_type,
+            trigger_id=trigger_model.id,
         )
         with get_sa_session() as session:
             srpm_build = cls()
@@ -955,7 +966,10 @@ class SRPMBuildModel(Base):
             return srpm_build
 
     @classmethod
-    def get_by_id(cls, id_: int,) -> Optional["SRPMBuildModel"]:
+    def get_by_id(
+        cls,
+        id_: int,
+    ) -> Optional["SRPMBuildModel"]:
         with get_sa_session() as session:
             return session.query(SRPMBuildModel).filter_by(id=id_).first()
 

--- a/packit_service/sentry_integration.py
+++ b/packit_service/sentry_integration.py
@@ -70,7 +70,9 @@ def configure_sentry(
         integrations.append(SqlalchemyIntegration())
 
     sentry_sdk.init(
-        secret_key, integrations=integrations, environment=getenv("DEPLOYMENT"),
+        secret_key,
+        integrations=integrations,
+        environment=getenv("DEPLOYMENT"),
     )
     with sentry_sdk.configure_scope() as scope:
         scope.set_tag("runner-type", runner_type)

--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -73,7 +73,10 @@ class CoprBuildsList(Resource):
 
             result.append(build_dict)
 
-        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT.value,)
+        resp = response_maker(
+            result,
+            status=HTTPStatus.PARTIAL_CONTENT.value,
+        )
         resp.headers["Content-Range"] = f"copr-builds {first + 1}-{last}/*"
         return resp
 

--- a/packit_service/service/api/healthz.py
+++ b/packit_service/service/api/healthz.py
@@ -38,7 +38,9 @@ class HealthCheck(Resource):
     @ns.response(HTTPStatus.OK.value, "Healthy")
     def get(self):
         """Health check"""
-        return response_maker({"status": "We are healthy!"},)
+        return response_maker(
+            {"status": "We are healthy!"},
+        )
 
     @ns.response(HTTPStatus.OK.value, "Healthy")
     def head(self):

--- a/packit_service/service/api/projects.py
+++ b/packit_service/service/api/projects.py
@@ -44,7 +44,10 @@ class ProjectsList(Resource):
             }
             result.append(project_info)
 
-        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT.value,)
+        resp = response_maker(
+            result,
+            status=HTTPStatus.PARTIAL_CONTENT.value,
+        )
         resp.headers["Content-Range"] = f"git-projects {first + 1}-{last}/*"
         return resp
 
@@ -165,7 +168,10 @@ class ProjectsPRs(Resource):
 
             result.append(pr_info)
 
-        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT.value,)
+        resp = response_maker(
+            result,
+            status=HTTPStatus.PARTIAL_CONTENT.value,
+        )
         resp.headers["Content-Range"] = f"git-project-prs {first + 1}-{last}/*"
         return resp
 

--- a/packit_service/service/api/srpm_builds.py
+++ b/packit_service/service/api/srpm_builds.py
@@ -69,6 +69,9 @@ class SRPMBuildsList(Resource):
 
             result.append(build_dict)
 
-        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT.value,)
+        resp = response_maker(
+            result,
+            status=HTTPStatus.PARTIAL_CONTENT.value,
+        )
         resp.headers["Content-Range"] = f"srpm-builds {first + 1}-{last}/*"
         return resp

--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -165,6 +165,9 @@ class TestingFarmResults(Resource):
 
             result.append(result_dict)
 
-        resp = response_maker(result, status=HTTPStatus.PARTIAL_CONTENT.value,)
+        resp = response_maker(
+            result,
+            status=HTTPStatus.PARTIAL_CONTENT.value,
+        )
         resp.headers["Content-Range"] = f"test-results {first + 1}-{last}/*"
         return resp

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -395,21 +395,24 @@ class AbstractGithubEvent(AbstractForgeIndependentEvent):
         super().__init__(trigger, pr_id=pr_id)
         self.project_url: str = project_url
         self.git_ref: Optional[str] = None  # git ref that can be 'git checkout'-ed
-        self.identifier: Optional[str] = (
-            None  # will be shown to users -- e.g. in logs or in the copr-project name
-        )
+        self.identifier: Optional[
+            str
+        ] = None  # will be shown to users -- e.g. in logs or in the copr-project name
 
 
 class AbstractGitlabEvent(AbstractForgeIndependentEvent):
     def __init__(
-        self, trigger: TheJobTriggerType, project_url: str, pr_id: Optional[int] = None,
+        self,
+        trigger: TheJobTriggerType,
+        project_url: str,
+        pr_id: Optional[int] = None,
     ):
         super().__init__(trigger, pr_id=pr_id)
         self.project_url: str = project_url
         self.git_ref: Optional[str] = None
-        self.identifier: Optional[str] = (
-            None  # will be shown to users -- e.g. in logs or in the copr-project name
-        )
+        self.identifier: Optional[
+            str
+        ] = None  # will be shown to users -- e.g. in logs or in the copr-project name
 
 
 class ReleaseEvent(AddReleaseDbTrigger, AbstractGithubEvent):
@@ -425,7 +428,7 @@ class ReleaseEvent(AddReleaseDbTrigger, AbstractGithubEvent):
         self._commit_sha: Optional[str] = None
 
     @property
-    def commit_sha(self,) -> Optional[str]:  # type:ignore
+    def commit_sha(self) -> Optional[str]:  # type:ignore
         # mypy does not like properties
         if not self._commit_sha:
             self._commit_sha = self.project.get_sha_from_tag(tag_name=self.tag_name)
@@ -616,7 +619,7 @@ class PullRequestCommentGithubEvent(AddPullRequestDbTrigger, AbstractGithubEvent
         self._commit_sha = commit_sha
 
     @property
-    def commit_sha(self,) -> Optional[str]:  # type:ignore
+    def commit_sha(self) -> Optional[str]:  # type:ignore
         # mypy does not like properties
         if not self._commit_sha:
             self._commit_sha = self.project.get_pr(pr_id=self.pr_id).head_commit
@@ -915,7 +918,7 @@ class KojiBuildEvent(AbstractForgeIndependentEvent):
         return self._pr_id
 
     @property
-    def commit_sha(self,) -> Optional[str]:  # type:ignore
+    def commit_sha(self) -> Optional[str]:  # type:ignore
         if not self.build_model:
             return None
 
@@ -1161,9 +1164,9 @@ class AbstractPagureEvent(AbstractForgeIndependentEvent):
         super().__init__(trigger, pr_id=pr_id)
         self.project_url: str = project_url
         self.git_ref: Optional[str] = None  # git ref that can be 'git checkout'-ed
-        self.identifier: Optional[str] = (
-            None  # will be shown to users -- e.g. in logs or in the copr-project name
-        )
+        self.identifier: Optional[
+            str
+        ] = None  # will be shown to users -- e.g. in logs or in the copr-project name
 
 
 class PushPagureEvent(AbstractPagureEvent):

--- a/packit_service/service/urls.py
+++ b/packit_service/service/urls.py
@@ -25,7 +25,9 @@ from flask import url_for
 from packit_service.service.app import packit_as_a_service as application
 
 
-def get_srpm_log_url_from_flask(id_: int = None,) -> str:
+def get_srpm_log_url_from_flask(
+    id_: int = None,
+) -> str:
     """
     provide absolute URL to p-s srpm build logs view meant to set in a commit status
     """
@@ -38,7 +40,9 @@ def get_srpm_log_url_from_flask(id_: int = None,) -> str:
         )
 
 
-def get_copr_build_info_url_from_flask(id_: int = None,) -> str:
+def get_copr_build_info_url_from_flask(
+    id_: int = None,
+) -> str:
     """
     provide absolute URL to p-s copr build logs view meant to set in a commit status
     """
@@ -50,7 +54,9 @@ def get_copr_build_info_url_from_flask(id_: int = None,) -> str:
         )
 
 
-def get_koji_build_info_url_from_flask(id_: int = None,) -> str:
+def get_koji_build_info_url_from_flask(
+    id_: int = None,
+) -> str:
     """
     provide absolute URL to p-s koji build logs view meant to set in a commit status
     """

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -361,7 +361,9 @@ class BaseBuildJobHelper:
             )
 
         self._srpm_model = SRPMBuildModel.create(
-            logs=srpm_logs, success=srpm_success, trigger_model=self.db_trigger,
+            logs=srpm_logs,
+            success=srpm_success,
+            trigger_model=self.db_trigger,
         )
 
     def _report(
@@ -376,7 +378,10 @@ class BaseBuildJobHelper:
         so we can extend it in subclasses easily.
         """
         self.status_reporter.report(
-            description=description, state=state, url=url, check_names=check_names,
+            description=description,
+            state=state,
+            url=url,
+            check_names=check_names,
         )
 
     def report_status_to_all(
@@ -409,7 +414,10 @@ class BaseBuildJobHelper:
         if self.job_build and chroot in self.build_targets:
             cs = self.get_build_check(chroot)
             self._report(
-                description=description, state=state, url=url, check_names=cs,
+                description=description,
+                state=state,
+                url=url,
+                check_names=cs,
             )
 
     def report_status_to_test_for_chroot(

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -204,7 +204,10 @@ class JobHandler(Handler):
     task_name: TaskName
 
     def __init__(
-        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
+        self,
+        package_config: PackageConfig,
+        job_config: JobConfig,
+        data: EventData,
     ):
         # build helper needs package_config to resolve dependencies b/w tests and build jobs
         self.package_config = package_config

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -83,7 +83,9 @@ class CommentActionHandler(JobHandler):
         **kwargs
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
 
     def run(self) -> TaskResults:

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -88,10 +88,15 @@ class FedmsgHandler(JobHandler):
     topic: str
 
     def __init__(
-        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
+        self,
+        package_config: PackageConfig,
+        job_config: JobConfig,
+        data: EventData,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
         self._pagure_service = None
 
@@ -109,10 +114,15 @@ class NewDistGitCommitHandler(FedmsgHandler):
     task_name = TaskName.distgit_commit
 
     def __init__(
-        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
+        self,
+        package_config: PackageConfig,
+        job_config: JobConfig,
+        data: EventData,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
         self.branch = data.event_dict.get("branch")
 
@@ -155,7 +165,9 @@ class AbstractCoprBuildReportHandler(FedmsgHandler):
         copr_event: CoprBuildEvent,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
         self.copr_event = copr_event
         self._build = None
@@ -372,7 +384,9 @@ class KojiBuildReportHandler(FedmsgHandler):
         koji_event: KojiBuildEvent,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
         self.koji_event = koji_event
         self._db_trigger: Optional[AbstractTriggerDbType] = None

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -99,7 +99,9 @@ class GithubAppInstallationHandler(JobHandler):
         installation_event: InstallationEvent,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
         self.installation_event = installation_event
         self.account_type = installation_event.account_type
@@ -156,7 +158,9 @@ class ProposeDownstreamHandler(JobHandler):
         task: Task,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
         self.task = task
 
@@ -228,10 +232,15 @@ class AbstractCoprBuildHandler(JobHandler):
     type = JobType.copr_build
 
     def __init__(
-        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
+        self,
+        package_config: PackageConfig,
+        job_config: JobConfig,
+        data: EventData,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
 
         self._copr_build_helper: Optional[CoprBuildJobHelper] = None
@@ -253,9 +262,9 @@ class AbstractCoprBuildHandler(JobHandler):
         return self.copr_build_helper.run_copr_build()
 
     def pre_check(self) -> bool:
-        is_copr_build: Callable[
-            [JobConfig], bool
-        ] = lambda job: job.type == JobType.copr_build
+        is_copr_build: Callable[[JobConfig], bool] = (
+            lambda job: job.type == JobType.copr_build
+        )
 
         if self.job_config.type == JobType.tests and any(
             filter(is_copr_build, self.package_config.jobs)
@@ -363,10 +372,15 @@ class AbstractGithubKojiBuildHandler(JobHandler):
     type = JobType.production_build
 
     def __init__(
-        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
+        self,
+        package_config: PackageConfig,
+        job_config: JobConfig,
+        data: EventData,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
 
         if not (
@@ -404,9 +418,9 @@ class AbstractGithubKojiBuildHandler(JobHandler):
         return self.koji_build_helper.run_koji_build()
 
     def pre_check(self) -> bool:
-        is_copr_build: Callable[
-            [JobConfig], bool
-        ] = lambda job: job.type == JobType.copr_build
+        is_copr_build: Callable[[JobConfig], bool] = (
+            lambda job: job.type == JobType.copr_build
+        )
 
         if self.job_config.type == JobType.tests and any(
             filter(is_copr_build, self.package_config.jobs)
@@ -511,7 +525,9 @@ class GithubTestingFarmHandler(JobHandler):
         build_id: int,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
         self.chroot = chroot
         self.build_id = build_id

--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -53,10 +53,15 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
     task_name = TaskName.pagure_pr_comment_copr_build
 
     def __init__(
-        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
+        self,
+        package_config: PackageConfig,
+        job_config: JobConfig,
+        data: EventData,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
 
         # lazy property

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -65,7 +65,9 @@ class TestingFarmResultsHandler(JobHandler):
         message: str,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data,
+            package_config=package_config,
+            job_config=job_config,
+            data=data,
         )
 
         self.tests = tests

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -297,7 +297,8 @@ class SteveJobs:
         if pr_comment_error_msg:
             return {
                 event.trigger.value: TaskResults(
-                    success=True, details={"msg": pr_comment_error_msg},
+                    success=True,
+                    details={"msg": pr_comment_error_msg},
                 )
             }
 
@@ -345,7 +346,9 @@ class SteveJobs:
             handler_kls = PagurePullRequestCommentCoprBuildHandler
 
         jobs = get_config_for_handler_kls(
-            handler_kls=handler_kls, event=event, package_config=event.package_config,
+            handler_kls=handler_kls,
+            event=event,
+            package_config=event.package_config,
         )
         if user_login and user_login in self.service_config.admins:
             logger.info(f"{user_login} is admin, you shall pass.")
@@ -422,7 +425,8 @@ class SteveJobs:
         # Label/Tag added event handler is run even when the job is not configured in package
         elif event_object.trigger == TheJobTriggerType.pr_label:
             PagurePullRequestLabelHandler.get_signature(
-                event=event_object, job=None,
+                event=event_object,
+                job=None,
             ).apply_async()
         elif event_object.trigger in {
             TheJobTriggerType.issue_comment,

--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -88,7 +88,11 @@ class StatusReporter:
             )
 
     def set_status(
-        self, state: CommitStatus, description: str, check_name: str, url: str = "",
+        self,
+        state: CommitStatus,
+        description: str,
+        check_name: str,
+        url: str = "",
     ):
         # Required because Pagure API doesn't accept empty url.
         if not url and isinstance(self.project, PagureProject):

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -70,7 +70,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
     def _trigger_payload(self, pipeline_id: str, chroot: str) -> dict:
         """Produce payload that can be used to trigger tests in Testing
-           Farm using the Copr chroot given.
+        Farm using the Copr chroot given.
         """
         git_url = self.metadata.project_url
         if not git_url.endswith(".git"):
@@ -124,7 +124,10 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             msg = f"Target '{chroot}' not defined for tests but triggered."
             logger.error(msg)
             send_to_sentry(PackitConfigException(msg))
-            return TaskResults(success=False, details={"msg": msg},)
+            return TaskResults(
+                success=False,
+                details={"msg": msg},
+            )
 
         if chroot not in self.build_targets:
             self.report_missing_build_chroot(chroot)
@@ -166,7 +169,9 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             msg = "Failed to post request to testing farm API."
             logger.debug("Failed to post request to testing farm API.")
             self.report_status_to_test_for_chroot(
-                state=CommitStatus.failure, description=msg, chroot=chroot,
+                state=CommitStatus.failure,
+                description=msg,
+                chroot=chroot,
             )
             test_run_model.set_status(TestingFarmResult.error)
             return TaskResults(success=False, details={"msg": msg})
@@ -193,7 +198,9 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
                     msg = f"Failed to submit tests: {req.reason}"
                     logger.error(msg)
                 self.report_status_to_test_for_chroot(
-                    state=CommitStatus.failure, description=msg, chroot=chroot,
+                    state=CommitStatus.failure,
+                    description=msg,
+                    chroot=chroot,
                 )
                 test_run_model.set_status(TestingFarmResult.error)
                 return TaskResults(success=False, details={"msg": msg})

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -72,15 +72,18 @@ def test_precheck(github_pr_event):
         package_config=PackageConfig(
             jobs=[
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
             ]
         ),
         job_config=JobConfig(
-            type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+            type=JobType.copr_build,
+            trigger=JobConfigTriggerType.pull_request,
         ),
         data=EventData.from_event_dict(github_pr_event.get_dict()),
     )
@@ -92,15 +95,18 @@ def test_precheck_skip_tests_when_build_defined(github_pr_event):
         package_config=PackageConfig(
             jobs=[
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
             ]
         ),
         job_config=JobConfig(
-            type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
+            type=JobType.tests,
+            trigger=JobConfigTriggerType.pull_request,
         ),
         data=EventData.from_event_dict(github_pr_event.get_dict()),
     )

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -124,7 +124,9 @@ def test_issue_comment_propose_update_handler(
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_propose_update_comment_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
     assert first_dict_value(results["job"])["success"]

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -176,10 +176,18 @@ def copr_build_release():
 
 
 @pytest.mark.parametrize(
-    "pc_comment_pr_succ,pr_comment_called", ((True, True), (False, False),)
+    "pc_comment_pr_succ,pr_comment_called",
+    (
+        (True, True),
+        (False, False),
+    ),
 )
 def test_copr_build_end(
-    copr_build_end, pc_build_pr, copr_build_pr, pc_comment_pr_succ, pr_comment_called,
+    copr_build_end,
+    pc_build_pr,
+    copr_build_pr,
+    pc_comment_pr_succ,
+    pr_comment_called,
 ):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     pc_build_pr.jobs[0].notifications.pull_request.successful_build = pc_comment_pr_succ
@@ -215,7 +223,9 @@ def test_copr_build_end(
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     run_copr_build_end_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
 
@@ -256,7 +266,9 @@ def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build_branch_pu
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     run_copr_build_end_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
 
@@ -296,7 +308,9 @@ def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build_rel
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     run_copr_build_end_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
 
@@ -412,7 +426,9 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     run_copr_build_end_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
     flexmock(GithubTestingFarmHandler).should_receive("db_trigger").and_return(
@@ -525,7 +541,9 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     run_copr_build_end_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
     flexmock(GithubTestingFarmHandler).should_receive("db_trigger").and_return(
@@ -640,7 +658,9 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     run_copr_build_end_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
     flexmock(GithubTestingFarmHandler).should_receive("db_trigger").and_return(
@@ -688,7 +708,9 @@ def test_copr_build_start(copr_build_start, pc_build_pr, copr_build_pr):
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     run_copr_build_start_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
 
@@ -730,7 +752,9 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build_pr
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     run_copr_build_start_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
 
@@ -771,7 +795,9 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_bui
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     run_copr_build_end_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
 
@@ -806,7 +832,9 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_koji_build_report_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
     assert first_dict_value(results["job"])["success"]
@@ -857,7 +885,9 @@ def test_koji_build_end(koji_build_scratch_end, pc_koji_build_pr, koji_build_pr)
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_koji_build_report_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
     assert first_dict_value(results["job"])["success"]

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -180,7 +180,9 @@ def test_pr_comment_copr_build_handler(
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_pr_comment_copr_build_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
     assert first_dict_value(results["job"])["success"]
 
@@ -206,7 +208,9 @@ def test_pr_comment_build_handler(
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_pr_comment_copr_build_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
     assert first_dict_value(results["job"])["success"]
 
@@ -267,7 +271,9 @@ def test_pr_embedded_command_handler(
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_pr_comment_copr_build_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
 
     assert first_dict_value(results["job"])["success"]

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -63,7 +63,9 @@ def test_dist_git_push_release_handle(github_release_webhook):
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_propose_downstream_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
     assert first_dict_value(results["job"])["success"]
 
@@ -110,7 +112,9 @@ def test_dist_git_push_release_handle_multiple_branches(
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_propose_downstream_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
     assert first_dict_value(results["job"])["success"]
 
@@ -168,7 +172,9 @@ def test_dist_git_push_release_handle_one_failed(
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_propose_downstream_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
     assert not first_dict_value(results["job"])["success"]
 
@@ -232,7 +238,9 @@ def test_dist_git_push_release_handle_all_failed(
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_propose_downstream_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
     assert not first_dict_value(results["job"])["success"]
 
@@ -276,5 +284,7 @@ def test_retry_propose_downstream_task(github_release_webhook):
 
     with pytest.raises(Retry):
         run_propose_downstream_handler(
-            package_config=package_config, event=event_dict, job_config=job,
+            package_config=package_config,
+            event=event_dict,
+            job_config=job,
         )

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -134,7 +134,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
         pytest.param(
             [
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 )
             ],
             TheJobTriggerType.pull_request,
@@ -144,7 +145,12 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
             id="build_without_targets",
         ),
         pytest.param(
-            [JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.pull_request,)],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                )
+            ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
             STABLE_CHROOTS,
@@ -168,10 +174,12 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
         pytest.param(
             [
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
             ],
             TheJobTriggerType.pull_request,
@@ -188,7 +196,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                     metadata=JobMetadataConfig(targets=STABLE_VERSIONS),
                 ),
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
             ],
             TheJobTriggerType.pull_request,
@@ -200,7 +209,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
         pytest.param(
             [
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
                     type=JobType.tests,
@@ -217,7 +227,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
         pytest.param(
             [
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
                     type=JobType.tests,
@@ -234,7 +245,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
         pytest.param(
             [
                 JobConfig(
-                    type=JobType.build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
                     type=JobType.tests,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -120,7 +120,11 @@ def test_parse_missing(service_config_missing):
 
 
 @pytest.mark.parametrize(
-    "sc", ((ServiceConfig.get_from_dict({"deployment": "stg"})), (ServiceConfig()),)
+    "sc",
+    (
+        (ServiceConfig.get_from_dict({"deployment": "stg"})),
+        (ServiceConfig()),
+    ),
 )
 def test_config_opts(sc):
     """ test that ServiceConfig knows all the options """

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -360,7 +360,11 @@ def test_copr_build_success_set_test_check(github_pr_event):
     )
     trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
     flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
-    helper = build_helper(jobs=[test_job], event=github_pr_event, db_trigger=trigger,)
+    helper = build_helper(
+        jobs=[test_job],
+        event=github_pr_event,
+        db_trigger=trigger,
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(4)
     flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
     flexmock(SRPMBuildModel).should_receive("create").and_return(
@@ -413,7 +417,9 @@ def test_copr_build_for_branch(branch_push_event):
     trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
     flexmock(AddBranchPushDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(
-        jobs=[branch_build_job], event=branch_push_event, db_trigger=trigger,
+        jobs=[branch_build_job],
+        event=branch_push_event,
+        db_trigger=trigger,
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
     flexmock(SRPMBuildModel).should_receive("create").and_return(
@@ -470,7 +476,9 @@ def test_copr_build_for_release(release_event):
         "123456"
     )
     helper = build_helper(
-        jobs=[branch_build_job], event=release_event, db_trigger=trigger,
+        jobs=[branch_build_job],
+        event=release_event,
+        db_trigger=trigger,
     )
     flexmock(ReleaseEvent).should_receive("get_project").and_return(helper.project)
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
@@ -664,7 +672,8 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
     ).once()
 
     flexmock(CoprHelper).should_receive("get_copr_settings_url").with_args(
-        "nobody", "the-example-namespace-the-example-repo-342-stg",
+        "nobody",
+        "the-example-namespace-the-example-repo-342-stg",
     ).and_return(
         "https://copr.fedorainfracloud.org/"
         "coprs/nobody/the-example-namespace-the-example-repo-342-stg/edit/"
@@ -855,7 +864,9 @@ def test_copr_build_for_branch_gitlab(branch_push_event_gitlab):
     trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.release)
     flexmock(AddBranchPushDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(
-        jobs=[branch_build_job], event=branch_push_event_gitlab, db_trigger=trigger,
+        jobs=[branch_build_job],
+        event=branch_push_event_gitlab,
+        db_trigger=trigger,
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
     flexmock(SRPMBuildModel).should_receive("create").and_return(

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -64,7 +64,8 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 )
             ],
             {PullRequestCoprBuildHandler},
@@ -73,21 +74,36 @@ from packit_service.worker.jobs import (
         pytest.param(
             TheJobTriggerType.pull_request,
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request,)],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                )
+            ],
             {PullRequestCoprBuildHandler},
             id="config=build@trigger=pull_request",
         ),
         pytest.param(
             TheJobTriggerType.push,
             flexmock(job_config_trigger_type=JobConfigTriggerType.commit),
-            [JobConfig(type=JobType.copr_build, trigger=JobConfigTriggerType.commit,)],
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.commit,
+                )
+            ],
             {PushCoprBuildHandler},
             id="config=copr_build_on_push@trigger=push",
         ),
         pytest.param(
             TheJobTriggerType.commit,
             flexmock(job_config_trigger_type=JobConfigTriggerType.commit),
-            [JobConfig(type=JobType.copr_build, trigger=JobConfigTriggerType.commit,)],
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.commit,
+                )
+            ],
             {PushCoprBuildHandler},
             id="config=copr_build_on_push@trigger=commit",
         ),
@@ -108,7 +124,8 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 )
             ],
             {CoprBuildStartHandler},
@@ -119,7 +136,8 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 )
             ],
             {CoprBuildEndHandler},
@@ -130,10 +148,12 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.release,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.release,
                 ),
             ],
             {PullRequestCoprBuildHandler},
@@ -144,10 +164,12 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.release,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.release,
                 ),
             ],
             {CoprBuildEndHandler},
@@ -156,28 +178,48 @@ from packit_service.worker.jobs import (
         pytest.param(
             TheJobTriggerType.pull_request,
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.pull_request,)],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                )
+            ],
             {PullRequestCoprBuildHandler},
             id="config=tests@trigger=pull_request",
         ),
         pytest.param(
             TheJobTriggerType.copr_start,
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.pull_request,)],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                )
+            ],
             {CoprBuildStartHandler},
             id="config=tests@trigger=copr_start",
         ),
         pytest.param(
             TheJobTriggerType.copr_end,
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.pull_request,)],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                )
+            ],
             {CoprBuildEndHandler},
             id="config=tests@trigger=copr_end",
         ),
         pytest.param(
             TheJobTriggerType.testing_farm_results,
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.pull_request,)],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                )
+            ],
             {TestingFarmResultsHandler},
             id="config=tests@trigger=testing_farm_results",
         ),
@@ -186,10 +228,12 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
             ],
             {TestingFarmResultsHandler},
@@ -200,10 +244,12 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
             ],
             {PullRequestCoprBuildHandler},
@@ -214,10 +260,12 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
             ],
             {CoprBuildStartHandler},
@@ -228,10 +276,12 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
                     type=JobType.propose_downstream,
@@ -262,7 +312,8 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.commit),
             [
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.commit,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.commit,
                 ),
             ],
             {PushGithubKojiBuildHandler},
@@ -273,7 +324,8 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.commit),
             [
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.commit,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.commit,
                 ),
             ],
             {PushGithubKojiBuildHandler},
@@ -284,7 +336,8 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.release),
             [
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.release,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.release,
                 ),
             ],
             {ReleaseGithubKojiBuildHandler},
@@ -295,7 +348,8 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.commit),
             [
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.commit,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.commit,
                 ),
                 JobConfig(
                     type=JobType.production_build,
@@ -322,7 +376,8 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
             ],
             set(),
@@ -337,7 +392,8 @@ from packit_service.worker.jobs import (
                     trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 ),
             ],
             {KojiBuildReportHandler},
@@ -836,10 +892,12 @@ def test_get_handlers_for_event(trigger, db_trigger, jobs, result):
                     trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.release,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.release,
                 ),
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.commit,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.commit,
                 ),
             ],
             [
@@ -864,15 +922,18 @@ def test_get_handlers_for_event(trigger, db_trigger, jobs, result):
                     trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.release,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.release,
                 ),
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.commit,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.commit,
                 ),
             ],
             [
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.release,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.release,
                 )
             ],
             id="koji_results_for_release_when_multiple_triggers_defined",
@@ -891,15 +952,18 @@ def test_get_handlers_for_event(trigger, db_trigger, jobs, result):
                     trigger=JobConfigTriggerType.pull_request,
                 ),
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.release,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.release,
                 ),
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.commit,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.commit,
                 ),
             ],
             [
                 JobConfig(
-                    type=JobType.production_build, trigger=JobConfigTriggerType.commit,
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.commit,
                 )
             ],
             id="koji_results_for_commit_when_multiple_triggers_defined",
@@ -978,6 +1042,8 @@ def test_get_handlers_for_event(trigger, db_trigger, jobs, result):
 )
 def test_get_config_for_handler_kls(handler_kls, event, jobs, result_job_config):
     job_config = get_config_for_handler_kls(
-        handler_kls=handler_kls, event=event, package_config=flexmock(jobs=jobs),
+        handler_kls=handler_kls,
+        event=event,
+        package_config=flexmock(jobs=jobs),
     )
     assert job_config == result_job_config

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -391,8 +391,14 @@ def test_get_koji_build_logs_url(id_, result):
 @pytest.mark.parametrize(
     "id_,result",
     [
-        (45270227, "https://koji.fedoraproject.org/koji/taskinfo?taskID=45270227",),
-        (45452270, "https://koji.fedoraproject.org/koji/taskinfo?taskID=45452270",),
+        (
+            45270227,
+            "https://koji.fedoraproject.org/koji/taskinfo?taskID=45270227",
+        ),
+        (
+            45452270,
+            "https://koji.fedoraproject.org/koji/taskinfo?taskID=45452270",
+        ),
     ],
 )
 def test_get_koji_rpm_build_web_url(id_, result):

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -94,7 +94,9 @@ def test_process_message(event):
     event_dict, package_config, job = get_parameters_from_results(processing_results)
 
     results = run_propose_downstream_handler(
-        package_config=package_config, event=event_dict, job_config=job,
+        package_config=package_config,
+        event=event_dict,
+        job_config=job,
     )
     assert "propose_downstream" in next(iter(results["job"]))
     assert first_dict_value(results["job"])["success"]

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -169,7 +169,8 @@ def test_testing_farm_response(
         flexmock(
             jobs=[
                 JobConfig(
-                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                 )
             ],
         )

--- a/tests/unit/test_whitelist.py
+++ b/tests/unit/test_whitelist.py
@@ -153,7 +153,14 @@ def test_signed_fpca(whitelist, account_name, person_object, raises, signed_fpca
         ),
         (
             IssueCommentEvent(
-                IssueCommentAction.created, 0, "foo", "", "", "", "bar", "",
+                IssueCommentAction.created,
+                0,
+                "foo",
+                "",
+                "",
+                "",
+                "bar",
+                "",
             ),
             "issue_comment",
             False,
@@ -176,7 +183,14 @@ def test_signed_fpca(whitelist, account_name, person_object, raises, signed_fpca
         ),
         (
             IssueCommentEvent(
-                IssueCommentAction.created, 0, "", "", "", "", "lojzo", "",
+                IssueCommentAction.created,
+                0,
+                "",
+                "",
+                "",
+                "",
+                "lojzo",
+                "",
             ),
             "issue_comment",
             True,
@@ -285,7 +299,9 @@ def events(request) -> List[Tuple[AbstractGithubEvent, bool]]:
 
 # https://stackoverflow.com/questions/35413134/what-does-indirect-true-false-in-pytest-mark-parametrize-do-mean
 @pytest.mark.parametrize(
-    "events", ["release", "pr", "pr_comment", "issue_comment"], indirect=True,
+    "events",
+    ["release", "pr", "pr_comment", "issue_comment"],
+    indirect=True,
 )
 def test_check_and_report(
     whitelist: Whitelist, events: List[Tuple[AbstractGithubEvent, bool]]
@@ -308,7 +324,9 @@ def test_check_and_report(
         )
     ]
     flexmock(PullRequestGithubEvent).should_receive("get_package_config").and_return(
-        flexmock(jobs=job_configs,)
+        flexmock(
+            jobs=job_configs,
+        )
     )
 
     git_project = GithubProject("", GithubService(), "")

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -685,8 +685,12 @@ def multiple_installation_entries(installation_events):
     with get_sa_session() as session:
         session.query(InstallationModel).delete()
         yield [
-            InstallationModel.create(event=installation_events[0],),
-            InstallationModel.create(event=installation_events[1],),
+            InstallationModel.create(
+                event=installation_events[0],
+            ),
+            InstallationModel.create(
+                event=installation_events[1],
+            ),
         ]
     clean_db()
 

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -648,9 +648,14 @@ def test_project_token_model(clean_before_and_after):
     http_url = "https://gitlab.com/the-namespace/repo-name"
 
     actual = ProjectAuthenticationIssueModel.create(
-        namespace=namespace, repo_name=repo, project_url=http_url, issue_created=True,
+        namespace=namespace,
+        repo_name=repo,
+        project_url=http_url,
+        issue_created=True,
     )
     expected = ProjectAuthenticationIssueModel.get_project(
-        namespace=namespace, repo_name=repo, project_url=http_url,
+        namespace=namespace,
+        repo_name=repo,
+        project_url=http_url,
     )
     assert actual.issue_created == expected.issue_created


### PR DESCRIPTION
Black 20+ changed the formatting of some lines. Commit these changes to
keep 'pre-commit run' in Zuul happy.

Also: remove pinning the Python version to 3.6 for black.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>