### PR TITLE
Pin sentry-sdk to 0.18.0

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -41,7 +41,7 @@
       pip:
         name:
           - git+https://github.com/packit/sandcastle.git
-          - sentry-sdk
+          - sentry-sdk==0.18.0
         executable: pip3
     # --no-deps: to fail instead of installing from PyPI when we forget to add some dependency to packit.spec
     - name: pip install packit & ogr with --no-deps

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -44,7 +44,7 @@
       pip:
         name:
           - persistentdict # still needed by one Alembic migration script
-          - sentry-sdk[flask]
+          - sentry-sdk[flask]==0.18.0
         executable: pip3
 
     # --no-deps: to fail instead of installing from PyPI when we forget to add some dependency to packit.spec


### PR DESCRIPTION
0.19.0 introduced this issue:

https://github.com/getsentry/sentry-python/issues/858

Pin to the previous version until this is fixed, in order to make stage
work.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>