### PR TITLE
Fix ignoring of push that deletes branch

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -41,9 +41,6 @@ from packit_service.service.events import (
     PullRequestCommentGithubEvent,
     PullRequestCommentPagureEvent,
     PullRequestLabelPagureEvent,
-    PushGitHubEvent,
-    PushGitlabEvent,
-    PushPagureEvent,
 )
 from packit_service.worker.handlers import (
     CoprBuildEndHandler,
@@ -232,18 +229,6 @@ class SteveJobs:
         """
         Create a Celery task for a job handler (if trigger matches) for every job defined in config.
         """
-
-        if isinstance(
-            event, (PushGitHubEvent, PushGitlabEvent, PushPagureEvent)
-        ) and event.commit_sha.startswith("0000000"):
-            return [
-                TaskResults.create_from(
-                    success=True,
-                    msg="Triggered by deleting a branch",
-                    job_config=None,
-                    event=event,
-                )
-            ]
 
         if not event.package_config:
             # this happens when service receives events for repos which don't have packit config

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -321,6 +321,11 @@ class Parser:
 
         if not (raw_ref and commits and before and pusher):
             return None
+        elif event.get("after").startswith("0000000"):
+            logger.info(
+                f"GitLab push event on '{raw_ref}' by {pusher} to delete branch"
+            )
+            return None
 
         number_of_commits = event.get("total_commits_count")
 
@@ -382,6 +387,11 @@ class Parser:
         )
 
         if not (raw_ref and head_commit and before and pusher):
+            return None
+        elif event.get("deleted"):
+            logger.info(
+                f"GitHub push event on '{raw_ref}' by {pusher} to delete branch"
+            )
             return None
 
         number_of_commits = event.get("size")

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -102,83 +102,30 @@ class Parser:
             logger.warning("No event to process!")
             return None
 
-        response: Optional[
-            Union[
-                PullRequestGithubEvent,
-                InstallationEvent,
-                ReleaseEvent,
-                DistGitEvent,
-                TestingFarmResultsEvent,
-                PullRequestCommentGithubEvent,
-                IssueCommentEvent,
-                KojiBuildEvent,
-                AbstractCoprBuildEvent,
-                PushGitHubEvent,
-                MergeRequestGitlabEvent,
-                MergeRequestCommentGitlabEvent,
-                IssueCommentGitlabEvent,
-                PushGitlabEvent,
-            ]
-        ] = Parser.parse_pr_event(event)
-        if response:
-            return response
+        for response in map(
+            lambda parser: parser(event),
+            (
+                Parser.parse_pr_event,
+                Parser.parse_pull_request_comment_event,
+                Parser.parse_issue_comment_event,
+                Parser.parse_release_event,
+                Parser.parse_push_event,
+                Parser.parse_installation_event,
+                Parser.parse_distgit_event,
+                Parser.parse_testing_farm_results_event,
+                Parser.parse_copr_event,
+                Parser.parse_mr_event,
+                Parser.parse_koji_event,
+                Parser.parse_merge_request_comment_event,
+                Parser.parse_gitlab_issue_comment_event,
+                Parser.parse_gitlab_push_event,
+            ),
+        ):
+            if response:
+                return response
 
-        response = Parser.parse_pull_request_comment_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_issue_comment_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_release_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_push_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_installation_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_distgit_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_testing_farm_results_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_copr_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_mr_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_koji_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_merge_request_comment_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_gitlab_issue_comment_event(event)
-        if response:
-            return response
-
-        response = Parser.parse_gitlab_push_event(event)
-        if response:
-            return response
-
-        if not response:
-            logger.debug("We don't process this event.")
-
-        return response
+        logger.debug("We don't process this event.")
+        return None
 
     @staticmethod
     def parse_mr_event(event) -> Optional[MergeRequestGitlabEvent]:

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -517,18 +517,20 @@ class TestEvents:
         ).once()
         assert event_object.package_config
 
-    def test_parse_github_push(self, github_push):
-        event_object = Parser.parse_event(github_push)
+    def test_parse_github_push(self, github_push_branch):
+        event_object = Parser.parse_event(github_push_branch)
 
         assert isinstance(event_object, PushGitHubEvent)
-        assert event_object.repo_namespace == "some-user"
-        assert event_object.repo_name == "some-repo"
-        assert event_object.commit_sha == "0000000000000000000000000000000000000000"
-        assert event_object.project_url == "https://github.com/some-user/some-repo"
-        assert event_object.git_ref == "simple-tag"
+        assert event_object.repo_namespace == "packit-service"
+        assert event_object.repo_name == "hello-world"
+        assert event_object.commit_sha == "04885ff850b0fa0e206cd09db73565703d48f99b"
+        assert (
+            event_object.project_url == "https://github.com/packit-service/hello-world"
+        )
+        assert event_object.git_ref == "build-branch"
 
         assert isinstance(event_object.project, GithubProject)
-        assert event_object.project.full_repo_name == "some-user/some-repo"
+        assert event_object.project.full_repo_name == "packit-service/hello-world"
         assert not event_object.base_project
 
         flexmock(PackageConfigGetter).should_receive(
@@ -537,7 +539,7 @@ class TestEvents:
             base_project=event_object.base_project,
             project=event_object.project,
             pr_id=None,
-            reference="0000000000000000000000000000000000000000",
+            reference="04885ff850b0fa0e206cd09db73565703d48f99b",
             fail_when_missing=False,
             spec_file_path=None,
         ).and_return(

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -37,7 +37,6 @@ from packit.local_project import LocalProject
 from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
 from packit_service.service.db_triggers import AddReleaseDbTrigger
-from packit_service.service.events import PushGitHubEvent
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
 from packit_service.worker.tasks import run_propose_downstream_handler
@@ -123,11 +122,7 @@ def test_ignore_delete_branch(github_push):
         GithubProject,
         is_private=lambda: False,
     )
-    # Only because of the JobResults.
-    flexmock(PushGitHubEvent).should_receive("package_config").and_return(None)
 
     processing_results = SteveJobs().process_message(github_push)
 
-    assert len(processing_results) == 1
-    assert processing_results[0]["success"]
-    assert "deleting a branch" in processing_results[0]["details"]["msg"]
+    assert processing_results == []


### PR DESCRIPTION
Instead of parsing delete by push, explicitly log it's delete by push and do not parse the event

Signed-off-by: Matej Focko <mfocko@redhat.com>