### PR TITLE
Autoretry the Celery handler tasks on any error

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -36,9 +36,9 @@ COPR_API_FAIL_STATE = 2
 PG_COPR_BUILD_STATUS_FAILURE = "failure"
 PG_COPR_BUILD_STATUS_SUCCESS = "success"
 
-RETRY_LIMIT = 2
+DEFAULT_RETRY_LIMIT = 2
 # retry in 3s, 6s
-RETRY_BACKOFF = 3
+DEFAULT_RETRY_BACKOFF = 3
 
 WHITELIST_CONSTANTS = {
     "approved_automatically": "approved_automatically",

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -39,8 +39,6 @@ PG_COPR_BUILD_STATUS_SUCCESS = "success"
 RETRY_LIMIT = 2
 # retry in 3s, 6s
 RETRY_BACKOFF = 3
-# retry on any error
-EXCEPTIONS = (Exception,)
 
 WHITELIST_CONSTANTS = {
     "approved_automatically": "approved_automatically",

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -36,7 +36,11 @@ COPR_API_FAIL_STATE = 2
 PG_COPR_BUILD_STATUS_FAILURE = "failure"
 PG_COPR_BUILD_STATUS_SUCCESS = "success"
 
-RETRY_LIMIT = 5
+RETRY_LIMIT = 2
+# retry in 3s, 6s
+RETRY_BACKOFF = 3
+# retry on any error
+EXCEPTIONS = (Exception,)
 
 WHITELIST_CONSTANTS = {
     "approved_automatically": "approved_automatically",

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -25,6 +25,7 @@ This file defines classes for job handlers specific for Github hooks
 TODO: The build and test handlers are independent and should be moved away.
 """
 import logging
+from os import getenv
 from typing import Optional
 
 from celery.app.task import Task
@@ -40,11 +41,11 @@ from packit.config.package_config import PackageConfig
 from packit.local_project import LocalProject
 from packit_service import sentry_integration
 from packit_service.constants import (
+    DEFAULT_RETRY_LIMIT,
     FAQ_URL_HOW_TO_RETRIGGER,
     FILE_DOWNLOAD_FAILURE,
     MSG_RETRIGGER,
     PERMISSIONS_ERROR_WRITE_OR_ADMIN,
-    RETRY_LIMIT,
 )
 from packit_service.models import (
     AbstractTriggerDbType,
@@ -191,7 +192,7 @@ class ProposeDownstreamHandler(JobHandler):
                     # when the task hits max_retries, it raises MaxRetriesExceededError
                     # and the error handling code would be never executed
                     retries = self.task.request.retries
-                    if retries < RETRY_LIMIT:
+                    if retries < getenv("RETRY_LIMIT", DEFAULT_RETRY_LIMIT):
                         logger.info(f"Retrying for the {retries + 1}. time...")
                         # throw=False so that exception is not raised and task
                         # is not retried also automatically

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -193,7 +193,17 @@ class ProposeDownstreamHandler(JobHandler):
                     retries = self.task.request.retries
                     if retries < RETRY_LIMIT:
                         logger.info(f"Retrying for the {retries + 1}. time...")
-                        self.task.retry(exc=ex, countdown=15 * 2 ** retries)
+                        # throw=False so that exception is not raised and task
+                        # is not retried also automatically
+                        self.task.retry(
+                            exc=ex, countdown=15 * 2 ** retries, throw=False
+                        )
+                        return TaskResults(
+                            success=False,
+                            details={
+                                "msg": "Task was retried, we were not able to download the archive."
+                            },
+                        )
                 sentry_integration.send_to_sentry(ex)
                 errors[branch] = str(ex)
 

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -23,8 +23,9 @@ import logging
 from typing import List, Optional
 
 from packit_service.celerizer import celery_app
-from packit_service.constants import RETRY_LIMIT
+
 from packit_service.models import TestingFarmResult
+from packit_service.constants import RETRY_LIMIT, RETRY_BACKOFF, EXCEPTIONS
 from packit_service.service.events import (
     AbstractCoprBuildEvent,
     EventData,
@@ -102,7 +103,12 @@ def babysit_copr_build(self, build_id: int):
 
 
 # tasks for running the handlers
-@celery_app.task(name=TaskName.copr_build_start)
+@celery_app.task(
+    name=TaskName.copr_build_start,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_copr_build_start_handler(event: dict, package_config: dict, job_config: dict):
     handler = CoprBuildStartHandler(
         package_config=load_package_config(package_config),
@@ -113,7 +119,12 @@ def run_copr_build_start_handler(event: dict, package_config: dict, job_config: 
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.copr_build_end)
+@celery_app.task(
+    name=TaskName.copr_build_end,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_copr_build_end_handler(event: dict, package_config: dict, job_config: dict):
     handler = CoprBuildEndHandler(
         package_config=load_package_config(package_config),
@@ -124,7 +135,12 @@ def run_copr_build_end_handler(event: dict, package_config: dict, job_config: di
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.copr_build)
+@celery_app.task(
+    name=TaskName.copr_build,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_copr_build_handler(event: dict, package_config: dict, job_config: dict):
     handler = CoprBuildHandler(
         package_config=load_package_config(package_config),
@@ -134,7 +150,12 @@ def run_copr_build_handler(event: dict, package_config: dict, job_config: dict):
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.installation)
+@celery_app.task(
+    name=TaskName.installation,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_installation_handler(event: dict, package_config: dict, job_config: dict):
     handler = GithubAppInstallationHandler(
         package_config=None,
@@ -145,7 +166,12 @@ def run_installation_handler(event: dict, package_config: dict, job_config: dict
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.testing_farm)
+@celery_app.task(
+    name=TaskName.testing_farm,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_testing_farm_handler(
     event: dict,
     package_config: dict,
@@ -163,7 +189,12 @@ def run_testing_farm_handler(
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.testing_farm_results)
+@celery_app.task(
+    name=TaskName.testing_farm_results,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_testing_farm_results_handler(
     event: dict, package_config: dict, job_config: dict
 ):
@@ -181,7 +212,13 @@ def run_testing_farm_results_handler(
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(bind=True, name=TaskName.propose_downstream, max_retries=RETRY_LIMIT)
+@celery_app.task(
+    bind=True,
+    name=TaskName.propose_downstream,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_propose_downstream_handler(
     self, event: dict, package_config: dict, job_config: dict
 ):
@@ -194,7 +231,12 @@ def run_propose_downstream_handler(
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.koji_build)
+@celery_app.task(
+    name=TaskName.koji_build,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_koji_build_handler(event: dict, package_config: dict, job_config: dict):
     handler = KojiBuildHandler(
         package_config=load_package_config(package_config),
@@ -204,7 +246,12 @@ def run_koji_build_handler(event: dict, package_config: dict, job_config: dict):
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.distgit_commit)
+@celery_app.task(
+    name=TaskName.distgit_commit,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_distgit_commit_handler(event: dict, package_config: dict, job_config: dict):
     handler = NewDistGitCommitHandler(
         package_config=load_package_config(package_config),
@@ -214,7 +261,12 @@ def run_distgit_commit_handler(event: dict, package_config: dict, job_config: di
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.pagure_pr_label)
+@celery_app.task(
+    name=TaskName.pagure_pr_label,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_pagure_pr_label_handler(event: dict, package_config: dict, job_config: dict):
     handler = PagurePullRequestLabelHandler(
         package_config=load_package_config(package_config),
@@ -229,7 +281,12 @@ def run_pagure_pr_label_handler(event: dict, package_config: dict, job_config: d
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.koji_build_report)
+@celery_app.task(
+    name=TaskName.koji_build_report,
+    autoretry_for=EXCEPTIONS,
+    retry_backoff=RETRY_BACKOFF,
+    retry_kwargs={"max_retries": RETRY_LIMIT},
+)
 def run_koji_build_report_handler(event: dict, package_config: dict, job_config: dict):
     handler = KojiBuildReportHandler(
         package_config=load_package_config(package_config),

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -20,14 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import logging
+from os import getenv
 from typing import List, Optional
 
 from celery import Task
 from packit_service.celerizer import celery_app
-
-
 from packit_service.models import TestingFarmResult
-from packit_service.constants import RETRY_LIMIT, RETRY_BACKOFF
+from packit_service.constants import DEFAULT_RETRY_LIMIT, DEFAULT_RETRY_BACKOFF
 from packit_service.service.events import (
     AbstractCoprBuildEvent,
     EventData,
@@ -78,8 +77,8 @@ logging.getLogger("sandcastle").setLevel(logging.DEBUG)
 
 class HandlerTaskWithRetry(Task):
     autoretry_for = (Exception,)
-    retry_kwargs = {"max_retries": RETRY_LIMIT}
-    retry_backoff = RETRY_BACKOFF
+    retry_kwargs = {"max_retries": getenv("RETRY_LIMIT", DEFAULT_RETRY_LIMIT)}
+    retry_backoff = getenv("RETRY_BACKOFF", DEFAULT_RETRY_BACKOFF)
 
 
 @celery_app.task(name="task.steve_jobs.process_message", bind=True)

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -1,0 +1,17 @@
+import pytest
+from celery.app.task import Task
+from copr.v3 import CoprRequestException
+from flexmock import flexmock
+from packit_service.worker.tasks import run_copr_build_handler
+from packit_service.worker.handlers.github_handlers import CoprBuildHandler
+
+
+def test_autoretry():
+    flexmock(CoprBuildHandler).should_receive("run_job").and_raise(
+        CoprRequestException
+    ).once()
+
+    # verify that retry is called automatically
+    flexmock(Task).should_receive("retry").and_raise(CoprRequestException).once()
+    with pytest.raises(CoprRequestException):
+        run_copr_build_handler({}, {}, {})


### PR DESCRIPTION
Fixes #873 
Retry the handler task on any error, maximally 2 times, with exponential backoff (3s, 6s) (these parameters can be configured via env vars), and by default, the jitter is set to True.

