### PR TITLE
Fix `packit.api.sync_release` usage bug

### DIFF
--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -182,9 +182,7 @@ class ProposeDownstreamHandler(JobHandler):
             *self.job_config.metadata.dist_git_branches, default="master"
         ):
             try:
-                self.api.sync_release(
-                    dist_git_branch=branch, version=self.data.tag_name
-                )
+                self.api.sync_release(dist_git_branch=branch, tag=self.data.tag_name)
             except Exception as ex:
                 # the archive has not been uploaded to PyPI yet
                 if FILE_DOWNLOAD_FAILURE in str(ex):
@@ -671,7 +669,7 @@ class GitHubIssueCommentProposeUpdateHandler(CommentActionHandler):
             )
             try:
                 new_pr = api.sync_release(
-                    dist_git_branch=branch, version=self.data.tag_name, create_pr=True
+                    dist_git_branch=branch, tag=self.data.tag_name, create_pr=True
                 )
                 msg = f"Packit-as-a-Service proposed [a new update]({new_pr.url}) {msg}"
                 self.project.issue_comment(self.db_trigger.issue_id, msg)

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -50,7 +50,7 @@ def test_dist_git_push_release_handle(github_release_webhook):
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
     # it would make sense to make LocalProject offline
     flexmock(PackitAPI).should_receive("sync_release").with_args(
-        dist_git_branch="master", version="0.3.0"
+        dist_git_branch="master", tag="0.3.0"
     ).once()
 
     flexmock(AddReleaseDbTrigger).should_receive("db_trigger").and_return(
@@ -97,7 +97,7 @@ def test_dist_git_push_release_handle_multiple_branches(
     # it would make sense to make LocalProject offline
     for branch in fedora_branches:
         flexmock(PackitAPI).should_receive("sync_release").with_args(
-            dist_git_branch=branch, version="0.3.0"
+            dist_git_branch=branch, tag="0.3.0"
         ).once()
 
     flexmock(FedPKG).should_receive("clone").and_return(None)
@@ -153,7 +153,7 @@ def test_dist_git_push_release_handle_one_failed(
         sync_release = (
             flexmock(PackitAPI)
             .should_receive("sync_release")
-            .with_args(dist_git_branch=branch, version="0.3.0")
+            .with_args(dist_git_branch=branch, tag="0.3.0")
             .once()
         )
         if i == 1:
@@ -274,7 +274,7 @@ def test_retry_propose_downstream_task(github_release_webhook):
     flexmock(Signature).should_receive("apply_async").once()
 
     flexmock(PackitAPI).should_receive("sync_release").with_args(
-        dist_git_branch="master", version="0.3.0"
+        dist_git_branch="master", tag="0.3.0"
     ).and_raise(RebaseHelperError, "Failed to download file from URL example.com")
     flexmock(Task).should_receive("retry").once().and_raise(Retry)
 

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -85,7 +85,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
     flexmock(PackitAPI).should_receive("sync_release").with_args(
-        dist_git_branch="master", version="1.2.3"
+        dist_git_branch="master", tag="1.2.3"
     ).times(1 if success else 0)
     flexmock(AddReleaseDbTrigger).should_receive("db_trigger").and_return(
         flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=1)


### PR DESCRIPTION
`packit.api.sync_release` is called with correct `tag`parameter where
required.