### PR TITLE
[files/install-deps*.yaml] install pycurl build dependencies

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -22,7 +22,7 @@
           #- python3-celery # don't, the liveness probe doesn't work
           - python3-redis # celery[redis]
           - python3-boto3 # celery[sqs]
-          - python3-pycurl # celery[sqs]
+          # - python3-pycurl # celery[sqs]  see below task
           - python3-lazy-object-proxy
           - python3-bugzilla # python-bugzilla (not bugzilla) on PyPI
           - python3-backoff # Bugzilla class
@@ -35,6 +35,14 @@
           # oc rsync /sandcastle -> sandcastle pod
           - rsync
         state: present
+    # https://github.com/packit/packit/issues/965
+    - name: Install pycurl build dependencies
+      dnf:
+        name:
+          - gcc
+          - libcurl-devel
+          - openssl-devel
+          - python3-devel
     - import_tasks: tasks/install-packit-deps.yaml
     - import_tasks: tasks/install-ogr-deps.yaml
     - name: Install pip deps

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -40,6 +40,7 @@
     - name: Install pip deps
       pip:
         name:
+          - celery[redis,sqs] == 4.4.2
           - git+https://github.com/packit/sandcastle.git
           - sentry-sdk
           - flask-restx

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -30,7 +30,7 @@
           #- python3-celery # don't, the liveness probe doesn't work
           - python3-redis # celery[redis]
           - python3-boto3 # celery[sqs]
-          - python3-pycurl # celery[sqs]
+          # - python3-pycurl # celery[sqs] see below task
           - python3-lazy-object-proxy
           #- python3-flask-restx # Needs Fedora 32
           - python3-flexmock # because of the hack during the alembic upgrade
@@ -38,6 +38,12 @@
           - dnf-plugins-core
           - python-jwt
         state: present
+    # https://github.com/packit/packit/issues/965
+    - name: Install pycurl build dependencies
+      dnf:
+        name:
+          - libcurl-devel
+          - openssl-devel
     - import_tasks: tasks/install-ogr-deps.yaml
     - import_tasks: tasks/install-packit-deps.yaml
     - name: Install pip deps

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -43,7 +43,7 @@
     - name: Install pip deps
       pip:
         name:
-          # temporary workaround for sake of marhsmallow
+          - celery[redis,sqs] == 4.4.2
           - persistentdict # still needed by one Alembic migration script
           - sentry-sdk[flask]
           - flask-restx

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,12 +29,8 @@ keywords =
 [options]
 packages = find:
 # This repo contains 2 components (with separate container images): web service and celery worker
-# Here are only those deps that are required by both, so that each image doesn't pull everything.
-# The others are in files/install-deps*.yaml
-install_requires =
-    # 4.4.4 was broken, stick to what works
-    celery[redis,sqs]==4.4.2
-    lazy_object_proxy
+# They have separate dependencies in files/install-deps*.yaml
+# install_requires = ...
 python_requires = >=3.7
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
Fixes: https://github.com/packit/packit/issues/965

celery[sqs] pins pycurl dependency to specific version which
might not be the same version as dnf installed python3-pycurl so we have to build
pycurl ourselves, hence the dependencies