### PR TITLE
Move setting of SRPM URL to avoid temporary one

### DIFF
--- a/packit_service/worker/build/babysit.py
+++ b/packit_service/worker/build/babysit.py
@@ -85,6 +85,8 @@ def check_copr_build(build_id: int) -> bool:
             ),  # this seems to be the SRPM name
             timestamp=chroot_build.ended_on,
         )
+        if build.srpm_build.url is None:
+            build.srpm_build.set_url(build_copr.source_package.get("url"))
 
         job_configs = get_config_for_handler_kls(
             handler_kls=CoprBuildEndHandler,

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -371,7 +371,6 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             build = self.api.copr_helper.copr_client.build_proxy.create_from_file(
                 ownername=owner, projectname=self.job_project, path=self.srpm_path
             )
-            self.srpm_model.set_url(build.source_package.get("url"))
         except CoprRequestException as ex:
             if "You don't have permissions to build in this copr." in str(
                 ex

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -95,6 +95,10 @@ def test_check_copr_build_updated():
                     )
                 )
                 .mock(),
+                srpm_build=flexmock(url=None)
+                .should_receive("set_url")
+                .with_args("https://some.host/my.srpm")
+                .mock(),
             )
         ]
     )
@@ -107,7 +111,10 @@ def test_check_copr_build_updated():
                 flexmock(
                     ended_on=True,
                     state="completed",
-                    source_package={"name": "source_package_name"},
+                    source_package={
+                        "name": "source_package_name",
+                        "url": "https://some.host/my.srpm",
+                    },
                 )
             )
             .mock(),

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -198,7 +198,6 @@ def test_copr_build_check_names(github_pr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="packit",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -311,7 +310,6 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="packit",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -430,7 +428,6 @@ def test_copr_build_check_names_multiple_jobs(github_pr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="packit",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -516,7 +513,6 @@ def test_copr_build_check_names_custom_owner(github_pr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="nobody",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -582,7 +578,6 @@ def test_copr_build_success_set_test_check(github_pr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="the-owner",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -649,7 +644,6 @@ def test_copr_build_for_branch(branch_push_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="the-owner",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -779,7 +773,6 @@ def test_copr_build_for_release(release_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="the-owner",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -836,7 +829,6 @@ def test_copr_build_success(github_pr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="the-owner",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -1071,7 +1063,6 @@ def test_copr_build_no_targets(github_pr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="the-owner",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -1163,7 +1154,6 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="nobody",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -1227,7 +1217,6 @@ def test_copr_build_success_set_test_check_gitlab(gitlab_mr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="the-owner",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -1294,7 +1283,6 @@ def test_copr_build_for_branch_gitlab(branch_push_event_gitlab):
                     id=2,
                     projectname="the-project-name",
                     ownername="the-owner",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -1357,7 +1345,6 @@ def test_copr_build_success_gitlab(gitlab_mr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="the-owner",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -1487,7 +1474,6 @@ def test_copr_build_success_gitlab_comment(gitlab_mr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="the-owner",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),
@@ -1560,7 +1546,6 @@ def test_copr_build_no_targets_gitlab(gitlab_mr_event):
                     id=2,
                     projectname="the-project-name",
                     ownername="the-owner",
-                    source_package={"url": "https://some.host/my.srpm"},
                 )
             )
             .mock(),


### PR DESCRIPTION
Since COPR sets just a temporary URL for SRPM when triggering the build,
move setting of the URL to `check_copr_build` where it will be set after
the build is finished.

Fixes #934

Signed-off-by: Matej Focko <mfocko@redhat.com>