### PR TITLE
[Dockerfile(s)] use WORKDIR properly

### DIFF
--- a/files/docker/Dockerfile
+++ b/files/docker/Dockerfile
@@ -9,32 +9,28 @@ echo -e "\nMissing SOURCE_BRANCH build argument! Please add \
 This is the branch used when installing other Packit projects (e.g. ogr, packit).\n" && exit 1;\
 fi
 
-ENV LANG=en_US.UTF-8 \
-    ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
-    ANSIBLE_STDOUT_CALLBACK=debug \
-    USER=packit \
+ENV USER=packit \
     HOME=/home/packit
 
-COPY files/ /src/files/
+WORKDIR /src
 
-RUN cd /src/ \
-    && ansible-playbook -vv -c local -i localhost, files/install-deps.yaml \
+COPY files/ ./files/
+RUN ansible-playbook -vv -c local -i localhost, files/install-deps.yaml \
     && dnf clean all
 
-COPY setup.py setup.cfg files/recipe.yaml files/tasks/httpd.yaml files/tasks/common.yaml files/packit.wsgi files/run_httpd.sh files/setup_env_in_openshift.sh files/packit-httpd.conf /src/
+COPY setup.py setup.cfg ./
 # setuptools-scm
-COPY .git /src/.git
-COPY packit_service/ /src/packit_service/
+COPY .git ./.git
+COPY packit_service/ ./packit_service/
 
-RUN cd /src/ \
-    && git rev-parse HEAD >/.packit-service.git.commit.hash \
+RUN git rev-parse HEAD >/.packit-service.git.commit.hash \
     && git show --quiet --format=%B HEAD >/.packit-service.git.commit.message \
-    && ansible-playbook -vv -c local -i localhost, recipe.yaml
+    && ansible-playbook -vv -c local -i localhost, files/recipe.yaml
 
 # no need to rm /src, it will stay in the image anyway
 
-COPY alembic.ini /src/
-COPY alembic/ /src/alembic/
+COPY alembic.ini ./
+COPY alembic/ ./alembic/
 
 EXPOSE 8443
 

--- a/files/docker/Dockerfile.tests
+++ b/files/docker/Dockerfile.tests
@@ -9,18 +9,13 @@ echo -e "\nMissing SOURCE_BRANCH build argument! Please add \
 This is the branch used when installing other Packit projects (e.g. ogr, packit).\n" && exit 1;\
 fi
 
-ENV ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
-    ANSIBLE_STDOUT_CALLBACK=debug
-
 # Since we use worker base image, we need to install service deps manually
-COPY files/install-deps.yaml /src/files/
-RUN cd /src/ \
-    && ansible-playbook -vv -c local -i localhost, files/install-deps.yaml
+RUN ansible-playbook -vv -c local -i localhost, files/install-deps.yaml
 
-RUN set -ex; mkdir -p /home/packit/.config \
-    && ln -s /src/files/packit-service.yaml /home/packit/.config/packit-service.yaml \
-    && ansible-playbook -vv -c local -i localhost, ./files/recipe-tests.yaml
+RUN set -ex; mkdir -p ${HOME}/.config \
+    && ln -s $(pwd)/files/packit-service.yaml ${HOME}/.config/packit-service.yaml \
+    && ansible-playbook -vv -c local -i localhost, files/recipe-tests.yaml
 
 # we are doing the same here as in worker Df so that we don't need to rerun the
 # playbook above for every code change: iterating fast <3
-COPY . /src
+COPY . ./

--- a/files/docker/Dockerfile.worker
+++ b/files/docker/Dockerfile.worker
@@ -9,31 +9,25 @@ echo -e "\nMissing SOURCE_BRANCH build argument! Please add \
 This is the branch used when installing other Packit projects (e.g. ogr, packit).\n" && exit 1;\
 fi
 
-ENV LANG=en_US.UTF-8 \
-    ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
-    ANSIBLE_STDOUT_CALLBACK=debug \
-    USER=packit \
+ENV USER=packit \
     HOME=/home/packit
 
-
 # Ansible doesn't like /tmp
-#COPY files/install-deps-worker.yaml /src/files/
-COPY files/ /src/files/
-RUN cd /src/ \
-    && ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
+WORKDIR /src
+
+COPY files/ ./files/
+RUN ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
     && dnf clean all
 
-COPY setup.py setup.cfg files/recipe-worker.yaml files/tasks/common.yaml files/run_worker.sh files/gitconfig .git_archival.txt .gitattributes /src/
+COPY setup.py setup.cfg .git_archival.txt .gitattributes ./
 # setuptools-scm
-COPY .git /src/.git
-COPY packit_service/ /src/packit_service/
+COPY .git ./.git
+COPY packit_service/ ./packit_service/
 
-RUN cd /src \
-    && git rev-parse HEAD >/.packit-service.git.commit.hash \
+RUN git rev-parse HEAD >/.packit-service.git.commit.hash \
     && git show --quiet --format=%B HEAD >/.packit-service.git.commit.message \
-    && ansible-playbook -vv -c local -i localhost, recipe-worker.yaml
+    && ansible-playbook -vv -c local -i localhost, files/recipe-worker.yaml
 
-COPY . /src
-WORKDIR /src
+COPY . ./
 
 CMD ["/usr/bin/run_worker.sh"]

--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -5,7 +5,7 @@
     home_path: "{{ lookup('env', 'HOME') }}"
     packit_service_path: /src
   tasks:
-    - import_tasks: common.yaml
+    - import_tasks: tasks/common.yaml
     - name: Create /sandcastle
       # working dir for the upstream git which is mapped to the sandbox pod
       file:

--- a/files/recipe.yaml
+++ b/files/recipe.yaml
@@ -5,5 +5,5 @@
     home_path: "{{ lookup('env', 'HOME') }}"
     packit_service_path: /src
   tasks:
-    - import_tasks: common.yaml
-    - import_tasks: httpd.yaml
+    - import_tasks: tasks/common.yaml
+    - import_tasks: tasks/httpd.yaml


### PR DESCRIPTION
From https://docs.docker.com/engine/reference/builder/#workdir

"The WORKDIR instruction sets the working directory
for any RUN, CMD, ENTRYPOINT, COPY and ADD instructions
that follow it in the Dockerfile."

So having the WORKDIR instruction at the end of a Dockerfile
(as we had in Dockerfile.worker) makes no sense.

With having it at the beginning we can remove all the 'cd /src/'.

This commit also removes ENVs defined in base image.