### PR TITLE
Pin celery to 4.4.7

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -22,7 +22,7 @@
           #- python3-celery # don't, the liveness probe doesn't work
           - python3-redis # celery[redis]
           - python3-boto3 # celery[sqs]
-          # - python3-pycurl # celery[sqs]  see below task
+          - python3-pycurl # celery[sqs]  see also below task
           - python3-lazy-object-proxy
           - python3-bugzilla # python-bugzilla (not bugzilla) on PyPI
           - python3-backoff # Bugzilla class
@@ -48,7 +48,7 @@
     - name: Install pip deps
       pip:
         name:
-          - celery[redis,sqs] == 4.4.2
+          - celery[redis,sqs] == 4.4.7
           - git+https://github.com/packit/sandcastle.git
           - sentry-sdk
           - flask-restx

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -30,7 +30,7 @@
           #- python3-celery # don't, the liveness probe doesn't work
           - python3-redis # celery[redis]
           - python3-boto3 # celery[sqs]
-          # - python3-pycurl # celery[sqs] see below task
+          - python3-pycurl # celery[sqs] see also below task
           - python3-lazy-object-proxy
           #- python3-flask-restx # Needs Fedora 32
           - python3-flexmock # because of the hack during the alembic upgrade
@@ -49,7 +49,7 @@
     - name: Install pip deps
       pip:
         name:
-          - celery[redis,sqs] == 4.4.2
+          - celery[redis,sqs] == 4.4.7
           - persistentdict # still needed by one Alembic migration script
           - sentry-sdk[flask]
           - flask-restx


### PR DESCRIPTION
Also dnf install `python3-pycurl`.
This is to work-around failing reverse-dep tests in packit because I'm getting out of ideas why `reverse-dep-packit-service-tests` job [can't build pycurl](https://softwarefactory-project.io/logs/64/964/a7b8552475cbf4650465be7d6e260b276654bb28/check/reverse-dep-packit-service-tests/1ccb6d9/job-output.txt).
celery 4.4.7 requires pycurl-7.43.0.5 which is the same version as python3-pycurl on Fedora 32 (in Zuul)