### PR TITLE
files/install-deps[-worker].yaml - install pycurl as rpm

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -20,8 +20,9 @@
           - python3-sqlalchemy
           - python3-psycopg2
           #- python3-celery # don't, the liveness probe doesn't work
-          - python3-redis
-          - python3-boto3 # AWS SDK
+          - python3-redis # celery[redis]
+          - python3-boto3 # celery[sqs]
+          - python3-pycurl # celery[sqs]
           - python3-lazy-object-proxy
           - python3-bugzilla # python-bugzilla (not bugzilla) on PyPI
           - python3-backoff # Bugzilla class

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -28,8 +28,9 @@
           - python3-prometheus_client
           - python3-psycopg2
           #- python3-celery # don't, the liveness probe doesn't work
-          - python3-redis
-          - python3-boto3 # AWS SDK
+          - python3-redis # celery[redis]
+          - python3-boto3 # celery[sqs]
+          - python3-pycurl # celery[sqs]
           - python3-lazy-object-proxy
           #- python3-flask-restx # Needs Fedora 32
           - python3-flexmock # because of the hack during the alembic upgrade


### PR DESCRIPTION
It's required by `celery[sqs]` and would otherwise need additional libs to be installed from PyPI.
https://stackoverflow.com/questions/23937933/could-not-run-curl-config-errno-2-no-such-file-or-directory-when-installing