### PR TITLE
[install-deps-worker] install sandcastle@source_branch instead of master

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -43,7 +43,7 @@
     - name: Install pip deps
       pip:
         name:
-          - git+https://github.com/packit/sandcastle.git
+          - git+https://github.com/packit/sandcastle.git@{{ source_branch }}
           - sentry-sdk
         executable: pip3
     # --no-deps: to fail instead of installing from PyPI when we forget to add some dependency to packit.spec
@@ -55,5 +55,5 @@
           - git+https://github.com/packit/ogr.git
         executable: pip3
         extra_args: --no-deps
-    - name: Chek if all pip packages have all dependencies installed
+    - name: Check if all pip packages have all dependencies installed
       command: pip check

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -56,5 +56,5 @@
           - git+https://github.com/packit/ogr.git
         executable: pip3
         extra_args: --no-deps
-    - name: Chek if all pip packages have all dependencies installed
+    - name: Check if all pip packages have all dependencies installed
       command: pip check


### PR DESCRIPTION
This installs sandcastle@stable instead of sandcastle@master in `worker:prod`.

Hunor says he thinks it's been intentional but doesn't remember more details. @sakalosj do you remember?