### PR TITLE
Upgrade to Celery 5

### DIFF
--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -29,11 +29,11 @@ popd
 if [[ "${CELERY_COMMAND}" == "beat" ]]; then
     # when using the database backend, celery beat must be running for the results to be expired.
     # https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html#starting-the-scheduler
-    exec celery beat --app="${APP}" --loglevel=${LOGLEVEL} --pidfile=/tmp/celerybeat.pid --schedule=/tmp/celerybeat-schedule
+    exec celery --app="${APP}" beat --loglevel=${LOGLEVEL} --pidfile=/tmp/celerybeat.pid --schedule=/tmp/celerybeat-schedule
 
 elif [[ "${CELERY_COMMAND}" == "worker" ]]; then
     # concurrency: Number of concurrent worker processes/threads/green threads executing tasks.
     # prefetch-multiplier: How many messages to prefetch at a time multiplied by the number of concurrent processes.
     # http://docs.celeryproject.org/en/latest/userguide/optimizing.html#prefetch-limits
-    exec celery worker --app="${APP}" --loglevel=${LOGLEVEL} --concurrency=1 --prefetch-multiplier=1
+    exec celery --app="${APP}" worker --loglevel=${LOGLEVEL} --concurrency=1 --prefetch-multiplier=1
 fi


### PR DESCRIPTION
https://docs.celeryproject.org/en/stable/whatsnew-5.0.html#step-1-adjust-your-command-line-invocation

Related to packit/deployment#173
After we update our base image to fedora-33, we will use Celery 5.0.5.
