### PR TITLE
Support AWS SQS & RDS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,16 +4,16 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.5
+    rev: 2.1.1
     hooks:
       - id: prettier
         exclude: tests_requre/openshift_integration/test_data/*
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -32,18 +32,18 @@ repos:
           - --max-line-length=100
           - --per-file-ignores=files/packit.wsgi:F401,E402
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.781
+    rev: v0.782
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
   - repo: https://github.com/packit/pre-commit-hooks
-    rev: master
+    rev: 76dd54a98306a9f6ecf6672aa7687d6f07091c4e
     hooks:
       - id: check-rebase
         args:
           - git://github.com/packit-service/packit-service.git
   - repo: https://github.com/packit/requre
-    rev: master
+    rev: 0.2.2
     hooks:
       - id: requre-purge
         name: Requre response files cleanup

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,9 @@ repos:
         exclude: zuul.d
       - id: detect-private-key
         exclude: tests/conftest.py
+      - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ check_in_container: test_image
 		--env COV_REPORT \
 		--env TEST_TARGET \
 		--env COLOR \
+		--env REDIS_SERVICE_HOST=redis \
 		-v $(CURDIR):/src \
 		-w /src \
 		--security-opt label=disable \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,6 @@ services:
     command: /usr/bin/run_httpd.sh
     depends_on:
       - redis
-      - fedora-messaging
       - postgres
     ports:
       - 8443:8443
@@ -116,6 +115,7 @@ services:
     depends_on:
       - redis
     environment:
+      DEPLOYMENT: dev
       FEDORA_MESSAGING_CONF: /home/packit/.config/fedora.toml
       REDIS_SERVICE_HOST: redis
     volumes:
@@ -129,6 +129,7 @@ services:
     depends_on:
       - redis
     environment:
+      DEPLOYMENT: dev
       LOG_LEVEL: DEBUG
       REDIS_SERVICE_HOST: redis
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
   redis:
     image: registry.fedoraproject.org/f31/redis
     container_name: redis
-    environment:
-      REDIS_PASSWORD: redispasswd
     ports:
       - 6379:6379
     user: "123123"
@@ -17,7 +15,6 @@ services:
     environment:
       REDIS_HOST: redis
       REDIS_PORT: "6379"
-      REDIS_PASSWORD: redispasswd
     ports:
       - 8081:8081
     depends_on:
@@ -33,14 +30,7 @@ services:
       - redis
     environment:
       FLOWER_DEBUG: "True"
-      CELERY_BROKER_URL: redis://:redispasswd@redis:6379/0
-      # TODO: Why these don't work, even when prefixed with additional CELERY_ as described in
-      # https://www.distributedpython.com/2018/10/13/flower-docker/
-      #CELERY_BROKER_TRANSPORT: redis
-      #CELERY_REDIS_PASSWORD: redispasswd
-      #CELERY_REDIS_HOST: redis
-      #CELERY_REDIS_PORT: 6379
-      #CELERY_REDIS_DB: 0
+      CELERY_BROKER_URL: redis://redis:6379/0
     user: "123123"
 
   postgres:
@@ -69,7 +59,6 @@ services:
     environment:
       DEPLOYMENT: dev
       REDIS_SERVICE_HOST: redis
-      REDIS_PASSWORD: redispasswd
       APP: packit_service.worker.tasks
       KRB5CCNAME: FILE:/tmp/krb5cc_packit
       POSTGRESQL_USER: packit
@@ -106,7 +95,6 @@ services:
     environment:
       DEPLOYMENT: dev
       REDIS_SERVICE_HOST: redis
-      REDIS_PASSWORD: redispasswd
       POSTGRESQL_USER: packit
       POSTGRESQL_PASSWORD: secret-password
       POSTGRESQL_DATABASE: packit
@@ -125,10 +113,11 @@ services:
   fedora-messaging:
     container_name: fedora-messaging
     image: docker.io/usercont/packit-service-fedmsg:dev
+    depends_on:
+      - redis
     environment:
       FEDORA_MESSAGING_CONF: /home/packit/.config/fedora.toml
       REDIS_SERVICE_HOST: redis
-      REDIS_PASSWORD: redispasswd
     volumes:
       # get it from secrets
       - ./secrets/dev/fedora.toml:/home/packit/.config/fedora.toml:ro,Z
@@ -142,7 +131,6 @@ services:
     environment:
       LOG_LEVEL: DEBUG
       REDIS_SERVICE_HOST: redis
-      REDIS_PASSWORD: redispasswd
     volumes:
       - ./secrets/dev/centos-server-ca.cert:/secrets/centos-server-ca.cert:ro,Z
       - ./secrets/dev/centos.cert:/secrets/centos.cert:ro,Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       KRB5CCNAME: FILE:/tmp/krb5cc_packit
       POSTGRESQL_USER: packit
       POSTGRESQL_PASSWORD: secret-password
+      POSTGRESQL_HOST: postgres
       POSTGRESQL_DATABASE: packit
     volumes:
       - ./packit_service:/src/packit_service:ro,z
@@ -96,6 +97,7 @@ services:
       REDIS_SERVICE_HOST: redis
       POSTGRESQL_USER: packit
       POSTGRESQL_PASSWORD: secret-password
+      POSTGRESQL_HOST: postgres
       POSTGRESQL_DATABASE: packit
     volumes:
       - ./packit_service:/usr/local/lib/python3.7/site-packages/packit_service:ro,z

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -21,6 +21,7 @@
           - python3-psycopg2
           #- python3-celery # don't, the liveness probe doesn't work
           - python3-redis
+          - python3-boto3 # AWS SDK
           - python3-lazy-object-proxy
           - python3-bugzilla # python-bugzilla (not bugzilla) on PyPI
           - python3-backoff # Bugzilla class

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -29,6 +29,7 @@
           - python3-psycopg2
           #- python3-celery # don't, the liveness probe doesn't work
           - python3-redis
+          - python3-boto3 # AWS SDK
           - python3-lazy-object-proxy
           #- python3-flask-restx # Needs Fedora 32
           - python3-flexmock # because of the hack during the alembic upgrade

--- a/files/test-in-openshift.yaml
+++ b/files/test-in-openshift.yaml
@@ -38,6 +38,11 @@ objects:
                     secretKeyRef:
                       key: database-password
                       name: postgres-secret
+                - name: POSTGRESQL_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      key: database-host
+                      name: postgres-secret
                 - name: POSTGRESQL_DATABASE
                   valueFrom:
                     secretKeyRef:

--- a/packit_service/service/templates/layout.html
+++ b/packit_service/service/templates/layout.html
@@ -10,9 +10,7 @@
       rel="shortcut icon"
       href="{{ url_for('static', filename='packit.png') }}"
     />
-    <title>
-      {% block title %}{% endblock %}
-    </title>
+    <title>{% block title %}{% endblock %}</title>
   </head>
   <body id="build-result-page">
     {% block content %}{% endblock %}

--- a/packit_service/service/templates/srpm_logs.html
+++ b/packit_service/service/templates/srpm_logs.html
@@ -2,8 +2,6 @@
 <!-- prettier-ignore -->
 {% block title %}SRPM build {{ id }}{% endblock %}
 {% block content %}
-<h1>
-  SRPM build logs
-</h1>
+<h1>SRPM build logs</h1>
 <pre>{{ srpm_build.logs }}</pre>
 {% endblock %}

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -76,6 +76,7 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 logging.getLogger("github").setLevel(logging.WARNING)
 logging.getLogger("kubernetes").setLevel(logging.WARNING)
+logging.getLogger("botocore").setLevel(logging.WARNING)
 # info is just enough
 logging.getLogger("ogr").setLevel(logging.INFO)
 # easier debugging

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ packages = find:
 # The others are in files/install-deps*.yaml
 install_requires =
     # 4.4.4 was broken, stick to what works
-    celery[redis]==4.4.2
+    celery[redis,sqs]==4.4.2
     lazy_object_proxy
 python_requires = >=3.7
 include_package_data = True


### PR DESCRIPTION
1. We use AWS SQS if both `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` are set.
It they are not, fall back to redis.
By default (if `QUEUE_NAME_PREFIX` is not set) we use `packit-$DEPLOYMENT-` queue prefix,
i.e. we have `packit-stg-celery` and `packit-prod-celery` queues.

2. Also allow to specify PostgreSQL host to be able to use other than local instance (e.g. AWS RDS PostgreSQL).