### PR TITLE
Turn PR labels into a set in the handler

### DIFF
--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 import logging
-from typing import Optional, Set
+from typing import Optional, List
 
 from ogr.abstract import CommitStatus, PullRequest
 from packit.config import JobType, JobConfig, PackageConfig
@@ -94,7 +94,7 @@ class PagurePullRequestLabelHandler(JobHandler):
         package_config: PackageConfig,
         job_config: JobConfig,
         data: EventData,
-        labels: Set[str],
+        labels: List[str],
         action: PullRequestLabelAction,
         base_repo_owner: str,
         base_repo_name: str,
@@ -103,7 +103,7 @@ class PagurePullRequestLabelHandler(JobHandler):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data
         )
-        self.labels = labels
+        self.labels = set(labels)
         self.action = action
         self.base_repo_owner = base_repo_owner
         self.base_repo_name = base_repo_name


### PR DESCRIPTION
PR #792, made PullRequestLabelPagureEvents JSON serializable, but this
also means that the handler receives these events as a list, not as a
set.

Due to this the intersection used to find out whether the service should
react on the labels applied fails with an AttributeError ('list' object
has no attribute 'intersection'). To fix this, explicitly construct a
set in the handler's `__init__()`.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>