### PR TITLE
Don't raise exception when REDIS_SERVICE_HOST not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ check_in_container: test_image
 		--env COV_REPORT \
 		--env TEST_TARGET \
 		--env COLOR \
-		--env REDIS_SERVICE_HOST=redis \
 		-v $(CURDIR):/src \
 		-w /src \
 		--security-opt label=disable \
@@ -71,7 +70,6 @@ check-in-container-tomas:
 		-v $(CURDIR)/files/packit-service.yaml:/root/.config/packit-service.yaml \
 		-v $(CURDIR)/tests_requre/openshift_integration/test_data/:/tmp/test_data/ \
 		--network packit-service_default \
-		-e REDIS_SERVICE_HOST=redis \
 		$(TEST_IMAGE) make check "TEST_TARGET=$(TEST_TARGET)"
 
 # deploy a pod with tests and run them

--- a/packit_service/celerizer.py
+++ b/packit_service/celerizer.py
@@ -42,14 +42,12 @@ class Celerizer:
                 if not getenv("QUEUE_NAME_PREFIX"):
                     raise ValueError("QUEUE_NAME_PREFIX not set")
                 bt_options["queue_name_prefix"] = getenv("QUEUE_NAME_PREFIX")
-            elif getenv("REDIS_SERVICE_HOST"):
-                host = getenv("REDIS_SERVICE_HOST")
+            else:
+                host = getenv("REDIS_SERVICE_HOST", "redis")
                 password = getenv("REDIS_PASSWORD", "")
                 port = getenv("REDIS_SERVICE_PORT", "6379")
                 db = getenv("REDIS_SERVICE_DB", "0")
                 broker_url = f"redis://:{password}@{host}:{port}/{db}"
-            else:
-                raise ValueError("Celery broker not configured")
 
             # https://docs.celeryproject.org/en/stable/userguide/configuration.html#database-url-examples
             postgres_url = f"db+{get_pg_url()}"


### PR DESCRIPTION
Just default to 'redis', as we did before b0080eed454 so we don't have to set it in all the tests.