### PR TITLE
[models.get_pg_url] POSTGRES_SERVICE_HOST -> POSTGRESQL_HOST

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -62,7 +62,7 @@ def get_pg_url() -> str:
     """ create postgresql connection string """
     return (
         f"postgres+psycopg2://{os.getenv('POSTGRESQL_USER')}"
-        f":{os.getenv('POSTGRESQL_PASSWORD')}@{os.getenv('POSTGRES_SERVICE_HOST', 'postgres')}"
+        f":{os.getenv('POSTGRESQL_PASSWORD')}@{os.getenv('POSTGRESQL_HOST', 'postgres')}"
         f":{os.getenv('POSTGRESQL_PORT', '5432')}/{os.getenv('POSTGRESQL_DATABASE')}"
     )
 


### PR DESCRIPTION
`POSTGRES_SERVICE_HOST` is set by k8s/openshift and points to local 'postgres'
while `POSTGRESQL_HOST` is set by us and points to
either AWS RDS instance url or also local 'postgres'

(I initially had this change in my previous #800 but then removed it when debugging failing tests in openshift)