### PR TITLE
Testing Farm: load FMF from commit_sha of source/fork of PR

### DIFF
--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -84,12 +84,16 @@ class TestingFarmResultsHandler(JobHandler):
 
         if self.result == TestingFarmResult.running:
             status = CommitStatus.running
+            summary = self.summary or "Tests are running ..."
         elif self.result == TestingFarmResult.passed:
             status = CommitStatus.success
+            summary = self.summary or "Tests passed ..."
         elif self.result == TestingFarmResult.error:
             status = CommitStatus.error
+            summary = self.summary or "Error ..."
         else:
             status = CommitStatus.failure
+            summary = self.summary or "Tests failed ..."
 
         if test_run_model:
             test_run_model.set_web_url(self.log_url)
@@ -98,7 +102,7 @@ class TestingFarmResultsHandler(JobHandler):
         )
         status_reporter.report(
             state=status,
-            description=self.summary,
+            description=summary,
             url=self.log_url,
             check_names=TestingFarmJobHelper.get_test_check(self.copr_chroot),
         )

--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -159,7 +159,9 @@ class StatusReporter:
         if not url and isinstance(self.project, PagureProject):
             url = "https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream"
 
-        logger.debug(f"Setting status for check '{check_name}': {description}")
+        logger.debug(
+            f"Setting status '{state.name}' for check '{check_name}': {description}"
+        )
 
         try:
             self.project_with_commit.set_commit_status(

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -66,21 +66,12 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
         """
         compose, arch = self.get_compose_arch(chroot)
-        # FIXME FIXME FIXME !!!
-        # This tells TF to load fmf metadata from main/master of the base project.
-        # What we need is to load it from self.metadata.commit_sha of the FORKED project.
-        # This is ugly hack, but I need to make this work at least like this ASAP
-        # and find proper way later. Sorry.
-        url = self.metadata.project_url
-        ref = self.project.default_branch
-        # url = ? url of the fork from which the PR has been created ?
-        # ref = self.metadata.commit_sha
         return {
             "api_key": self.service_config.testing_farm_secret,
             "test": {
                 "fmf": {
-                    "url": url,
-                    "ref": ref,
+                    "url": self.metadata.project_url,
+                    "ref": self.metadata.commit_sha,
                 },
             },
             "environments": [

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -66,11 +66,14 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
         """
         compose, arch = self.get_compose_arch(chroot)
+        pr = self.project.get_pr(self.metadata.pr_id)
+        # url of the source/fork from which the PR has been created
+        from_url = pr.source_project.get_web_url()
         return {
             "api_key": self.service_config.testing_farm_secret,
             "test": {
                 "fmf": {
-                    "url": self.metadata.project_url,
+                    "url": from_url,
                     "ref": self.metadata.commit_sha,
                 },
             },

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -391,13 +391,12 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
     ).once()
 
-    flexmock(GithubProject).should_receive("default_branch").and_return("main")
     payload = {
         "api_key": "secret token",
         "test": {
             "fmf": {
                 "url": "https://github.com/foo/bar",
-                "ref": "main",
+                "ref": "0011223344",
             },
         },
         "environments": [
@@ -520,7 +519,6 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         "was_last_packit_comment_with_congratulation"
     ).and_return(False)
     flexmock(GithubProject).should_receive("pr_comment")
-    flexmock(GithubProject).should_receive("default_branch").and_return("main")
 
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
@@ -601,7 +599,6 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(GithubProject).should_receive("default_branch").and_return("main")
 
     config = PackageConfig(
         jobs=[

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -334,7 +334,9 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     )
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(
-        flexmock(source_project=flexmock())
+        flexmock(
+            source_project=flexmock(get_web_url=lambda: "https://github.com/foo/bar")
+        )
     )
 
     config = PackageConfig(
@@ -487,7 +489,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
 def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(
-        flexmock(source_project=flexmock())
+        flexmock(source_project=flexmock(get_web_url=lambda: "abc"))
     )
 
     config = PackageConfig(
@@ -597,7 +599,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
 def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(
-        flexmock(source_project=flexmock())
+        flexmock(source_project=flexmock(get_web_url=lambda: "abc"))
     )
 
     config = PackageConfig(

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -291,7 +291,6 @@ def test_payload(
         namespace=namespace,
         service="GitHub",
         get_git_urls=lambda: {"git": f"{project_url}.git"},
-        default_branch=commit_sha,
     )
     metadata = flexmock(
         trigger=flexmock(),

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -286,17 +286,20 @@ def test_payload(
         command_handler_work_dir="/tmp",
     )
     package_config = flexmock(jobs=[])
+    pr = flexmock(source_project=flexmock(get_web_url=lambda: project_url))
     project = flexmock(
         repo=repo,
         namespace=namespace,
         service="GitHub",
         get_git_urls=lambda: {"git": f"{project_url}.git"},
+        get_pr=lambda id_: pr,
     )
     metadata = flexmock(
         trigger=flexmock(),
         commit_sha=commit_sha,
         git_ref=git_ref,
         project_url=project_url,
+        pr_id=123,
     )
     db_trigger = flexmock()
 


### PR DESCRIPTION
and give better status when `summary` is empty