### PR TITLE
Support for enabled_private_namespaces

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -22,7 +22,7 @@
 import enum
 import logging
 from pathlib import Path
-from typing import Set, Optional, List
+from typing import Set, Optional, List, Union
 
 from yaml import safe_load
 
@@ -66,6 +66,7 @@ class ServiceConfig(Config):
         bugzilla_api_key: str = "",
         pr_accepted_labels: List[str] = None,
         gitlab_webhook_tokens: List[str] = None,
+        enabled_private_namespaces: Union[Set[str], List[str]] = None,
         gitlab_token_secret: str = "",
         **kwargs,
     ):
@@ -98,6 +99,14 @@ class ServiceConfig(Config):
         # Gitlab token secret to decode JWT tokens
         self.gitlab_token_secret: str = gitlab_token_secret
 
+        # Explicit list of private namespaces we work with
+        # e.g.:
+        #  - github.com/other-private-namespace
+        #  - gitlab.com/private/namespace
+        self.enabled_private_namespaces: Set[str] = set(
+            enabled_private_namespaces or []
+        )
+
     def __repr__(self):
         def hide(token: str) -> str:
             return f"{token[:1]}***{token[-1:]}" if token else ""
@@ -115,6 +124,7 @@ class ServiceConfig(Config):
             f"bugzilla_api_key='{hide(self.bugzilla_api_key)}', "
             f"gitlab_webhook_tokens='{self.gitlab_webhook_tokens}',"
             f"gitlab_token_secret='{hide(self.gitlab_token_secret)}',"
+            f"enabled_private_namespaces='{self.enabled_private_namespaces}',"
             f"server_name='{self.server_name}')"
         )
 

--- a/packit_service/schema.py
+++ b/packit_service/schema.py
@@ -58,6 +58,7 @@ class ServiceConfigSchema(UserConfigSchema):
     server_name = fields.String()
     gitlab_webhook_tokens = fields.List(fields.String())
     gitlab_token_secret = fields.String()
+    enabled_private_namespaces = fields.List(fields.String())
 
     @post_load
     def make_instance(self, data, **kwargs):

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -404,8 +404,24 @@ class SteveJobs:
                 "Skipping private repository check!"
             )
         elif event_object.project.is_private():
-            logger.info("We do not interact with private repositories!")
-            return None
+            service_with_namespace = (
+                f"{event_object.project.service.hostname}/"
+                f"{event_object.project.namespace}"
+            )
+            if (
+                service_with_namespace
+                not in self.service_config.enabled_private_namespaces
+            ):
+                logger.info(
+                    f"We do not interact with private repositories by default. "
+                    f"Add `{service_with_namespace}` to the `enabled_private_namespaces` "
+                    f"in the service configuration."
+                )
+                return None
+            logger.debug(
+                f"Working in `{service_with_namespace}` namespace "
+                f"which is private but enabled via configuration."
+            )
 
         handler: Union[
             GithubAppInstallationHandler,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -64,6 +64,10 @@ def service_config_valid():
         "server_name": "hub.packit.org",
         "gitlab_webhook_tokens": ["token1", "token2", "token3", "aged"],
         "gitlab_token_secret": "jwt_secret",
+        "enabled_private_namespaces": [
+            "gitlab.com/private/namespace",
+            "github.com/other-private-namespace",
+        ],
     }
 
 
@@ -85,6 +89,10 @@ def test_parse_valid(service_config_valid):
     assert config.server_name == "hub.packit.org"
     assert config.gitlab_token_secret == "jwt_secret"
     assert config.gitlab_webhook_tokens == {"token1", "token2", "token3", "aged"}
+    assert config.enabled_private_namespaces == {
+        "gitlab.com/private/namespace",
+        "github.com/other-private-namespace",
+    }
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
- Work with private namespaces enabled in the service config.
  - We do not work with private repositories by default. This field contains list of namespaces in a form of hostname/namespace that are enabled.
- Add `enabled_private_namespaces` field to the service config.