### PR TITLE
Add header to status table

### DIFF
--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -100,11 +100,13 @@ class StatusReporter:
 
         if isinstance(check_names, str):
             check_names = [check_names]
-        comment_msg = [
-            f"| [{check}]({url}) | {state.name.upper()} |" for check in check_names
-        ]
 
-        self.project.pr_comment(self.pr_id, "\n\n".join(comment_msg))
+        comment_table_rows = [
+            "| Job | Result |",
+            "| ------------- | ------------ |",
+        ] + [f"| [{check}]({url}) | {state.name.upper()} |" for check in check_names]
+
+        self.project.pr_comment(self.pr_id, "\n".join(comment_table_rows))
 
     def set_status(
         self,

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -151,7 +151,8 @@ def test_report_status_by_comment(
     reporter = StatusReporter(project, commit_sha, pr_id)
 
     project.should_receive("pr_comment").with_args(
-        pr_id, f"| [{check_names}]({url}) | SUCCESS |"
+        pr_id,
+        f"| Job | Result |\n| ------------- | ------------ |\n| [{check_names}]({url}) | SUCCESS |",
     ).once()
 
     reporter.report_status_by_comment(state, url, check_names)


### PR DESCRIPTION
- Add missing markdown header to the status table.
- Example of the current state: https://gitlab.com/packit-service/src/drpm/-/merge_requests/2#note_414152514