### PR TITLE
Add commit comment if cannot set commit status or comment on PR

### DIFF
--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -109,7 +109,7 @@ class StatusReporter:
             "| ------------- | ------------ |",
         ] + [f"| [{check}]({url}) | {state.name.upper()} |" for check in check_names]
 
-        self.project.pr_comment(self.pr_id, "\n".join(comment_table_rows))
+        self.comment("\n".join(comment_table_rows))
 
     def __add_commit_comment_with_status(
         self, state: CommitStatus, description: str, check_name: str, url: str = ""
@@ -163,3 +163,9 @@ class StatusReporter:
 
     def get_statuses(self):
         self.project.get_commit_statuses(commit=self.commit_sha)
+
+    def comment(self, body: str):
+        if self.pr_id:
+            self.project.get_pr(pr_id=self.pr_id).comment(body=body)
+        else:
+            self.project.commit_comment(commit=self.commit_sha, body=body)

--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -19,10 +19,13 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
 import hashlib
 import logging
 from typing import Optional, Union
+
 import gitlab
+import github
 
 from ogr.abstract import GitProject, CommitStatus
 from ogr.services.pagure import PagureProject
@@ -108,6 +111,24 @@ class StatusReporter:
 
         self.project.pr_comment(self.pr_id, "\n".join(comment_table_rows))
 
+    def __add_commit_comment_with_status(
+        self, state: CommitStatus, description: str, check_name: str, url: str = ""
+    ):
+        body = (
+            "\n".join(
+                [
+                    f"- name: {check_name}",
+                    f"- state: {state.name}",
+                    f"- url: {url if url else 'not provided'}",
+                ]
+            )
+            + f"\n\n{description}"
+        )
+        self.project.commit_comment(
+            commit=self.commit_sha,
+            body=body,
+        )
+
     def set_status(
         self,
         state: CommitStatus,
@@ -125,10 +146,16 @@ class StatusReporter:
             self.project.set_commit_status(
                 self.commit_sha, state, url, description, check_name, trim=True
             )
-        except gitlab.exceptions.GitlabCreateError:
+        except gitlab.exceptions.GitlabCreateError as e:
             # Ignoring Gitlab 'enqueue' error
             # https://github.com/packit-service/packit-service/issues/741
-            pass
+            if e.response_code == 403:
+                # In case we don't have permissions to set status we post comment
+                self.__add_commit_comment_with_status(
+                    state, description, check_name, url
+                )
+        except github.GithubException:
+            self.__add_commit_comment_with_status(state, description, check_name, url)
 
         # Also set the status of the pull-request for forges which don't do
         # this automatically based on the flags on the last commit in the PR.

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -601,6 +601,63 @@ def test_copr_build_for_branch(branch_push_event):
     assert helper.run_copr_build()["success"]
 
 
+def test_copr_build_for_branch_failed(branch_push_event):
+    # status is set for each build-target (4x):
+    #  - Building SRPM ...
+    #  - Starting RPM build...
+    branch_build_job = JobConfig(
+        type=JobType.build,
+        trigger=JobConfigTriggerType.commit,
+        metadata=JobMetadataConfig(
+            targets=DEFAULT_TARGETS,
+            owner="nobody",
+            dist_git_branches=["build-branch"],
+        ),
+    )
+    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.commit, id=123)
+    flexmock(AddBranchPushDbTrigger).should_receive("db_trigger").and_return(trigger)
+    helper = build_helper(
+        jobs=[branch_build_job],
+        event=branch_push_event,
+        db_trigger=trigger,
+    )
+    flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
+    flexmock(GitProject).should_receive("commit_comment").and_return(flexmock())
+    flexmock(SRPMBuildModel).should_receive("create").and_return(
+        SRPMBuildModel(success=False, id=2)
+    )
+    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
+        CoprBuildModel(id=1)
+    )
+    flexmock(PushGitHubEvent).should_receive("db_trigger").and_raise(flexmock())
+
+    flexmock(PackitAPI).should_receive("create_srpm").and_raise(
+        FailedCreateSRPM, "some error"
+    )
+
+    flexmock(Client).should_receive("create_from_config_file").and_return(
+        flexmock(
+            config={"copr_url": "https://copr.fedorainfracloud.org/"},
+            build_proxy=flexmock()
+            .should_receive("create_from_file")
+            .and_return(
+                flexmock(id=2, projectname="the-project-name", ownername="the-owner")
+            )
+            .mock(),
+            mock_chroot_proxy=flexmock()
+            .should_receive("get_list")
+            .and_return({target: "" for target in DEFAULT_TARGETS})
+            .mock(),
+        )
+    )
+
+    flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
+    flexmock(Pushgateway).should_receive("push_copr_build_created").never()
+    flexmock(CoprBuildJobHelper).should_receive("run_build").never()
+
+    assert not helper.run_copr_build()["success"]
+
+
 def test_copr_build_for_release(release_event):
     # status is set for each build-target (4x):
     #  - Building SRPM ...

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -806,36 +806,41 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
     )
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
-    flexmock(GitProject).should_receive("pr_comment").with_args(
-        pr_id=342,
-        body="Based on your Packit configuration the settings of the "
-        "nobody/git.instance.io-the-example-namespace-the-example-repo-342-stg "
-        "Copr project would need to be updated as follows:\n"
-        "\n"
-        "| field | old value | new value |\n"
-        "| ----- | --------- | --------- |\n"
-        "| chroots | ['f30', 'f31'] | ['f31', 'f32'] |\n"
-        "| description | old | new |\n"
-        "\n"
-        "\n"
-        "Packit was unable to update the settings above "
-        "as it is missing `admin` permissions on the "
-        "nobody/git.instance.io-the-example-namespace-the-example-repo-342-stg Copr project.\n"
-        "\n"
-        "To fix this you can do one of the following:\n"
-        "\n"
-        "- Grant Packit `admin` permissions on the "
-        "nobody/git.instance.io-the-example-namespace-the-example-repo-342-stg Copr project on the "
-        "[permissions page](https://copr.fedorainfracloud.org/coprs/nobody/"
-        "git.instance.io-the-example-namespace-the-example-repo-342-stg/permissions/).\n"
-        "- Change the above Copr project settings manually on the "
-        "[settings page](https://copr.fedorainfracloud.org/"
-        "coprs/nobody/git.instance.io-the-example-namespace-the-example-repo-342-stg/edit/) "
-        "to match the Packit configuration.\n"
-        "- Update the Packit configuration to match the Copr project settings.\n"
-        "\n"
-        "Please re-trigger the build, once the issue above is fixed.\n",
-    ).and_return().once()
+    flexmock(GitProject).should_receive("get_pr").with_args(pr_id=342).and_return(
+        flexmock()
+        .should_receive("comment")
+        .with_args(
+            body="Based on your Packit configuration the settings of the "
+            "nobody/git.instance.io-the-example-namespace-the-example-repo-342-stg "
+            "Copr project would need to be updated as follows:\n"
+            "\n"
+            "| field | old value | new value |\n"
+            "| ----- | --------- | --------- |\n"
+            "| chroots | ['f30', 'f31'] | ['f31', 'f32'] |\n"
+            "| description | old | new |\n"
+            "\n"
+            "\n"
+            "Packit was unable to update the settings above "
+            "as it is missing `admin` permissions on the "
+            "nobody/git.instance.io-the-example-namespace-the-example-repo-342-stg Copr project.\n"
+            "\n"
+            "To fix this you can do one of the following:\n"
+            "\n"
+            "- Grant Packit `admin` permissions on the "
+            "nobody/git.instance.io-the-example-namespace-the-example-repo-342-stg "
+            "Copr project on the [permissions page](https://copr.fedorainfracloud.org/coprs/nobody/"
+            "git.instance.io-the-example-namespace-the-example-repo-342-stg/permissions/).\n"
+            "- Change the above Copr project settings manually on the "
+            "[settings page](https://copr.fedorainfracloud.org/"
+            "coprs/nobody/git.instance.io-the-example-namespace-the-example-repo-342-stg/edit/) "
+            "to match the Packit configuration.\n"
+            "- Update the Packit configuration to match the Copr project settings.\n"
+            "\n"
+            "Please re-trigger the build, once the issue above is fixed.\n",
+        )
+        .and_return()
+        .mock()
+    ).and_return()
 
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
     # copr build
@@ -1246,7 +1251,9 @@ def test_copr_build_success_gitlab_comment(gitlab_mr_event):
     flexmock(BaseBuildJobHelper).should_receive("is_reporting_allowed").and_return(
         False
     )
-    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(comment=flexmock().should_receive("comment").and_return().mock())
+    )
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
     )

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import github
+import gitlab
 import pytest
 from flexmock import flexmock
 
@@ -119,6 +121,78 @@ def test_set_status(
         pr_object.should_receive("set_flag").with_args(
             check_name, description, url, state, uid
         )
+
+    reporter.set_status(state, description, check_name, url)
+
+
+@pytest.mark.parametrize(
+    (
+        "project,commit_sha,"
+        "pr_id,has_pr_id,pr_object,"
+        "state,description,check_name,url,"
+        "exception_mock"
+    ),
+    [
+        pytest.param(
+            flexmock(),
+            "7654321",
+            "11",
+            True,
+            flexmock(),
+            CommitStatus.success,
+            "We made it!",
+            "packit/pr-rpm-build",
+            "https://api.packit.dev/build/111/logs",
+            (github.GithubException, (None, None), dict()),
+            id="GitHub PR",
+        ),
+        pytest.param(
+            flexmock(),
+            "7654321",
+            None,
+            False,
+            flexmock(),
+            CommitStatus.failure,
+            "We made it!",
+            "packit/branch-rpm-build",
+            "https://api.packit.dev/build/112/logs",
+            (gitlab.exceptions.GitlabCreateError, (), {"response_code": 403}),
+            id="branch push",
+        ),
+    ],
+)
+def test_commit_comment_instead_of_status(
+    project,
+    commit_sha,
+    pr_id,
+    has_pr_id,
+    pr_object,
+    state,
+    description,
+    check_name,
+    url,
+    exception_mock,
+):
+    reporter = StatusReporter(project, commit_sha, pr_id)
+
+    exception, exception_args, exception_kwargs = exception_mock
+    project.should_receive("set_commit_status").with_args(
+        commit_sha, state, url, description, check_name, trim=True
+    ).and_raise(exception, *exception_args, **exception_kwargs).once()
+    project.should_receive("commit_comment").with_args(
+        commit=commit_sha,
+        body="\n".join(
+            [
+                f"- name: {check_name}",
+                f"- state: {state.name}",
+                f"- url: {url if url else 'not provided'}",
+            ]
+        )
+        + f"\n\n{description}",
+    )
+
+    if has_pr_id:
+        project.should_receive("get_pr").with_args(pr_id).once().and_return(pr_object)
 
     reporter.set_status(state, description, check_name, url)
 

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -224,9 +224,15 @@ def test_report_status_by_comment(
 ):
     reporter = StatusReporter(project, commit_sha, pr_id)
 
-    project.should_receive("pr_comment").with_args(
-        pr_id,
-        f"| Job | Result |\n| ------------- | ------------ |\n| [{check_names}]({url}) | SUCCESS |",
+    project.should_receive("get_pr").with_args(pr_id=pr_id).and_return(
+        flexmock()
+        .should_receive("comment")
+        .with_args(
+            body="| Job | Result |\n"
+            "| ------------- | ------------ |\n"
+            f"| [{check_names}]({url}) | SUCCESS |",
+        )
+        .mock()
     ).once()
 
     reporter.report_status_by_comment(state, url, check_names)


### PR DESCRIPTION
In case we don't have permissions to set commit status,
fallback to adding comment on commit

Fixes #780

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:
- [x] Test for commit comment if cannot set commit status
- [x] Refactor commenting on PRs
- [x] In case we cannot comment on PR comment on commit
- [x] Add test for commenting on commit