### PR TITLE
Refactor reporting for GitLab

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -242,11 +242,10 @@ class BaseBuildJobHelper:
     def status_reporter(self) -> StatusReporter:
         if not self._status_reporter:
             self._status_reporter = StatusReporter(
-                project=self.base_project
-                if isinstance(self.project, GitlabProject) and self.is_reporting_allowed
-                else self.project,
+                project=self.project,
                 commit_sha=self.metadata.commit_sha,
                 pr_id=self.metadata.pr_id,
+                base_project=self.base_project,
             )
         return self._status_reporter
 

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -207,6 +207,9 @@ def test_copr_build_end(
     pr_comment_called,
 ):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     pc_build_pr.jobs[0].notifications.pull_request.successful_build = pc_comment_pr_succ
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
@@ -248,6 +251,9 @@ def test_copr_build_end(
 
 def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build_branch_push):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_push
     )
@@ -291,6 +297,9 @@ def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build_branch_pu
 
 def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build_release):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_release
     )
@@ -333,6 +342,9 @@ def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build_rel
 
 def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
 
     config = PackageConfig(
         jobs=[
@@ -464,6 +476,9 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
 
 def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
 
     config = PackageConfig(
         jobs=[
@@ -580,6 +595,9 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
 
 def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
 
     config = PackageConfig(
         jobs=[
@@ -698,6 +716,9 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
 
 def test_copr_build_start(copr_build_start, pc_build_pr, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
     )
@@ -736,6 +757,9 @@ def test_copr_build_start(copr_build_start, pc_build_pr, copr_build_pr):
 
 def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(pc_tests)
     flexmock(TestingFarmJobHelper).should_receive("get_build_check").and_return(
         EXPECTED_BUILD_CHECK_NAME
@@ -780,6 +804,9 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build_pr
 
 def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
     )

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -159,6 +159,9 @@ def test_copr_build_check_names(github_pr_event):
         url="https://test.url",
     ).and_return()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
@@ -255,6 +258,9 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
         url="https://test.url",
     ).and_return()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(GitProject).should_receive("pr_comment").with_args(
         pr_id=342,
@@ -369,6 +375,9 @@ def test_copr_build_check_names_multiple_jobs(github_pr_event):
         url="https://test.url",
     ).and_return().once()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
@@ -444,6 +453,9 @@ def test_copr_build_check_names_custom_owner(github_pr_event):
         url="https://test.url",
     ).and_return()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
@@ -510,7 +522,9 @@ def test_copr_build_success_set_test_check(github_pr_event):
         db_trigger=trigger,
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(4)
-    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
     )
@@ -564,6 +578,9 @@ def test_copr_build_for_branch(branch_push_event):
         jobs=[branch_build_job],
         event=branch_push_event,
         db_trigger=trigger,
+    )
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
     flexmock(SRPMBuildModel).should_receive("create").and_return(
@@ -620,6 +637,9 @@ def test_copr_build_for_branch_failed(branch_push_event):
         jobs=[branch_build_job],
         event=branch_push_event,
         db_trigger=trigger,
+    )
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
     flexmock(GitProject).should_receive("commit_comment").and_return(flexmock())
@@ -682,6 +702,9 @@ def test_copr_build_for_release(release_event):
         db_trigger=trigger,
     )
     flexmock(ReleaseEvent).should_receive("get_project").and_return(helper.project)
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
@@ -728,7 +751,9 @@ def test_copr_build_success(github_pr_event):
         ),
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
-    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
     )
@@ -800,7 +825,9 @@ def test_copr_build_fails_in_packit(github_pr_event):
             templ.format(ver=v),
             trim=True,
         ).and_return().once()
-    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=False, id=2)
     )
@@ -854,7 +881,6 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
             templ.format(ver=v),
             trim=True,
         ).and_return().once()
-    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True, id=2)
     )
@@ -863,8 +889,9 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
     )
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
+    flexmock(GitProject).should_receive("get_pr").with_args(342).and_return(flexmock())
     flexmock(GitProject).should_receive("get_pr").with_args(pr_id=342).and_return(
-        flexmock()
+        flexmock(source_project=flexmock())
         .should_receive("comment")
         .with_args(
             body="Based on your Packit configuration the settings of the "
@@ -897,7 +924,7 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
         )
         .and_return()
         .mock()
-    ).and_return()
+    )
 
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
     # copr build
@@ -951,7 +978,9 @@ def test_copr_build_no_targets(github_pr_event):
         {"fedora-32-x86_64", "fedora-31-x86_64"}
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(4)
-    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
     )
@@ -1017,6 +1046,9 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
         url="https://test.url",
     ).and_return()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
@@ -1087,7 +1119,9 @@ def test_copr_build_success_set_test_check_gitlab(gitlab_mr_event):
     flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(jobs=[test_job], event=gitlab_mr_event, db_trigger=trigger)
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(4)
-    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
     )
@@ -1142,6 +1176,9 @@ def test_copr_build_for_branch_gitlab(branch_push_event_gitlab):
         event=branch_push_event_gitlab,
         db_trigger=trigger,
     )
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
@@ -1193,7 +1230,9 @@ def test_copr_build_success_gitlab(gitlab_mr_event):
         ),
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
-    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
     )
@@ -1269,7 +1308,9 @@ def test_copr_build_fails_in_packit_gitlab(gitlab_mr_event):
             templ.format(ver=v),
             trim=True,
         ).and_return().once()
-    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=False, id=2)
     )
@@ -1309,7 +1350,10 @@ def test_copr_build_success_gitlab_comment(gitlab_mr_event):
         False
     )
     flexmock(GitProject).should_receive("get_pr").and_return(
-        flexmock(comment=flexmock().should_receive("comment").and_return().mock())
+        flexmock(
+            comment=flexmock().should_receive("comment").and_return().mock(),
+            source_project=flexmock(),
+        )
     )
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
@@ -1376,7 +1420,9 @@ def test_copr_build_no_targets_gitlab(gitlab_mr_event):
         {"fedora-32-x86_64", "fedora-31-x86_64"}
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(4)
-    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(success=True)
     )

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -136,6 +136,9 @@ def test_koji_build_check_names(github_pr_event):
         url=koji_build_url,
     ).and_return()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(id=1, success=True)
@@ -186,6 +189,9 @@ def test_koji_build_failed_kerberos(github_pr_event):
         url=get_srpm_log_url_from_flask(1),
     ).and_return()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(id=1, success=True)
@@ -237,6 +243,9 @@ def test_koji_build_target_not_supported(github_pr_event):
         url=get_srpm_log_url_from_flask(1),
     ).and_return()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(id=1, success=True)
@@ -273,6 +282,9 @@ def test_koji_build_with_multiple_targets(github_pr_event):
     # 2x SRPM + 2x RPM
     flexmock(StatusReporter).should_receive("set_status").and_return().times(4)
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(id=1, success=True)
@@ -329,6 +341,9 @@ def test_koji_build_failed(github_pr_event):
         url=srpm_build_url,
     ).and_return()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(SRPMBuildModel).should_receive("create").and_return(
         SRPMBuildModel(id=2, success=True)
@@ -372,6 +387,9 @@ def test_koji_build_failed_srpm(github_pr_event):
         url=srpm_build_url,
     ).and_return()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(PackitAPI).should_receive("create_srpm").and_raise(Exception, "some error")
     flexmock(SRPMBuildModel).should_receive("create").and_return(
@@ -402,6 +420,9 @@ def test_koji_build_non_scratch(github_pr_event):
         url=KOJI_PRODUCTION_BUILDS_ISSUE,
     ).and_return()
 
+    flexmock(GitProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(KojiBuildModel).should_receive("get_or_create").never()
 

--- a/tests/unit/test_whitelist.py
+++ b/tests/unit/test_whitelist.py
@@ -316,6 +316,7 @@ def test_check_and_report(
         pr_comment=lambda *args, **kwargs: None,
         set_commit_status=lambda *args, **kwargs: None,
         issue_comment=lambda *args, **kwargs: None,
+        get_pr=lambda *args, **kwargs: flexmock(source_project=flexmock()),
     )
     job_configs = [
         JobConfig(

--- a/tests_requre/database/test_tasks.py
+++ b/tests_requre/database/test_tasks.py
@@ -164,7 +164,9 @@ def test_check_copr_build(clean_before_and_after, packit_build_752):
     ).and_return(chroot_response)
 
     # Reporting
-    flexmock(GithubProject).should_receive("get_pr").and_return(flexmock())
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(source_project=flexmock())
+    )
     flexmock(GithubProject).should_receive("get_pr_comments").and_return([])
     flexmock(GithubProject).should_receive("pr_comment").and_return()
     flexmock(GithubProject).should_receive("set_commit_status").and_return().once()


### PR DESCRIPTION
Fixes #899 

**TODO**:
- [x] Fix tests

- Pass base project (where the branch resides) too
- Add property that returns project where the commit is present, i.e.
  project from which we can set the status
- Change getting and setting statuses to use `project_with_commit`
- Add logging to caught GitLab exception when setting status

Signed-off-by: Matej Focko <mfocko@redhat.com>