### PR TITLE
TestingFarmResults{Event,Handler} need project's parent

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -928,6 +928,14 @@ class TestingFarmResultsEvent(AbstractForgeIndependentEvent):
                 return None  # With Github app, we cannot work with fork repo
         return self.project
 
+    def get_project(self) -> Optional[GitProject]:
+        project = super().get_project()
+        # In TestingFarmJobHelper._payload() we asked TF to test commit_sha of fork
+        # (PR's source). Now we again need its parent, in order to continue.
+        if project.parent:
+            project = project.parent
+        return project
+
 
 class KojiBuildEvent(AbstractForgeIndependentEvent):
     def __init__(

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -748,7 +748,6 @@ class Parser:
         event: dict,
     ) -> Optional[TestingFarmResultsEvent]:
         """ this corresponds to testing farm results event """
-        logger.debug(f"parse_testing_farm_results_event: {event}")
         if event.get("source") != "testing-farm" or not event.get("request_id"):
             return None
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -654,6 +654,8 @@ class TestEvents:
             )
         )
         assert event_object.db_trigger
+        project = super(TestingFarmResultsEvent, event_object).get_project()
+        flexmock(GithubProject).should_receive("parent").and_return(project)
         assert isinstance(event_object.project, GithubProject)
         assert event_object.project.full_repo_name == "packit/packit"
 
@@ -686,6 +688,8 @@ class TestEvents:
             )
         )
         assert event_object.db_trigger
+        project = super(TestingFarmResultsEvent, event_object).get_project()
+        flexmock(GithubProject).should_receive("parent").and_return(project)
         assert isinstance(event_object.project, GithubProject)
         assert event_object.project.full_repo_name == "packit/packit"
 

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -170,6 +170,7 @@ def test_testing_farm_response(
         copr_chroot="fedora-rawhide-x86_64",
         summary=tests_message,
     )
+    flexmock(test_farm_handler).should_receive("project").and_return(flexmock())
     flexmock(StatusReporter).should_receive("report").with_args(
         state=status_status,
         description=status_message,


### PR DESCRIPTION
When we submitted tests to TF (#944), we asked to test commit_sha of a fork (PR's source) project.
Now the project_url in TF results contains url of that fork/source, so we need its parent (project) in order to continue.

Fixes https://sentry.io/organizations/red-hat-0p/issues/2020954642