### PR TITLE
Make the update retrigger instructions clear

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -19,8 +19,8 @@ TESTING_FARM_TRIGGER_URL = (
 )
 
 MSG_RETRIGGER = (
-    "You can re-trigger build by adding a comment (`/packit {build}`) "
-    "into this pull request."
+    "You can retrigger the {job} by adding a comment (`/packit {command}`) "
+    "into this {place}."
 )
 
 FILE_DOWNLOAD_FAILURE = "Failed to download file from URL"

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -76,7 +76,9 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         )
 
         self.msg_retrigger: str = MSG_RETRIGGER.format(
-            build="copr-build" if self.job_build else "build"
+            job="build",
+            command="copr-build" if self.job_build else "build",
+            place="pull request",
         )
 
     @property
@@ -359,7 +361,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 "to match the Packit configuration.\n"
                 "- Update the Packit configuration to match the Copr project settings.\n"
                 "\n"
-                "Please re-trigger the build, once the issue above is fixed.\n"
+                "Please retrigger the build, once the issue above is fixed.\n"
             )
             self.status_reporter.comment(body=msg)
             raise ex
@@ -393,7 +395,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                     "Please confirm the request on the "
                     f"[{owner}/{self.job_project} Copr project permissions page]"
                     f"({permissions_url})"
-                    " and re-trigger the build.",
+                    " and retrigger the build.",
                 )
             raise ex
 

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -67,7 +67,9 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
             db_trigger=db_trigger,
             job_config=job_config,
         )
-        self.msg_retrigger: str = MSG_RETRIGGER.format(build="production-build")
+        self.msg_retrigger: str = MSG_RETRIGGER.format(
+            job="build", command="production-build", place="pull request"
+        )
 
         # Lazy properties
         self._supported_koji_targets = None

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -44,6 +44,7 @@ from packit_service.constants import (
     PERMISSIONS_ERROR_WRITE_OR_ADMIN,
     FAQ_URL_HOW_TO_RETRIGGER,
     FILE_DOWNLOAD_FAILURE,
+    MSG_RETRIGGER,
     RETRY_LIMIT,
 )
 from packit_service.models import (
@@ -211,8 +212,7 @@ class ProposeDownstreamHandler(JobHandler):
                 f"| dist-git branch | error |\n"
                 f"| --------------- | ----- |\n"
                 f"{branch_errors}\n\n"
-                "You can re-trigger the update by adding `/packit propose-update`"
-                " to the issue comment.\n"
+                f"{MSG_RETRIGGER.format(job='update', command='propose-update', place='issue')}\n"
             )
 
             self.project.create_issue(

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -208,8 +208,8 @@ def test_dist_git_push_release_handle_all_failed(
             "| dist-git branch | error |\n"
             "| --------------- | ----- |\n"
             f"{table_content}\n\n"
-            "You can re-trigger the update by adding `/packit propose-update`"
-            " to the issue comment.\n",
+            "You can retrigger the update by adding a comment (`/packit propose-update`)"
+            " into this issue.\n",
         )
         .once()
         .mock()

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -893,7 +893,7 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
             "to match the Packit configuration.\n"
             "- Update the Packit configuration to match the Copr project settings.\n"
             "\n"
-            "Please re-trigger the build, once the issue above is fixed.\n",
+            "Please retrigger the build, once the issue above is fixed.\n",
         )
         .and_return()
         .mock()


### PR DESCRIPTION
To have it consistent with the one for build:
https://github.com/packit/packit-service/blob/45903cf592dd7be8bff474c8c81b25e1a9dde8f6/packit_service/constants.py#L21-L24
Fixes #829 