### PR TITLE
Improve project resolving for StatusReporter

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -245,7 +245,6 @@ class BaseBuildJobHelper:
                 project=self.project,
                 commit_sha=self.metadata.commit_sha,
                 pr_id=self.metadata.pr_id,
-                base_project=self.base_project,
             )
         return self._status_reporter
 

--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -178,6 +178,8 @@ class StatusReporter:
                 self.__add_commit_comment_with_status(
                     state, description, check_name, url
                 )
+            if e.response_code not in {400, 403, 404}:
+                raise
         except github.GithubException:
             self.__add_commit_comment_with_status(state, description, check_name, url)
 


### PR DESCRIPTION
Fixes #902

Also fix the error status code from GitLab for which we want to fallback
to commit comment.

Move the logic behind resolving of project, which contains commit where
we want to set commit status, from helpers to the StatusReporter itself

Current behaviour:
1. GitHub
   can set commit status from the project where the PR resides
2. GitLab
   - MR: if present MR ID, grabs the MR and related source_project
   - branch push: resolves _project_with_commit to the project itself
3. Pagure
   similar to GitHub

Signed-off-by: Matej Focko <mfocko@redhat.com>