### PR TITLE
Don't fall back to flask_restplus 

### DIFF
--- a/packit_service/sentry_integration.py
+++ b/packit_service/sentry_integration.py
@@ -1,27 +1,12 @@
-# MIT License
-#
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
 
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 import logging
 from contextlib import contextmanager
 from os import getenv
+from typing import List
+
+from sentry_sdk.integrations import Integration
 
 from packit_service.utils import only_once
 
@@ -49,7 +34,7 @@ def configure_sentry(
     # so that we don't have to have sentry sdk installed locally
     import sentry_sdk
 
-    integrations = []
+    integrations: List[Integration] = []
 
     if celery_integration:
         # https://docs.sentry.io/platforms/python/celery/

--- a/packit_service/service/api/__init__.py
+++ b/packit_service/service/api/__init__.py
@@ -1,38 +1,15 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 from flask import Blueprint
-
-from packit_service.service.api.koji_builds import koji_builds_ns
-
-try:
-    from flask_restx import Api
-except ModuleNotFoundError:
-    from flask_restplus import Api
+from flask_restx import Api
 
 from packit_service.service.api.copr_builds import ns as copr_builds_ns
-from packit_service.service.api.srpm_builds import ns as srpm_builds_ns
-from packit_service.service.api.projects import ns as projects_ns
 from packit_service.service.api.healthz import ns as healthz_ns
 from packit_service.service.api.installations import ns as installations_ns
+from packit_service.service.api.koji_builds import koji_builds_ns
+from packit_service.service.api.projects import ns as projects_ns
+from packit_service.service.api.srpm_builds import ns as srpm_builds_ns
 from packit_service.service.api.testing_farm import ns as testing_farm_ns
 from packit_service.service.api.webhooks import ns as webhooks_ns
 from packit_service.service.api.whitelist import ns as whitelist_ns

--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -1,36 +1,14 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 from http import HTTPStatus
 from logging import getLogger
 
-try:
-    from flask_restx import Namespace, Resource
-except ModuleNotFoundError:
-    from flask_restplus import Namespace, Resource
+from flask_restx import Namespace, Resource
 
-from packit_service.service.api.utils import response_maker
-from packit_service.service.api.parsers import indices, pagination_arguments
 from packit_service.models import CoprBuildModel, optional_time
-
+from packit_service.service.api.parsers import indices, pagination_arguments
+from packit_service.service.api.utils import response_maker
 
 logger = getLogger("packit_service")
 

--- a/packit_service/service/api/healthz.py
+++ b/packit_service/service/api/healthz.py
@@ -1,32 +1,12 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 from http import HTTPStatus
 from logging import getLogger
-from packit_service.service.api.utils import response_maker
 
-try:
-    from flask_restx import Namespace, Resource
-except ModuleNotFoundError:
-    from flask_restplus import Namespace, Resource
+from flask_restx import Namespace, Resource
+
+from packit_service.service.api.utils import response_maker
 
 logger = getLogger("packit_service")
 

--- a/packit_service/service/api/installations.py
+++ b/packit_service/service/api/installations.py
@@ -1,31 +1,10 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 from http import HTTPStatus
 from logging import getLogger
 
-try:
-    from flask_restx import Namespace, Resource
-except ModuleNotFoundError:
-    from flask_restplus import Namespace, Resource
+from flask_restx import Namespace, Resource
 
 from packit_service.models import InstallationModel
 

--- a/packit_service/service/api/koji_builds.py
+++ b/packit_service/service/api/koji_builds.py
@@ -1,35 +1,14 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 from http import HTTPStatus
 from logging import getLogger
 
-try:
-    from flask_restx import Namespace, Resource
-except ModuleNotFoundError:
-    from flask_restplus import Namespace, Resource
+from flask_restx import Namespace, Resource
 
-from packit_service.service.api.utils import response_maker
-from packit_service.service.api.parsers import indices, pagination_arguments
 from packit_service.models import KojiBuildModel, optional_time
+from packit_service.service.api.parsers import indices, pagination_arguments
+from packit_service.service.api.utils import response_maker
 
 logger = getLogger("packit_service")
 

--- a/packit_service/service/api/parsers.py
+++ b/packit_service/service/api/parsers.py
@@ -1,31 +1,9 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
 
 from flask import request
 
-try:
-    from flask_restx import reqparse
-except ModuleNotFoundError:
-    from flask_restplus import reqparse
+from flask_restx import reqparse
 
 DEFAULT_PAGE = 1
 DEFAULT_PER_PAGE = 10

--- a/packit_service/service/api/projects.py
+++ b/packit_service/service/api/projects.py
@@ -1,15 +1,15 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 from http import HTTPStatus
 from logging import getLogger
 
-try:
-    from flask_restx import Namespace, Resource
-except ModuleNotFoundError:
-    from flask_restplus import Namespace, Resource
-
-from packit_service.service.api.utils import response_maker
-from packit_service.service.api.parsers import indices, pagination_arguments
-from packit_service.models import GitProjectModel
 from flask import url_for
+from flask_restx import Namespace, Resource
+
+from packit_service.models import GitProjectModel
+from packit_service.service.api.parsers import indices, pagination_arguments
+from packit_service.service.api.utils import response_maker
 
 logger = getLogger("packit_service")
 

--- a/packit_service/service/api/srpm_builds.py
+++ b/packit_service/service/api/srpm_builds.py
@@ -1,38 +1,16 @@
-# MIT License
-#
-# Copyright (c) 2020 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 from http import HTTPStatus
 from logging import getLogger
 
-try:
-    from flask_restx import Namespace, Resource
-except ModuleNotFoundError:
-    from flask_restplus import Namespace, Resource
-
-from packit_service.service.api.utils import response_maker
-from packit_service.service.api.parsers import indices, pagination_arguments
-from packit_service.models import SRPMBuildModel, optional_time
-
 # from packit_service.service.urls import get_srpm_log_url_from_flask
 from flask import url_for
+from flask_restx import Namespace, Resource
+
+from packit_service.models import SRPMBuildModel, optional_time
+from packit_service.service.api.parsers import indices, pagination_arguments
+from packit_service.service.api.utils import response_maker
 
 logger = getLogger("packit_service")
 

--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -1,41 +1,18 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
 
 import logging
 from http import HTTPStatus
 
 from flask import request
+from flask_restx import Namespace, Resource, fields
 
-try:
-    from flask_restx import Namespace, Resource, fields
-except ModuleNotFoundError:
-    from flask_restplus import Namespace, Resource, fields
-
-from packit_service.service.api.utils import response_maker
 from packit_service.celerizer import celery_app
 from packit_service.config import ServiceConfig
-from packit_service.service.api.errors import ValidationFailed
 from packit_service.models import TFTTestRunModel
+from packit_service.service.api.errors import ValidationFailed
 from packit_service.service.api.parsers import indices, pagination_arguments
+from packit_service.service.api.utils import response_maker
 
 logger = logging.getLogger("packit_service")
 

--- a/packit_service/service/api/webhooks.py
+++ b/packit_service/service/api/webhooks.py
@@ -1,41 +1,18 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 import hmac
-import jwt
+import json
 from hashlib import sha1
 from http import HTTPStatus
 from logging import getLogger
-import json
 
+import jwt
 from flask import request
+from flask_restx import Namespace, Resource, fields
 from prometheus_client import Counter
 
 from ogr.parsing import parse_git_repo
-
-try:
-    from flask_restx import Namespace, Resource, fields
-except ModuleNotFoundError:
-    from flask_restplus import Namespace, Resource, fields
-
 from packit_service.celerizer import celery_app
 from packit_service.config import ServiceConfig
 from packit_service.models import ProjectAuthenticationIssueModel

--- a/packit_service/service/api/whitelist.py
+++ b/packit_service/service/api/whitelist.py
@@ -1,34 +1,12 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 from http import HTTPStatus
 from logging import getLogger
 
-try:
-    from flask_restx import Namespace, Resource
-except ModuleNotFoundError:
-    from flask_restplus import Namespace, Resource
+from flask_restx import Namespace, Resource
 
 from packit_service.models import WhitelistModel
-
 
 logger = getLogger("packit_service")
 


### PR DESCRIPTION
We are now [Fedora-32 based](https://github.com/packit/deployment/blob/master/containers/Dockerfile.base#L4), which [ships flask_restx](https://src.fedoraproject.org/rpms/python-flask-restx).