### PR TITLE
Base images on F32

### DIFF
--- a/files/docker/Dockerfile.tests
+++ b/files/docker/Dockerfile.tests
@@ -1,6 +1,6 @@
 # For running tests locally, see check_in_container target in Makefile
 
-FROM docker.io/usercont/packit-service-worker:stg
+FROM docker.io/usercont/packit-service-worker:dev
 
 ARG SOURCE_BRANCH
 RUN  if [[ -z $SOURCE_BRANCH ]]; then \

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -26,7 +26,7 @@
           - python3-lazy-object-proxy
           - python3-bugzilla # python-bugzilla (not bugzilla) on PyPI
           - python3-backoff # Bugzilla class
-          #- python3-flask-restx # needs Fedora 32
+          - python3-flask-restx
           - dnf-utils
           - python3-pip
           - make
@@ -42,7 +42,6 @@
         name:
           - git+https://github.com/packit/sandcastle.git
           - sentry-sdk
-          - flask-restx
         executable: pip3
     # --no-deps: to fail instead of installing from PyPI when we forget to add some dependency to packit.spec
     - name: pip install packit & ogr with --no-deps

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -32,7 +32,7 @@
           - python3-boto3 # celery[sqs]
           - python3-pycurl # celery[sqs]
           - python3-lazy-object-proxy
-          #- python3-flask-restx # Needs Fedora 32
+          - python3-flask-restx
           - python3-flexmock # because of the hack during the alembic upgrade
           # (see d90948124e46_add_tables_for_triggers_koji_and_tests.py )
           - dnf-plugins-core
@@ -45,7 +45,6 @@
         name:
           - persistentdict # still needed by one Alembic migration script
           - sentry-sdk[flask]
-          - flask-restx
         executable: pip3
 
     # --no-deps: to fail instead of installing from PyPI when we forget to add some dependency to packit.spec

--- a/files/run_httpd.sh
+++ b/files/run_httpd.sh
@@ -10,7 +10,7 @@ pushd /src
 n=0
 until [ $n -ge 7 ]
 do
-  alembic upgrade head && break
+  alembic-3 upgrade head && break
   n=$[$n+1]
   sleep 2
 done

--- a/files/run_tests.sh
+++ b/files/run_tests.sh
@@ -6,8 +6,8 @@ source /src/files/setup_env_in_openshift.sh
 
 id
 
-cat $HOME/.config/packit-service.yaml
+cat "${HOME}/.config/packit-service.yaml"
 
-alembic upgrade head
+alembic-3 upgrade head
 
 python3 -m pytest -vv tests_requre/


### PR DESCRIPTION
Since we [removed worker probes](https://github.com/packit/deployment/pull/142) let's try whether it's feasible to base images on F32 or [Zuul would still object](https://github.com/packit/deployment/pull/141#issuecomment-695987918).