### PR TITLE
don't install python3-kubernetes from Fedora

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -12,7 +12,10 @@
           - nss_wrapper # openshift anyuid passwd madness
           - redis # redis-cli for debugging
           - origin-clients # for sandcastle
-          - python3-kubernetes # for sandcastle
+          # we can't install kube from Fedora because kubernetes client API
+          # changes b/w major versions and we want to pin to the specific
+          # version to be sure it works well - it's 12.0.1 for now
+          # - python3-kubernetes  # for sandcastle
           - python3-fedora # to access FAS
           - python3-requests
           - python3-alembic


### PR DESCRIPTION
we can't install kube from Fedora because API changes b/w major versions