### PR TITLE
Remove usages of removed JobConfig values

### DIFF
--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -24,7 +24,7 @@ import logging
 from typing import List, Optional
 
 from ogr.abstract import CommitStatus, PullRequest
-from packit.config import JobConfig, JobType, PackageConfig
+from packit.config import JobConfig, PackageConfig
 from packit_service.models import BugzillaModel
 from packit_service.service.events import (
     EventData,
@@ -34,7 +34,6 @@ from packit_service.service.events import (
 from packit_service.worker.handlers.abstract import (
     JobHandler,
     TaskName,
-    configured_as,
     reacts_to,
 )
 from packit_service.worker.psbugzilla import Bugzilla
@@ -44,7 +43,6 @@ from packit_service.worker.result import TaskResults
 logger = logging.getLogger(__name__)
 
 
-@configured_as(job_type=JobType.create_bugzilla)
 @reacts_to(event=PullRequestLabelPagureEvent)
 class PagurePullRequestLabelHandler(JobHandler):
     task_name = TaskName.pagure_pr_label

--- a/tests_requre/openshift_integration/test_copr.py
+++ b/tests_requre/openshift_integration/test_copr.py
@@ -50,9 +50,7 @@ class Copr(PackitServiceTestCase):
     @unittest.skipIf(True, "troubles with whitelisting")
     def test_submit_copr_build_pr_event(self):
         result = self.steve.process_message(pr_event())
-        self.assertTrue(result)
-        self.assertIn("copr_build", result["jobs"])
-        self.assertTrue(result["jobs"]["copr_build"]["success"])
+        self.assertTrue(result[0]["success"])
 
     @unittest.skipIf(True, "We can't obtain installation ID, I give up.")
     def test_submit_copr_build_pr_comment(self):
@@ -65,9 +63,7 @@ class Copr(PackitServiceTestCase):
         #     )
         # )
         result = self.steve.process_message(pr_comment_event())
-        self.assertTrue(result)
-        self.assertIn("pull_request_action", result["jobs"])
-        self.assertTrue(result["jobs"]["pull_request_action"]["success"])
+        self.assertTrue(result[0]["success"])
 
     @unittest.skipIf(True, "We can't obtain installation ID, I give up.")
     def test_not_collaborator(self):
@@ -80,5 +76,4 @@ class Copr(PackitServiceTestCase):
         #     )
         # )
         result = self.steve.process_message(pr_comment_event_not_collaborator())
-        action = result["jobs"]["pull_request_action"]
-        self.assertEqual(action["details"]["msg"], "Account is not whitelisted!")
+        self.assertEqual(result[0]["details"]["msg"], "Account is not whitelisted!")


### PR DESCRIPTION
Related to packit/packit#1066

- remove usage of JobType.create_bugzilla
- change outdated tests using  `pull_request_action` from JobType (also the results dict has different structure now). Should we remove these 3 tests completely? They are skipped for 10 months now.