### PR TITLE
TF: store original/base project url in TFTTestRunModel

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1121,6 +1121,7 @@ class TFTTestRunModel(Base):
         target: str,
         trigger_model: AbstractTriggerDbType,
         web_url: Optional[str] = None,
+        data: dict = None,
     ) -> "TFTTestRunModel":
         job_trigger = JobTriggerModel.get_or_create(
             type=trigger_model.job_trigger_model_type, trigger_id=trigger_model.id
@@ -1134,6 +1135,7 @@ class TFTTestRunModel(Base):
             test_run.target = target
             test_run.web_url = web_url
             test_run.job_trigger = job_trigger
+            test_run.data = data or {}
             session.add(test_run)
             return test_run
 

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -928,14 +928,6 @@ class TestingFarmResultsEvent(AbstractForgeIndependentEvent):
                 return None  # With Github app, we cannot work with fork repo
         return self.project
 
-    def get_project(self) -> Optional[GitProject]:
-        project = super().get_project()
-        # In TestingFarmJobHelper._payload() we asked TF to test commit_sha of fork
-        # (PR's source). Now we again need its parent, in order to continue.
-        if project.parent:
-            project = project.parent
-        return project
-
 
 class KojiBuildEvent(AbstractForgeIndependentEvent):
     def __init__(

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -7,7 +7,7 @@ This file defines classes for job handlers specific for Testing farm
 import logging
 from typing import List, Optional
 
-from ogr.abstract import CommitStatus, GitProject
+from ogr.abstract import CommitStatus
 from packit.config import JobConfig, JobType
 from packit.config.package_config import PackageConfig
 
@@ -65,16 +65,6 @@ class TestingFarmResultsHandler(JobHandler):
             if run_model:
                 self._db_trigger = run_model.job_trigger.get_trigger_object()
         return self._db_trigger
-
-    @property
-    def project(self) -> Optional[GitProject]:
-        if not self._project:
-            self._project = super().project
-            # In TestingFarmJobHelper._payload() we asked TF to test commit_sha of fork
-            # (PR's source). Now we need its parent, in order for StatusReporter to work.
-            if self._project.parent:
-                self._project = self._project.parent
-        return self._project
 
     def run(self) -> TaskResults:
         logger.debug(f"Testing farm {self.pipeline_id} result:\n{self.result}")

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -234,6 +234,9 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             target=chroot,
             web_url=None,
             trigger_model=self.db_trigger,
+            # In _payload() we ask TF to test commit_sha of fork (PR's source).
+            # Store original url. If this proves to work, make it a separate column.
+            data={"base_project_url": self.project.get_web_url()},
         )
 
         self.report_status_to_test_for_chroot(

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -444,6 +444,10 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         url="",
     ).once()
 
+    flexmock(GithubProject).should_receive("get_web_url").and_return(
+        "https://github.com/foo/bar"
+    )
+
     tft_test_run_model = flexmock()
     flexmock(TFTTestRunModel).should_receive("create").with_args(
         pipeline_id=pipeline_id,
@@ -452,6 +456,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         target="fedora-rawhide-x86_64",
         trigger_model=copr_build_pr.job_trigger.get_trigger_object(),
         web_url=None,
+        data={"base_project_url": "https://github.com/foo/bar"},
     ).and_return(tft_test_run_model)
 
     flexmock(StatusReporter).should_receive("report").with_args(

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -632,6 +632,16 @@ class TestEvents:
         flexmock(TestingFarmJobHelper).should_receive("get_request_details").with_args(
             request_id
         ).and_return(testing_farm_results)
+        flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
+            flexmock(
+                job_trigger=flexmock()
+                .should_receive("get_trigger_object")
+                .and_return(PullRequestModel(pr_id=10))
+                .once()
+                .mock(),
+                data={"base_project_url": "https://github.com/packit/packit"},
+            )
+        )
         event_object = Parser.parse_event(testing_farm_notification)
 
         assert isinstance(event_object, TestingFarmResultsEvent)
@@ -644,15 +654,6 @@ class TestEvents:
         assert event_object.copr_build_id == "1810530"
         assert event_object.copr_chroot == "fedora-32-x86_64"
         assert event_object.tests
-        flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
-            flexmock(
-                job_trigger=flexmock()
-                .should_receive("get_trigger_object")
-                .and_return(PullRequestModel(pr_id=10))
-                .once()
-                .mock()
-            )
-        )
         assert event_object.db_trigger
         assert isinstance(event_object.project, GithubProject)
         assert event_object.project.full_repo_name == "packit/packit"
@@ -664,6 +665,16 @@ class TestEvents:
         flexmock(TestingFarmJobHelper).should_receive("get_request_details").with_args(
             request_id
         ).and_return(testing_farm_results_error)
+        flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
+            flexmock(
+                job_trigger=flexmock()
+                .should_receive("get_trigger_object")
+                .and_return(PullRequestModel(pr_id=10))
+                .once()
+                .mock(),
+                data={"base_project_url": "https://github.com/packit/packit"},
+            )
+        )
         event_object = Parser.parse_event(testing_farm_notification)
 
         assert isinstance(event_object, TestingFarmResultsEvent)
@@ -676,15 +687,6 @@ class TestEvents:
         assert event_object.copr_build_id == "1810530"
         assert event_object.copr_chroot == "fedora-32-x86_64"
         assert event_object.tests
-        flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
-            flexmock(
-                job_trigger=flexmock()
-                .should_receive("get_trigger_object")
-                .and_return(PullRequestModel(pr_id=10))
-                .once()
-                .mock()
-            )
-        )
         assert event_object.db_trigger
         assert isinstance(event_object.project, GithubProject)
         assert event_object.project.full_repo_name == "packit/packit"
@@ -882,11 +884,15 @@ class TestEvents:
         flexmock(TestingFarmJobHelper).should_receive("get_request_details").with_args(
             request_id
         ).and_return(testing_farm_results)
+        flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").with_args(
+            request_id
+        ).and_return(flexmock(data={"base_project_url": "abc"}))
         event_object = Parser.parse_event(testing_farm_notification)
 
         assert isinstance(event_object, TestingFarmResultsEvent)
         assert isinstance(event_object.pipeline_id, str)
         assert event_object.pipeline_id == request_id
+        assert event_object.project_url == "abc"
 
     def test_distgit_commit(self, distgit_commit):
         event_object = Parser.parse_event(distgit_commit)
@@ -904,6 +910,9 @@ class TestEvents:
     ):
         flexmock(TestingFarmJobHelper).should_receive("get_request_details").and_return(
             testing_farm_results
+        )
+        flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
+            flexmock(data={"base_project_url": "abc"})
         )
         event_object = Parser.parse_event(testing_farm_notification)
         assert json.dumps(event_object.pipeline_id)

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -654,8 +654,6 @@ class TestEvents:
             )
         )
         assert event_object.db_trigger
-        project = super(TestingFarmResultsEvent, event_object).get_project()
-        flexmock(GithubProject).should_receive("parent").and_return(project)
         assert isinstance(event_object.project, GithubProject)
         assert event_object.project.full_repo_name == "packit/packit"
 
@@ -688,8 +686,6 @@ class TestEvents:
             )
         )
         assert event_object.db_trigger
-        project = super(TestingFarmResultsEvent, event_object).get_project()
-        flexmock(GithubProject).should_receive("parent").and_return(project)
         assert isinstance(event_object.project, GithubProject)
         assert event_object.project.full_repo_name == "packit/packit"
 

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -170,7 +170,6 @@ def test_testing_farm_response(
         copr_chroot="fedora-rawhide-x86_64",
         summary=tests_message,
     )
-    flexmock(test_farm_handler).should_receive("project").and_return(flexmock())
     flexmock(StatusReporter).should_receive("report").with_args(
         state=status_status,
         description=status_message,


### PR DESCRIPTION
#946 has not worked. Trying to get a parent of forked project results in https://sentry.io/organizations/red-hat-0p/issues/2191846769

```
OgrException
Couldn't retrieve token from Tokman: (400) {"error": "Failed to retrieve a token: App is not installed on <forked repo>"}
```

So we need to store the original/base project URL in a db when submitting tests to TF and get it from there when processing TF notification.