### PR TITLE
TF hack: Temporarily load fmf from base/main

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -66,12 +66,21 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
         """
         compose, arch = self.get_compose_arch(chroot)
+        # FIXME FIXME FIXME !!!
+        # This tells TF to load fmf metadata from main/master of the base project.
+        # What we need is to load it from self.metadata.commit_sha of the FORKED project.
+        # This is ugly hack, but I need to make this work at least like this ASAP
+        # and find proper way later. Sorry.
+        url = self.metadata.project_url
+        ref = self.project.default_branch
+        # url = ? url of the fork from which the PR has been created ?
+        # ref = self.metadata.commit_sha
         return {
             "api_key": self.service_config.testing_farm_secret,
             "test": {
                 "fmf": {
-                    "url": self.metadata.project_url,
-                    "ref": self.metadata.commit_sha,
+                    "url": url,
+                    "ref": ref,
                 },
             },
             "environments": [

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -391,12 +391,13 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
     ).once()
 
+    flexmock(GithubProject).should_receive("default_branch").and_return("main")
     payload = {
         "api_key": "secret token",
         "test": {
             "fmf": {
                 "url": "https://github.com/foo/bar",
-                "ref": "0011223344",
+                "ref": "main",
             },
         },
         "environments": [
@@ -519,6 +520,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         "was_last_packit_comment_with_congratulation"
     ).and_return(False)
     flexmock(GithubProject).should_receive("pr_comment")
+    flexmock(GithubProject).should_receive("default_branch").and_return("main")
 
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
@@ -599,6 +601,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
+    flexmock(GithubProject).should_receive("default_branch").and_return("main")
 
     config = PackageConfig(
         jobs=[

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -291,6 +291,7 @@ def test_payload(
         namespace=namespace,
         service="GitHub",
         get_git_urls=lambda: {"git": f"{project_url}.git"},
+        default_branch=commit_sha,
     )
     metadata = flexmock(
         trigger=flexmock(),


### PR DESCRIPTION
Prior to this commit, we were loading the FMF from `self.metadata.commit_sha` of the base project,
which did not work, because that commit is not yet merged into the base project.

More in the code. If you know how to make this a proper way, please let me know, otherwise please ack so that submitting TF works at least like this and I'll keep looking for a proper solution.