### PR TITLE
[docker-compose.yml] worker no tty

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
         SOURCE_BRANCH: master
     image: docker.io/usercont/packit-service-worker:dev
     command: /usr/bin/run_worker.sh
-    tty: true
+    #tty: true
     depends_on:
       - redis
       - postgres


### PR DESCRIPTION
After upgrading the base image to Fedora32 I started seeing

```
worker |   File "/usr/lib64/python3.8/textwrap.py", line 248, in _wrap_chunks
worker |     raise ValueError("invalid width %r (must be > 0)" % self.width)
worker | ValueError: invalid width -2 (must be > 0)
worker exited with code 1
```

This change makes `docker-compose worker` work again.