### PR TITLE
Set pr_id in StatusReporter called from TestingFarmResultsHandler

### DIFF
--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -127,7 +127,9 @@ class TestingFarmResultsHandler(JobHandler):
 
         if test_run_model:
             test_run_model.set_web_url(self.log_url)
-        status_reporter = StatusReporter(self.project, self.data.commit_sha)
+        status_reporter = StatusReporter(
+            project=self.project, commit_sha=self.data.commit_sha, pr_id=self.data.pr_id
+        )
         status_reporter.report(
             state=status,
             description=short_msg,


### PR DESCRIPTION
`pr_id` is missing when StatusReporter is initialized from TestingFarmResultsHandler and we need it for the Pagure only method [__set_pull_request_status](https://github.com/packit/packit-service/blob/03b1c5e004a1c90c2397d98cc18c4d1c148fea81/packit_service/worker/reporting.py#L72)

From logs:
`[2020-09-14 09:04:14,209: DEBUG/ForkPoolWorker-1] Status reporter will report for PagureProject(namespace="source-git", repo="HdrHistogram_c"), commit=91d499d5f1c1aa4a098700b28f7af1a44ca3f942, pr=None`