### PR TITLE
Run model

### DIFF
--- a/alembic/versions/2870354b84cf_add_runmodel.py
+++ b/alembic/versions/2870354b84cf_add_runmodel.py
@@ -1,0 +1,428 @@
+"""Add RunModel
+
+Revision ID: 2870354b84cf
+Revises: 70444197d206
+Create Date: 2021-02-09 11:07:59.697152
+
+"""
+import enum
+from datetime import datetime
+from typing import List, TYPE_CHECKING
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    Text,
+    orm,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+
+
+revision = "2870354b84cf"
+down_revision = "70444197d206"
+branch_labels = None
+depends_on = None
+
+if TYPE_CHECKING:
+    Base = object
+else:
+    Base = declarative_base()
+
+
+class JobTriggerModelType(str, enum.Enum):
+    pull_request = "pull_request"
+    branch_push = "branch_push"
+    release = "release"
+    issue = "issue"
+
+
+class JobTriggerModel(Base):
+    """
+    Model representing a trigger of some packit task.
+
+    It connects RunModel (and built/test models via that model)
+    with models like PullRequestModel, GitBranchModel or ProjectReleaseModel.
+
+    * It contains type and id of the other database_model.
+      * We know table and id that we need to find in that table.
+    * Each RunModel has to be connected to exactly one JobTriggerModel.
+    * There can be multiple RunModels for one JobTriggerModel.
+      (e.g. For each push to PR, there will be new RunModel, but same JobTriggerModel.)
+    """
+
+    __tablename__ = "build_triggers"
+    id = Column(Integer, primary_key=True)  # our database PK
+    type = Column(Enum(JobTriggerModelType))
+    trigger_id = Column(Integer)
+
+    runs = relationship("RunModel", back_populates="job_trigger")
+
+    # TO-BE-REMOVED
+    copr_builds = relationship("CoprBuildModel", back_populates="job_trigger")
+    srpm_builds = relationship("SRPMBuildModel", back_populates="job_trigger")
+    koji_builds = relationship("KojiBuildModel", back_populates="job_trigger")
+    test_runs = relationship("TFTTestRunModel", back_populates="job_trigger")
+
+
+class RunModel(Base):
+    """
+    Represents one pipeline.
+
+    Connects JobTriggerModel (and triggers like PullRequestModel via that model) with
+    build/test models like  SRPMBuildModel, CoprBuildModel, KojiBuildModel, and TFTTestRunModel.
+
+    * One model of each build/test model can be connected.
+    * Each build/test model can be connected to multiple RunModels (e.g. on retrigger).
+    * Each RunModel has to be connected to exactly one JobTriggerModel.
+    * There can be multiple RunModels for one JobTriggerModel.
+      (e.g. For each push to PR, there will be new RunModel, but same JobTriggerModel.)
+    """
+
+    __tablename__ = "runs"
+    id = Column(Integer, primary_key=True)  # our database PK
+    type = Column(Enum(JobTriggerModelType))
+    trigger_id = Column(Integer)
+
+    job_trigger_id = Column(Integer, ForeignKey("build_triggers.id"))
+    job_trigger = relationship("JobTriggerModel", back_populates="runs")
+
+    srpm_build_id = Column(Integer, ForeignKey("runs.id"))
+    srpm_build = relationship("SRPMBuildModel", back_populates="runs")
+    copr_build_id = Column(Integer, ForeignKey("runs.id"))
+    copr_build = relationship("CoprBuildModel", back_populates="runs")
+    koji_build_id = Column(Integer, ForeignKey("runs.id"))
+    koji_build = relationship("KojiBuildModel", back_populates="runs")
+    test_run_id = Column(Integer, ForeignKey("runs.id"))
+    test_run = relationship("TFTTestRunModel", back_populates="runs")
+
+
+class SRPMBuildModel(Base):
+    __tablename__ = "srpm_builds"
+    id = Column(Integer, primary_key=True)
+    # our logs we want to show to the user
+    logs = Column(Text)
+    success = Column(Boolean)
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    url = Column(Text)
+
+    runs = relationship("RunModel", back_populates="job_trigger")
+
+    # TO-BE-REMOVED
+    job_trigger_id = Column(Integer, ForeignKey("build_triggers.id"))
+    job_trigger = relationship("JobTriggerModel", back_populates="srpm_builds")
+    copr_builds = relationship("CoprBuildModel", back_populates="srpm_build")
+    koji_builds = relationship("KojiBuildModel", back_populates="srpm_build")
+
+
+class CoprBuildModel(Base):
+    """
+    Representation of Copr build for one target.
+    """
+
+    __tablename__ = "copr_builds"
+    id = Column(Integer, primary_key=True)
+    build_id = Column(String, index=True)  # copr build id
+    runs = relationship("RunModel", back_populates="job_trigger")
+
+    # commit sha of the PR (or a branch, release) we used for a build
+    commit_sha = Column(String)
+    # what's the build status?
+    status = Column(String)
+    # chroot, but we use the word target in our docs
+    target = Column(String)
+    # URL to copr web ui for the particular build
+    web_url = Column(String)
+    # url to copr build logs
+    build_logs_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the copr build is initiated, not when the table is made
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+
+    # project name as shown in copr
+    project_name = Column(String)
+    owner = Column(String)
+
+    # metadata for the build which didn't make it to schema yet
+    # metadata is reserved to sqlalch
+    data = Column(JSON)
+
+    # TO-BE-REMOVED
+    job_trigger_id = Column(Integer, ForeignKey("build_triggers.id"))
+    job_trigger = relationship("JobTriggerModel", back_populates="copr_builds")
+
+    srpm_build_id = Column(Integer, ForeignKey("srpm_builds.id"))
+    srpm_build = relationship("SRPMBuildModel", back_populates="copr_builds")
+
+
+class KojiBuildModel(Base):
+    """ we create an entry for every target """
+
+    __tablename__ = "koji_builds"
+    id = Column(Integer, primary_key=True)
+    build_id = Column(String, index=True)  # koji build id
+    runs = relationship("RunModel", back_populates="job_trigger")
+
+    # commit sha of the PR (or a branch, release) we used for a build
+    commit_sha = Column(String)
+    # what's the build status?
+    status = Column(String)
+    # chroot, but we use the word target in our docs
+    target = Column(String)
+    # URL to koji web ui for the particular build
+    web_url = Column(String)
+    # url to koji build logs
+    build_logs_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the koji build is initiated, not when the table is made
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+
+    # metadata for the build which didn't make it to schema yet
+    # metadata is reserved to sqlalch
+    data = Column(JSON)
+
+    # TO-BE-REMOVED
+    job_trigger_id = Column(Integer, ForeignKey("build_triggers.id"))
+    job_trigger = relationship("JobTriggerModel", back_populates="copr_builds")
+
+    srpm_build_id = Column(Integer, ForeignKey("srpm_builds.id"))
+    srpm_build = relationship("SRPMBuildModel", back_populates="copr_builds")
+
+
+class TFTTestRunModel(Base):
+    __tablename__ = "tft_test_runs"
+    id = Column(Integer, primary_key=True)
+    pipeline_id = Column(String, index=True)
+    commit_sha = Column(String)
+    target = Column(String)
+    web_url = Column(String)
+    data = Column(JSON)
+
+    runs = relationship("RunModel", back_populates="job_trigger")
+
+    # TO-BE-REMOVED
+    job_trigger_id = Column(Integer, ForeignKey("build_triggers.id"))
+    job_trigger = relationship("JobTriggerModel", back_populates="test_runs")
+
+
+def upgrade():
+
+    op.create_table(
+        "runs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("job_trigger_id", sa.Integer(), nullable=True),
+        sa.Column("srpm_build_id", sa.Integer(), nullable=True),
+        sa.Column("copr_build_id", sa.Integer(), nullable=True),
+        sa.Column("koji_build_id", sa.Integer(), nullable=True),
+        sa.Column("test_run_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["copr_build_id"],
+            ["runs.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["job_trigger_id"],
+            ["build_triggers.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["koji_build_id"],
+            ["runs.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["srpm_build_id"],
+            ["runs.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["test_run_id"],
+            ["runs.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Start data migration
+
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+    for copr_build in session.query(CoprBuildModel).all():
+        run_model = RunModel()
+        run_model.job_trigger = copr_build.job_trigger
+        run_model.srpm_build = copr_build.srpm_build
+        run_model.copr_build = copr_build
+        session.add(run_model)
+
+    for koji_build in session.query(KojiBuildModel).all():
+        run_model = RunModel()
+        run_model.job_trigger = koji_build.job_trigger
+        run_model.srpm_build = koji_build.srpm_build
+        run_model.koji_build = koji_build
+        session.add(run_model)
+
+    for test_run in session.query(TFTTestRunModel):
+        matching_runs: List[CoprBuildModel] = []
+        for copr_build in test_run.job_trigger.copr_builds:
+            if (
+                copr_build.commit_sha == test_run.commit_sha
+                and copr_build.target == test_run.target
+            ):
+                # TODO: match only successful Copr builds
+                matching_runs += copr_build.runs
+
+        if not matching_runs:
+            # Leave it as is, bad data
+            pass
+        else:
+            if len(matching_runs) != 1:
+                # This is the problematic part of the previous schema.
+                # We don't know the matching between between test runs and builds.
+                pass
+
+            for run_model in matching_runs:
+                if not run_model.test_run:
+                    run_model.test_run = test_run
+                    session.add(run_model)
+                    break
+            else:
+                # Create new RunModel
+                run_to_copy = matching_runs[-1]
+                new_run = RunModel()
+                new_run.srpm_build = run_to_copy.srpm_build
+                new_run.copr_build = run_to_copy.copr_build
+                new_run.test_run = test_run
+                session.add(new_run)
+
+    session.commit()
+
+    # Remove direct connections:
+
+    op.drop_constraint(
+        "copr_builds_job_trigger_id_fkey", "copr_builds", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "copr_builds_srpm_build_id_fkey1", "copr_builds", type_="foreignkey"
+    )
+    op.drop_column("copr_builds", "srpm_build_id")
+    op.drop_column("copr_builds", "job_trigger_id")
+    op.drop_constraint(
+        "koji_builds_job_trigger_id_fkey", "koji_builds", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "koji_builds_srpm_build_id_fkey", "koji_builds", type_="foreignkey"
+    )
+    op.drop_column("koji_builds", "srpm_build_id")
+    op.drop_column("koji_builds", "job_trigger_id")
+    op.drop_constraint(
+        "srpm_builds_job_trigger_id_fkey", "srpm_builds", type_="foreignkey"
+    )
+    op.drop_column("srpm_builds", "job_trigger_id")
+    op.drop_constraint(
+        "tft_test_runs_job_trigger_id_fkey", "tft_test_runs", type_="foreignkey"
+    )
+    op.drop_column("tft_test_runs", "job_trigger_id")
+
+
+def downgrade():
+
+    # Recreated direct connections:
+
+    op.add_column(
+        "tft_test_runs",
+        sa.Column("job_trigger_id", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.create_foreign_key(
+        "tft_test_runs_job_trigger_id_fkey",
+        "tft_test_runs",
+        "build_triggers",
+        ["job_trigger_id"],
+        ["id"],
+    )
+    op.add_column(
+        "srpm_builds",
+        sa.Column("job_trigger_id", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.create_foreign_key(
+        "srpm_builds_job_trigger_id_fkey",
+        "srpm_builds",
+        "build_triggers",
+        ["job_trigger_id"],
+        ["id"],
+    )
+    op.add_column(
+        "koji_builds",
+        sa.Column("job_trigger_id", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        "koji_builds",
+        sa.Column("srpm_build_id", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.create_foreign_key(
+        "koji_builds_srpm_build_id_fkey",
+        "koji_builds",
+        "srpm_builds",
+        ["srpm_build_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "koji_builds_job_trigger_id_fkey",
+        "koji_builds",
+        "build_triggers",
+        ["job_trigger_id"],
+        ["id"],
+    )
+    op.add_column(
+        "copr_builds",
+        sa.Column("job_trigger_id", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        "copr_builds",
+        sa.Column("srpm_build_id", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.create_foreign_key(
+        "copr_builds_srpm_build_id_fkey1",
+        "copr_builds",
+        "srpm_builds",
+        ["srpm_build_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "copr_builds_job_trigger_id_fkey",
+        "copr_builds",
+        "build_triggers",
+        ["job_trigger_id"],
+        ["id"],
+    )
+
+    # Migrate data:
+
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+    for run_model in session.query(RunModel).all():
+        run_model.srpm_build.job_trigger = run_model.job_trigger
+
+        if run_model.copr_build:
+            run_model.copr_build.job_trigger = run_model.job_trigger
+            run_model.copr_build.srpm_build = run_model.srpm_build
+
+        if run_model.koji_build:
+            run_model.koji_build.job_trigger = run_model.job_trigger
+            run_model.koji_build.srpm_build = run_model.srpm_build
+
+        if run_model.test_run:
+            run_model.test_run.job_trigger = run_model.job_trigger
+
+    session.commit()
+
+    op.drop_table("runs")

--- a/alembic/versions/a5c06aa9ef30_add_runmodel.py
+++ b/alembic/versions/a5c06aa9ef30_add_runmodel.py
@@ -75,6 +75,9 @@ class JobTriggerModel(Base):
     koji_builds = relationship("KojiBuildModel", back_populates="job_trigger")
     test_runs = relationship("TFTTestRunModel", back_populates="job_trigger")
 
+    def __repr__(self):
+        return f"JobTriggerModel(type={self.type}, trigger_id={self.trigger_id})"
+
 
 class RunModel(Base):
     """
@@ -105,6 +108,9 @@ class RunModel(Base):
     test_run_id = Column(Integer, ForeignKey("tft_test_runs.id"))
     test_run = relationship("TFTTestRunModel", back_populates="runs")
 
+    def __repr__(self):
+        return f"RunModel(id={self.id}, job_trigger={self.job_trigger})"
+
 
 class SRPMBuildModel(Base):
     __tablename__ = "srpm_builds"
@@ -122,6 +128,9 @@ class SRPMBuildModel(Base):
     job_trigger = relationship("JobTriggerModel", back_populates="srpm_builds")
     copr_builds = relationship("CoprBuildModel", back_populates="srpm_build")
     koji_builds = relationship("KojiBuildModel", back_populates="srpm_build")
+
+    def __repr__(self):
+        return f"SRPMBuildModel(id={self.id}, build_submitted_time={self.build_submitted_time})"
 
 
 class CoprBuildModel(Base):
@@ -166,6 +175,9 @@ class CoprBuildModel(Base):
     srpm_build_id = Column(Integer, ForeignKey("srpm_builds.id"))
     srpm_build = relationship("SRPMBuildModel", back_populates="copr_builds")
 
+    def __repr__(self):
+        return f"COPRBuildModel(id={self.id}, build_submitted_time={self.build_submitted_time})"
+
 
 class KojiBuildModel(Base):
     """ we create an entry for every target """
@@ -202,6 +214,9 @@ class KojiBuildModel(Base):
 
     srpm_build_id = Column(Integer, ForeignKey("srpm_builds.id"))
     srpm_build = relationship("SRPMBuildModel", back_populates="koji_builds")
+
+    def __repr__(self):
+        return f"KojiBuildModel(id={self.id}, build_submitted_time={self.build_submitted_time})"
 
 
 class TFTTestRunModel(Base):

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -653,6 +653,9 @@ class RunModel(Base):
 
     __tablename__ = "runs"
     id = Column(Integer, primary_key=True)  # our database PK
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the model is initiated, not when the table is made
+    datetime = Column(DateTime, default=datetime.utcnow)
 
     job_trigger_id = Column(Integer, ForeignKey("build_triggers.id"))
     job_trigger = relationship("JobTriggerModel", back_populates="runs")
@@ -680,7 +683,7 @@ class RunModel(Base):
         return self.job_trigger.get_trigger_object()
 
     def __repr__(self):
-        return f"RunModel(id={self.id}, job_trigger={self.job_trigger})"
+        return f"RunModel(id={self.id}, datetime='{datetime}', job_trigger={self.job_trigger})"
 
 
 class CoprBuildModel(ProjectAndTriggersConnector, Base):
@@ -1192,6 +1195,9 @@ class TFTTestRunModel(ProjectAndTriggersConnector, Base):
     status = Column(Enum(TestingFarmResult))
     target = Column(String)
     web_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the model is initiated, not when the table is made
+    submitted_time = Column(DateTime)
     data = Column(JSON)
 
     runs = relationship("RunModel", back_populates="test_run")

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -656,8 +656,6 @@ class RunModel(Base):
 
     __tablename__ = "runs"
     id = Column(Integer, primary_key=True)  # our database PK
-    type = Column(Enum(JobTriggerModelType))
-    trigger_id = Column(Integer)
 
     job_trigger_id = Column(Integer, ForeignKey("build_triggers.id"))
     job_trigger = relationship("JobTriggerModel", back_populates="runs")
@@ -924,6 +922,12 @@ class KojiBuildModel(ProjectAndTriggersConnector, Base):
         with get_sa_session() as session:
             self.build_submitted_time = build_submitted_time
             session.add(self)
+
+    def get_srpm_build(self) -> Optional["SRPMBuildModel"]:
+        if not self.runs:
+            return None
+        # All SRPMBuild models for all the runs have to be same.
+        return self.runs[0].srpm_build
 
     @classmethod
     def get_by_id(cls, id_: int) -> Optional["KojiBuildModel"]:

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -384,7 +384,7 @@ class PullRequestModel(BuildsAndTestsConnector, Base):
             return session.query(PullRequestModel).filter_by(id=id_).first()
 
     def __repr__(self):
-        return f"PullRequestModel(id={self.pr_id}, project={self.project})"
+        return f"PullRequestModel(pr_id={self.pr_id}, project={self.project})"
 
 
 class IssueModel(BuildsAndTestsConnector, Base):
@@ -680,7 +680,7 @@ class RunModel(Base):
         return self.job_trigger.get_trigger_object()
 
     def __repr__(self):
-        return f"RunModel(type={self.type}, trigger_id={self.trigger_id})"
+        return f"RunModel(id={self.id}, job_trigger={self.job_trigger})"
 
 
 class CoprBuildModel(ProjectAndTriggersConnector, Base):
@@ -691,7 +691,6 @@ class CoprBuildModel(ProjectAndTriggersConnector, Base):
     __tablename__ = "copr_builds"
     id = Column(Integer, primary_key=True)
     build_id = Column(String, index=True)  # copr build id
-    runs = relationship("RunModel", back_populates="copr_build")
 
     # commit sha of the PR (or a branch, release) we used for a build
     commit_sha = Column(String)
@@ -716,6 +715,8 @@ class CoprBuildModel(ProjectAndTriggersConnector, Base):
     # metadata for the build which didn't make it to schema yet
     # metadata is reserved to sqlalch
     data = Column(JSON)
+
+    runs = relationship("RunModel", back_populates="copr_build")
 
     def set_start_time(self, start_time: DateTime):
         with get_sa_session() as session:
@@ -869,7 +870,7 @@ class CoprBuildModel(ProjectAndTriggersConnector, Base):
         return cls.get_by_build_id(build_id, target)
 
     def __repr__(self):
-        return f"COPRBuildModel(id={self.id}, run_model={self.run_model})"
+        return f"COPRBuildModel(id={self.id}, build_submitted_time={self.build_submitted_time})"
 
 
 class KojiBuildModel(ProjectAndTriggersConnector, Base):
@@ -878,7 +879,6 @@ class KojiBuildModel(ProjectAndTriggersConnector, Base):
     __tablename__ = "koji_builds"
     id = Column(Integer, primary_key=True)
     build_id = Column(String, index=True)  # koji build id
-    runs = relationship("RunModel", back_populates="koji_build")
 
     # commit sha of the PR (or a branch, release) we used for a build
     commit_sha = Column(String)
@@ -899,6 +899,8 @@ class KojiBuildModel(ProjectAndTriggersConnector, Base):
     # metadata for the build which didn't make it to schema yet
     # metadata is reserved to sqlalch
     data = Column(JSON)
+
+    runs = relationship("RunModel", back_populates="koji_build")
 
     def set_status(self, status: str):
         with get_sa_session() as session:
@@ -1029,7 +1031,7 @@ class KojiBuildModel(ProjectAndTriggersConnector, Base):
         return cls.get_by_build_id(build_id, target)
 
     def __repr__(self):
-        return f"KojiBuildModel(id={self.id}, run_model={self.run_model})"
+        return f"KojiBuildModel(id={self.id}, build_submitted_time={self.build_submitted_time})"
 
 
 class SRPMBuildModel(ProjectAndTriggersConnector, Base):
@@ -1108,7 +1110,7 @@ class SRPMBuildModel(ProjectAndTriggersConnector, Base):
             session.add(self)
 
     def __repr__(self):
-        return f"SRPMBuildModel(id={self.id}, run_model={self.run_model})"
+        return f"SRPMBuildModel(id={self.id}, build_submitted_time={self.build_submitted_time})"
 
 
 class AllowlistStatus(str, enum.Enum):
@@ -1263,7 +1265,7 @@ class TFTTestRunModel(ProjectAndTriggersConnector, Base):
             ]
 
     def __repr__(self):
-        return f"TFTTestRunModel(id={self.id}, run_model={self.run_model})"
+        return f"TFTTestRunModel(id={self.id}, pipeline_id={self.pipeline_id})"
 
 
 class ProjectAuthenticationIssueModel(Base):

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -812,8 +812,11 @@ class CoprBuildModel(ProjectAndTriggersConnector, Base):
             return query.first()
 
     @classmethod
-    def get_all_by_owner_and_project(
-        cls, owner: str, project_name: str
+    def get_all_by_owner_and_project_and_target(
+        cls,
+        owner: str,
+        project_name: str,
+        target: str,
     ) -> Optional[Iterable["CoprBuildModel"]]:
         """
         All owner/project_name builds sorted from latest to oldest
@@ -821,7 +824,7 @@ class CoprBuildModel(ProjectAndTriggersConnector, Base):
         with get_sa_session() as session:
             query = (
                 session.query(CoprBuildModel)
-                .filter_by(owner=owner, project_name=project_name)
+                .filter_by(owner=owner, project_name=project_name, target=target)
                 .order_by(CoprBuildModel.build_id.desc())
             )
             return query.all()

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -605,12 +605,6 @@ class JobTriggerModel(Base):
 
     runs = relationship("RunModel", back_populates="job_trigger")
 
-    # TODO: Remove this relation. We need to go through RunModel.
-    copr_builds = relationship("CoprBuildModel", back_populates="job_trigger")
-    srpm_builds = relationship("SRPMBuildModel", back_populates="job_trigger")
-    koji_builds = relationship("KojiBuildModel", back_populates="job_trigger")
-    test_runs = relationship("TFTTestRunModel", back_populates="job_trigger")
-
     @classmethod
     def get_or_create(
         cls, type: JobTriggerModelType, trigger_id: int
@@ -660,13 +654,13 @@ class RunModel(Base):
     job_trigger_id = Column(Integer, ForeignKey("build_triggers.id"))
     job_trigger = relationship("JobTriggerModel", back_populates="runs")
 
-    srpm_build_id = Column(Integer, ForeignKey("runs.id"))
+    srpm_build_id = Column(Integer, ForeignKey("srpm_builds.id"))
     srpm_build = relationship("SRPMBuildModel", back_populates="runs")
-    copr_build_id = Column(Integer, ForeignKey("runs.id"))
+    copr_build_id = Column(Integer, ForeignKey("copr_builds.id"))
     copr_build = relationship("CoprBuildModel", back_populates="runs")
-    koji_build_id = Column(Integer, ForeignKey("runs.id"))
+    koji_build_id = Column(Integer, ForeignKey("koji_builds.id"))
     koji_build = relationship("KojiBuildModel", back_populates="runs")
-    test_run_id = Column(Integer, ForeignKey("runs.id"))
+    test_run_id = Column(Integer, ForeignKey("tft_test_runs.id"))
     test_run = relationship("TFTTestRunModel", back_populates="runs")
 
     @classmethod
@@ -694,7 +688,7 @@ class CoprBuildModel(ProjectAndTriggersConnector, Base):
     __tablename__ = "copr_builds"
     id = Column(Integer, primary_key=True)
     build_id = Column(String, index=True)  # copr build id
-    runs = relationship("RunModel", back_populates="job_trigger")
+    runs = relationship("RunModel", back_populates="copr_build")
 
     # commit sha of the PR (or a branch, release) we used for a build
     commit_sha = Column(String)
@@ -871,7 +865,7 @@ class KojiBuildModel(ProjectAndTriggersConnector, Base):
     __tablename__ = "koji_builds"
     id = Column(Integer, primary_key=True)
     build_id = Column(String, index=True)  # koji build id
-    runs = relationship("RunModel", back_populates="job_trigger")
+    runs = relationship("RunModel", back_populates="koji_build")
 
     # commit sha of the PR (or a branch, release) we used for a build
     commit_sha = Column(String)
@@ -1024,7 +1018,7 @@ class SRPMBuildModel(ProjectAndTriggersConnector, Base):
     build_submitted_time = Column(DateTime, default=datetime.utcnow)
     url = Column(Text)
 
-    runs = relationship("RunModel", back_populates="job_trigger")
+    runs = relationship("RunModel", back_populates="srpm_build")
 
     @classmethod
     def create_with_new_run(
@@ -1175,7 +1169,7 @@ class TFTTestRunModel(ProjectAndTriggersConnector, Base):
     web_url = Column(String)
     data = Column(JSON)
 
-    runs = relationship("RunModel", back_populates="job_trigger")
+    runs = relationship("RunModel", back_populates="test_run")
 
     def set_status(self, status: TestingFarmResult):
         with get_sa_session() as session:

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -845,8 +845,18 @@ class CoprBuildModel(ProjectAndTriggersConnector, Base):
             build.target = target
             session.add(build)
 
-            run_model.copr_build = build
-            session.add(run_model)
+            if run_model.copr_build:
+                # Clone run model
+                new_run_model = RunModel.create(
+                    type=run_model.job_trigger.type,
+                    trigger_id=run_model.job_trigger.trigger_id,
+                )
+                new_run_model.srpm_build = run_model.srpm_build
+                new_run_model.copr_build = build
+                session.add(new_run_model)
+            else:
+                run_model.copr_build = build
+                session.add(run_model)
 
             return build
 
@@ -995,8 +1005,18 @@ class KojiBuildModel(ProjectAndTriggersConnector, Base):
             build.target = target
             session.add(build)
 
-            run_model.koji_build = build
-            session.add(run_model)
+            if run_model.koji_build:
+                # Clone run model
+                new_run_model = RunModel.create(
+                    type=run_model.job_trigger.type,
+                    trigger_id=run_model.job_trigger.trigger_id,
+                )
+                new_run_model.srpm_build = run_model.srpm_build
+                new_run_model.koji_build = build
+                session.add(new_run_model)
+            else:
+                run_model.koji_build = build
+                session.add(run_model)
 
             return build
 
@@ -1205,8 +1225,19 @@ class TFTTestRunModel(ProjectAndTriggersConnector, Base):
             test_run.data = data
             session.add(test_run)
 
-            run_model.test_run = test_run
-            session.add(run_model)
+            if run_model.test_run:
+                # Clone run model
+                new_run_model = RunModel.create(
+                    type=run_model.job_trigger.type,
+                    trigger_id=run_model.job_trigger.trigger_id,
+                )
+                new_run_model.srpm_build = run_model.srpm_build
+                new_run_model.copr_build = run_model.copr_build
+                new_run_model.test_run = test_run
+                session.add(new_run_model)
+            else:
+                run_model.test_run = test_run
+                session.add(run_model)
 
             return test_run
 
@@ -1218,6 +1249,11 @@ class TFTTestRunModel(ProjectAndTriggersConnector, Base):
                 .filter_by(pipeline_id=pipeline_id)
                 .first()
             )
+
+    @classmethod
+    def get_by_id(cls, id: int) -> Optional["InstallationModel"]:
+        with get_sa_session() as session:
+            return session.query(TFTTestRunModel).filter_by(id=id).first()
 
     @classmethod
     def get_range(cls, first: int, last: int) -> Optional[Iterable["TFTTestRunModel"]]:

--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -87,7 +87,7 @@ class CoprBuildItem(Resource):
             "build_logs_url": build.build_logs_url,
             "copr_project": build.project_name,
             "copr_owner": build.owner,
-            "srpm_build_id": build.srpm_build.id,
+            "srpm_build_id": build.get_srpm_build().id,
         }
 
         build_dict.update(get_project_info_from_build(build))

--- a/packit_service/service/api/koji_builds.py
+++ b/packit_service/service/api/koji_builds.py
@@ -84,7 +84,7 @@ class KojiBuildItem(Resource):
             "web_url": build.web_url,
             # from old data, sometimes build_logs_url is same and sometimes different to web_url
             "build_logs_url": build.build_logs_url,
-            "srpm_build_id": build.srpm_build.id,
+            "srpm_build_id": build.get_srpm_build().id,
         }
 
         build_dict.update(get_project_info_from_build(build))

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -39,6 +39,7 @@ from packit_service.models import (
     CoprBuildModel,
     GitBranchModel,
     IssueModel,
+    JobTriggerModelType,
     KojiBuildModel,
     ProjectReleaseModel,
     PullRequestModel,
@@ -1113,15 +1114,15 @@ class AbstractCoprBuildEvent(AbstractForgeIndependentEvent):
 
         trigger_db = build.get_trigger_object()
         pr_id = None
-        if isinstance(trigger_db, PullRequestModel):
-            pr_id = trigger_db.pr_id
-            self.identifier = str(trigger_db.pr_id)
-        elif isinstance(trigger_db, ProjectReleaseModel):
+        if trigger_db.job_trigger_model_type == JobTriggerModelType.pull_request:
+            pr_id = trigger_db.pr_id  # type: ignore
+            self.identifier = str(trigger_db.pr_id)  # type: ignore
+        elif trigger_db.job_trigger_model_type == JobTriggerModelType.release:
             pr_id = None
-            self.identifier = trigger_db.tag_name
-        elif isinstance(trigger_db, GitBranchModel):
+            self.identifier = trigger_db.tag_name  # type: ignore
+        elif trigger_db.job_trigger_model_type == JobTriggerModelType.branch_push:
             pr_id = None
-            self.identifier = trigger_db.name
+            self.identifier = trigger_db.name  # type: ignore
 
         super().__init__(project_url=trigger_db.project.project_url, pr_id=pr_id)
 

--- a/packit_service/service/templates/build_info.html
+++ b/packit_service/service/templates/build_info.html
@@ -9,12 +9,12 @@
 <p>Status: {{build.status}}</p>
 <p>
   <a
-    href="{{ url_for('builds.get_srpm_build_logs_by_id', id_=build.srpm_build_id) }}"
+    href="{{ url_for('builds.get_srpm_build_logs_by_id', id_=srpm_build.id) }}"
   >
     SRPM build</a
   >
-  {% if build.srpm_build.url %}
-  <a href="{{ build.srpm_build.url }}">(Download SRPM)</a>
+  {% if srpm_build.url %}
+  <a href="{{ srpm_build.url }}">(Download SRPM)</a>
   {% endif %} started {{srpm_submitted_time}}
 </p>
 {% if build.build_id %}

--- a/packit_service/service/views.py
+++ b/packit_service/service/views.py
@@ -55,7 +55,7 @@ def _get_build_info(
 ):
     project = build.get_project()
 
-    trigger = build.job_trigger.get_trigger_object()
+    trigger = build.get_trigger_object()
     if isinstance(trigger, PullRequestModel):
         title_identifier = f"PR #{trigger.pr_id}"
     elif isinstance(trigger, GitBranchModel):
@@ -65,6 +65,8 @@ def _get_build_info(
     else:
         title_identifier = ""
 
+    srpm_build = build.get_srpm_build()
+
     return render_template(
         "build_info.html",
         project=project,
@@ -72,7 +74,9 @@ def _get_build_info(
         build_description=build_description,
         build=build,
         build_submitted_time=pretty_time(build.build_submitted_time),
-        srpm_submitted_time=pretty_time(build.srpm_build.build_submitted_time),
+        srpm_submitted_time=pretty_time(srpm_build.build_submitted_time)
+        if srpm_build
+        else None,
         owner=build.owner if isinstance(build, CoprBuildModel) else None,
         project_name=build.project_name if isinstance(build, CoprBuildModel) else None,
         is_pr=isinstance(trigger, PullRequestModel),

--- a/packit_service/service/views.py
+++ b/packit_service/service/views.py
@@ -31,6 +31,7 @@ from packit_service.log_versions import log_service_versions
 from packit_service.models import (
     CoprBuildModel,
     GitBranchModel,
+    JobTriggerModelType,
     KojiBuildModel,
     ProjectReleaseModel,
     PullRequestModel,
@@ -77,9 +78,9 @@ def _get_build_info(
         srpm_submitted_time=pretty_time(srpm_build.build_submitted_time)
         if srpm_build
         else None,
-        owner=build.owner if isinstance(build, CoprBuildModel) else None,
-        project_name=build.project_name if isinstance(build, CoprBuildModel) else None,
-        is_pr=isinstance(trigger, PullRequestModel),
+        owner=build.owner if hasattr(build, "owner") else None,  # type: ignore
+        project_name=build.project_name if hasattr(build, "project_name") else None,  # type: ignore
+        is_pr=trigger.job_trigger_model_type == JobTriggerModelType.pull_request,
     )
 
 

--- a/packit_service/service/views.py
+++ b/packit_service/service/views.py
@@ -74,6 +74,7 @@ def _get_build_info(
         title_identifier=title_identifier,
         build_description=build_description,
         build=build,
+        srpm_build=srpm_build,
         build_submitted_time=pretty_time(build.build_submitted_time),
         srpm_submitted_time=pretty_time(srpm_build.build_submitted_time)
         if srpm_build

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -36,7 +36,7 @@ from packit.local_project import LocalProject
 from packit.utils import PackitFormatter
 from packit_service import sentry_integration
 from packit_service.config import Deployment, ServiceConfig
-from packit_service.models import SRPMBuildModel
+from packit_service.models import RunModel, SRPMBuildModel
 from packit_service.service.events import EventData
 from packit_service.trigger_mapping import are_job_types_same
 from packit_service.worker.reporting import StatusReporter
@@ -67,6 +67,7 @@ class BaseBuildJobHelper:
         self.db_trigger = db_trigger
         self.msg_retrigger: Optional[str] = ""
         self.metadata: EventData = metadata
+        self.run_model: Optional[RunModel] = None
 
         # lazy properties
         self._api = None
@@ -393,7 +394,7 @@ class BaseBuildJobHelper:
                 "\nPlease join the freenode IRC channel #packit for the latest info.\n"
             )
 
-        self._srpm_model = SRPMBuildModel.create(
+        self._srpm_model, self.run_model = SRPMBuildModel.create_with_new_run(
             logs=srpm_logs,
             success=srpm_success,
             trigger_model=self.db_trigger,

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -249,8 +249,6 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 web_url=web_url,
                 target=chroot,
                 status="pending",
-                srpm_build=self.srpm_model,
-                trigger_model=self.db_trigger,
             )
             url = get_copr_build_info_url_from_flask(id_=copr_build.id)
             self.report_status_to_all_for_chroot(

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -241,7 +241,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 unprocessed_chroots.append(chroot)
                 continue
 
-            copr_build = CoprBuildModel.get_or_create(
+            copr_build = CoprBuildModel.create(
                 build_id=str(build_id),
                 commit_sha=self.metadata.commit_sha,
                 project_name=self.job_project,
@@ -249,6 +249,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 web_url=web_url,
                 target=chroot,
                 status="pending",
+                run_model=self.run_model,
             )
             url = get_copr_build_info_url_from_flask(id_=copr_build.id)
             self.report_status_to_all_for_chroot(

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -180,14 +180,13 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
                 errors[target] = str(ex)
                 continue
 
-            koji_build = KojiBuildModel.get_or_create(
+            koji_build = KojiBuildModel.create(
                 build_id=str(build_id),
                 commit_sha=self.metadata.commit_sha,
                 web_url=web_url,
                 target=target,
                 status="pending",
-                srpm_build=self.srpm_model,
-                trigger_model=self.db_trigger,
+                run_model=self.run_model,
             )
             url = get_koji_build_info_url_from_flask(id_=koji_build.id)
             self.report_status_to_all_for_chroot(

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -174,7 +174,7 @@ class AbstractCoprBuildReportHandler(FedmsgHandler):
     @property
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
         if not self._db_trigger:
-            self._db_trigger = self.build.job_trigger.get_trigger_object()
+            self._db_trigger = self.build.get_trigger_object()
         return self._db_trigger
 
 
@@ -204,14 +204,16 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
         return False
 
     def set_srpm_url(self, build_job_helper: CoprBuildJobHelper) -> None:
-        if self.build.srpm_build.url is not None:
+        srpm_build = self.build.get_srpm_build()
+
+        if srpm_build.url is not None:
             # URL has been already set
             return
 
         srpm_url = build_job_helper.get_build(
             self.copr_event.build_id
         ).source_package.get("url")
-        self.build.srpm_build.set_url(srpm_url)
+        srpm_build.set_url(srpm_url)
 
     def run(self):
         build_job_helper = CoprBuildJobHelper(

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -410,7 +410,7 @@ class KojiBuildReportHandler(FedmsgHandler):
     @property
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
         if not self._db_trigger and self.build:
-            self._db_trigger = self.build.job_trigger.get_trigger_object()
+            self._db_trigger = self.build.get_trigger_object()
         return self._db_trigger
 
     def run(self):

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -415,7 +415,7 @@ class TestingFarmHandler(JobHandler):
             # copr build end
             if self.build_id:
                 build = CoprBuildModel.get_by_id(self.build_id)
-                self._db_trigger = build.job_trigger.get_trigger_object()
+                self._db_trigger = build.get_trigger_object()
             # '/packit test' comment
             else:
                 self._db_trigger = self.data.db_trigger

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -442,10 +442,10 @@ class TestingFarmHandler(JobHandler):
             return testing_farm_helper.run_testing_farm_on_all()
 
         if self.build_id:
-            copr_build_id = CoprBuildModel.get_by_id(self.build_id).build_id
+            copr_build = CoprBuildModel.get_by_id(self.build_id)
         else:
-            copr_build_id = testing_farm_helper.latest_copr_build.build_id
-        logger.info(f"Running testing farm for {copr_build_id}:{self.chroot}.")
+            copr_build = testing_farm_helper.get_latest_copr_build(target=self.chroot)
+        logger.info(f"Running testing farm for {copr_build}:{self.chroot}.")
         return testing_farm_helper.run_testing_farm(
-            build_id=int(copr_build_id), chroot=self.chroot
+            build=copr_build, chroot=self.chroot
         )

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -64,7 +64,7 @@ class TestingFarmResultsHandler(JobHandler):
         if not self._db_trigger:
             run_model = TFTTestRunModel.get_by_pipeline_id(pipeline_id=self.pipeline_id)
             if run_model:
-                self._db_trigger = run_model.job_trigger.get_trigger_object()
+                self._db_trigger = run_model.get_trigger_object()
         return self._db_trigger
 
     def run(self) -> TaskResults:

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -823,7 +823,7 @@ class Parser:
 
         # ["test"]["fmf"]["url"] contains PR's source/fork url or TF's install test url.
         # We need the original/base project url stored in db.
-        if tft_test_run:
+        if tft_test_run and tft_test_run.data:
             base_project_url = tft_test_run.data.get("base_project_url")
             if base_project_url and base_project_url != project_url:
                 logger.debug(

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -311,7 +311,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             status=TestingFarmResult.new,
             target=chroot,
             web_url=None,
-            trigger_model=self.db_trigger,
+            run_model=self.latest_copr_build.runs[-1],
             # In _payload() we ask TF to test commit_sha of fork (PR's source).
             # Store original url. If this proves to work, make it a separate column.
             data={"base_project_url": self.project.get_web_url()},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,10 @@ def copr_build_model(
         trigger_id=1,
         get_trigger_object=lambda: pr_model,
     )
-    return flexmock(
+
+    runs = []
+    srpm_build = flexmock(logs="asdsdf", url=None, runs=runs)
+    copr_build = flexmock(
         id=1,
         build_id="1",
         commit_sha="0011223344",
@@ -126,9 +129,18 @@ def copr_build_model(
         web_url="https://some-url",
         target="some-target",
         status="some-status",
-        srpm_build=flexmock(logs="asdsdf", url=None),
-        job_trigger=trigger_model,
+        runs=runs,
     )
+    copr_build._srpm_build_for_mocking = srpm_build
+    copr_build.get_trigger_object = lambda: pr_model
+    copr_build.get_srpm_build = lambda: srpm_build
+
+    run_model = flexmock(
+        id=3, job_trigger=trigger_model, srpm_build=srpm_build, copr_build=copr_build
+    )
+    runs.append(run_model)
+
+    return copr_build
 
 
 @pytest.fixture(scope="module")
@@ -153,6 +165,8 @@ def koji_build_pr():
         trigger_id=1,
         get_trigger_object=lambda: pr_model,
     )
+    runs = []
+    srpm_build = flexmock(logs="asdsdf", url=None, runs=runs)
     koji_build_model = flexmock(
         id=1,
         build_id="1",
@@ -162,9 +176,19 @@ def koji_build_pr():
         web_url="https://some-url",
         target="some-target",
         status="some-status",
-        srpm_build=flexmock(logs="asdsdf"),
-        job_trigger=trigger_model,
+        runs=runs,
     )
+    koji_build_model._srpm_build_for_mocking = srpm_build
+    koji_build_model.get_trigger_object = lambda: pr_model
+    koji_build_model.get_srpm_build = lambda: srpm_build
+
+    run_model = flexmock(
+        id=3,
+        job_trigger=trigger_model,
+        srpm_build=srpm_build,
+        copr_build=koji_build_model,
+    )
+    runs.append(run_model)
 
     return koji_build_model
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,7 @@ def copr_build_model(
         pr_id=123,
         project=project_model,
         job_config_trigger_type=job_config_trigger_type,
+        job_trigger_model_type=JobTriggerModelType.pull_request,
         **trigger_model_kwargs,
     )
     trigger_model = flexmock(

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -96,6 +96,7 @@ def test_check_copr_build_updated():
                     ),
                     pr_id=5,
                     job_config_trigger_type=JobConfigTriggerType.pull_request,
+                    job_trigger_model_type=JobTriggerModelType.pull_request,
                     id=123,
                 )
             )

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -80,26 +80,26 @@ def test_check_copr_build_updated():
                 owner="the-owner",
                 project_name="the-project-name",
                 commit_sha="123456",
-                job_trigger=flexmock(type=JobTriggerModelType.pull_request)
-                .should_receive("get_trigger_object")
-                .and_return(
-                    flexmock(
-                        project=flexmock(
-                            repo_name="repo_name",
-                            namespace="the-namespace",
-                            project_url="https://github.com/the-namespace/repo_name",
-                        ),
-                        pr_id=5,
-                        job_config_trigger_type=JobConfigTriggerType.pull_request,
-                        id=123,
-                    )
-                )
-                .mock(),
+                job_trigger=flexmock(type=JobTriggerModelType.pull_request),
                 srpm_build=flexmock(url=None)
                 .should_receive("set_url")
                 .with_args("https://some.host/my.srpm")
                 .mock(),
             )
+            .should_receive("get_trigger_object")
+            .and_return(
+                flexmock(
+                    project=flexmock(
+                        repo_name="repo_name",
+                        namespace="the-namespace",
+                        project_url="https://github.com/the-namespace/repo_name",
+                    ),
+                    pr_id=5,
+                    job_config_trigger_type=JobConfigTriggerType.pull_request,
+                    id=123,
+                )
+            )
+            .mock()
         ]
     )
     flexmock(Client).should_receive("create_from_config_file").and_return(

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -33,6 +33,7 @@ from ogr.services.github import GithubProject, GithubRelease
 from ogr.services.gitlab import GitlabProject, GitlabRelease
 from packit.api import PackitAPI
 from packit.distgit import DistGit
+from packit.config import JobConfigTriggerType
 from packit.local_project import LocalProject
 from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
@@ -138,9 +139,11 @@ def test_issue_comment_propose_downstream_handler(
         is_private=lambda: False,
     )
 
-    flexmock(event_type, db_trigger=IssueModel(id=123))
-    flexmock(IssueModel).should_receive("get_by_id").with_args(123).and_return(
-        flexmock(issue_id=12345)
+    flexmock(IssueCommentGitlabEvent).should_receive("db_trigger").and_return(
+        flexmock(id=123, job_config_trigger_type=JobConfigTriggerType.release)
+    )
+    flexmock(IssueModel).should_receive("get_or_create").and_return(
+        flexmock(id=123, job_config_trigger_type=JobConfigTriggerType.release)
     )
     flexmock(Signature).should_receive("apply_async").once()
 

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -202,6 +202,7 @@ def test_copr_build_end(
     flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
     copr_build_pr.should_receive("set_status").with_args("success")
     copr_build_pr.should_receive("set_end_time").once()
+
     url = get_copr_build_info_url_from_flask(1)
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -227,7 +228,7 @@ def test_copr_build_end(
         .at_least()
         .once()
     )
-    flexmock(copr_build_pr.srpm_build).should_receive("set_url").with_args(
+    flexmock(copr_build_pr._srpm_build_for_mocking).should_receive("set_url").with_args(
         "https://my.host/my.srpm"
     ).mock()
 
@@ -482,7 +483,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         commit_sha="0011223344",
         status=TestingFarmResult.new,
         target="fedora-rawhide-x86_64",
-        trigger_model=copr_build_pr.job_trigger.get_trigger_object(),
+        run_model=copr_build_pr.runs[0],
         web_url=None,
         data={"base_project_url": "https://github.com/foo/bar"},
     ).and_return(tft_test_run_model)
@@ -510,7 +511,11 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     )
 
     flexmock(TestingFarmHandler).should_receive("db_trigger").and_return(
-        copr_build_pr.job_trigger.get_trigger_object()
+        copr_build_pr.get_trigger_object()
+    )
+
+    flexmock(CoprBuildModel).should_receive("get_all_by_owner_and_project").and_return(
+        [copr_build_pr]
     )
 
     run_testing_farm_handler(
@@ -624,7 +629,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     )
 
     flexmock(TestingFarmHandler).should_receive("db_trigger").and_return(
-        copr_build_pr.job_trigger.get_trigger_object()
+        copr_build_pr.get_trigger_object()
     )
 
     run_testing_farm_handler(
@@ -740,7 +745,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     )
 
     flexmock(TestingFarmHandler).should_receive("db_trigger").and_return(
-        copr_build_pr.job_trigger.get_trigger_object()
+        copr_build_pr.get_trigger_object()
     )
 
     run_testing_farm_handler(

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -514,9 +514,9 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         copr_build_pr.get_trigger_object()
     )
 
-    flexmock(CoprBuildModel).should_receive("get_all_by_owner_and_project").and_return(
-        [copr_build_pr]
-    )
+    flexmock(CoprBuildModel).should_receive(
+        "get_all_by_owner_and_project_and_target"
+    ).and_return([copr_build_pr])
 
     run_testing_farm_handler(
         package_config=package_config,

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -214,7 +214,7 @@ def test_check_and_report_calls_method(allowlist, event, method, approved):
     flexmock(gp).should_receive("get_pr").and_return(flexmock(author=None))
     allowlist_mock = flexmock(DBAllowlist).should_receive("get_account")
     if approved:
-        allowlist_mock.and_return(DBAllowlist(status="approved_manually"))
+        allowlist_mock.and_return(flexmock(status="approved_manually"))
     else:
         allowlist_mock.and_return(None)
     assert (
@@ -407,7 +407,7 @@ def test_check_and_report(
         allowlist_mock = flexmock(DBAllowlist).should_receive("get_account")
         if not TYPE_CHECKING:
             if is_valid:
-                allowlist_mock.and_return(DBAllowlist(status="approved_manually"))
+                allowlist_mock.and_return(flexmock(status="approved_manually"))
             else:
                 allowlist_mock.and_return(None)
 

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -163,15 +163,16 @@ def test_copr_build_check_names(github_pr_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -283,15 +284,16 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
         "not-so-bright-future-x86_64\n"
         "```\n</details>",
     ).and_return()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -393,15 +395,16 @@ def test_copr_build_check_names_multiple_jobs(github_pr_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -478,15 +481,16 @@ def test_copr_build_check_names_custom_owner(github_pr_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -553,15 +557,16 @@ def test_copr_build_success_set_test_check(github_pr_event):
     flexmock(GitProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
@@ -618,15 +623,16 @@ def test_copr_build_for_branch(branch_push_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PushGitHubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -685,12 +691,10 @@ def test_copr_build_for_branch_failed(branch_push_event):
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
     flexmock(GitProject).should_receive("commit_comment").and_return(flexmock())
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        SRPMBuildModel(success=False, id=2)
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (flexmock(success=False, id=2), flexmock())
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PushGitHubEvent).should_receive("db_trigger").and_raise(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_raise(
@@ -748,15 +752,16 @@ def test_copr_build_for_release(release_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
@@ -803,15 +808,16 @@ def test_copr_build_success(github_pr_event):
     flexmock(GitProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -884,12 +890,10 @@ def test_copr_build_fails_in_packit(github_pr_event):
     flexmock(GitProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        SRPMBuildModel(success=False, id=2)
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (flexmock(success=False, id=2), flexmock())
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
 
     flexmock(PackitAPI).should_receive("create_srpm").and_raise(
@@ -937,12 +941,10 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
             templ.format(ver=v),
             trim=True,
         ).and_return().once()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        SRPMBuildModel(success=True, id=2)
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (flexmock(success=True, id=2), flexmock())
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
     flexmock(GitProject).should_receive("get_pr").with_args(342).and_return(flexmock())
@@ -1037,15 +1039,16 @@ def test_copr_build_no_targets(github_pr_event):
     flexmock(GitProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -1113,15 +1116,16 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(MergeRequestGitlabEvent).should_receive("db_trigger").and_return(
         flexmock()
     )
@@ -1192,15 +1196,16 @@ def test_copr_build_success_set_test_check_gitlab(gitlab_mr_event):
     flexmock(GitProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
@@ -1257,15 +1262,16 @@ def test_copr_build_for_branch_gitlab(branch_push_event_gitlab):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PushGitHubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -1317,15 +1323,16 @@ def test_copr_build_success_gitlab(gitlab_mr_event):
     flexmock(GitProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(MergeRequestGitlabEvent).should_receive("db_trigger").and_return(
         flexmock()
     )
@@ -1402,12 +1409,10 @@ def test_copr_build_fails_in_packit_gitlab(gitlab_mr_event):
     flexmock(GitProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        SRPMBuildModel(success=False, id=2)
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (flexmock(success=False, id=2), flexmock())
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
 
     flexmock(PackitAPI).should_receive("create_srpm").and_raise(
@@ -1449,15 +1454,16 @@ def test_copr_build_success_gitlab_comment(gitlab_mr_event):
             source_project=flexmock(),
         )
     )
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True, id=42)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True, id=42)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(MergeRequestGitlabEvent).should_receive("db_trigger").and_return(
         flexmock()
     )
@@ -1521,15 +1527,16 @@ def test_copr_build_no_targets_gitlab(gitlab_mr_event):
     flexmock(GitProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        flexmock(success=True)
-        .should_receive("set_url")
-        .with_args("https://some.host/my.srpm")
-        .mock()
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (
+            flexmock(success=True)
+            .should_receive("set_url")
+            .with_args("https://some.host/my.srpm")
+            .mock(),
+            flexmock(),
+        )
     )
-    flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
-        CoprBuildModel(id=1)
-    )
+    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(MergeRequestGitlabEvent).should_receive("db_trigger").and_return(
         flexmock()
     )

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -633,13 +633,13 @@ class TestEvents:
         ).and_return(testing_farm_results)
         flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
             flexmock(
-                job_trigger=flexmock()
-                .should_receive("get_trigger_object")
-                .and_return(PullRequestModel(pr_id=10))
-                .once()
-                .mock(),
+                job_trigger=flexmock(),
                 data={"base_project_url": "https://github.com/packit/packit"},
             )
+            .should_receive("get_trigger_object")
+            .and_return(flexmock(pr_id=10))
+            .once()
+            .mock()
         )
         event_object = Parser.parse_event(testing_farm_notification)
 
@@ -666,13 +666,13 @@ class TestEvents:
         ).and_return(testing_farm_results_error)
         flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
             flexmock(
-                job_trigger=flexmock()
-                .should_receive("get_trigger_object")
-                .and_return(PullRequestModel(pr_id=10))
-                .once()
-                .mock(),
+                job_trigger=flexmock(),
                 data={"base_project_url": "https://github.com/packit/packit"},
             )
+            .should_receive("get_trigger_object")
+            .and_return(flexmock(pr_id=10))
+            .once()
+            .mock()
         )
         event_object = Parser.parse_event(testing_farm_notification)
 

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -139,12 +139,10 @@ def test_koji_build_check_names(github_pr_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        SRPMBuildModel(id=1, success=True)
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (flexmock(id=1, success=True), flexmock())
     )
-    flexmock(KojiBuildModel).should_receive("get_or_create").and_return(
-        KojiBuildModel(id=1)
-    )
+    flexmock(KojiBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     # koji build
@@ -192,12 +190,10 @@ def test_koji_build_failed_kerberos(github_pr_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        SRPMBuildModel(id=1, success=True)
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (flexmock(id=1, success=True), flexmock())
     )
-    flexmock(KojiBuildModel).should_receive("get_or_create").and_return(
-        KojiBuildModel(id=1)
-    )
+    flexmock(KojiBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     flexmock(PackitAPI).should_receive("init_kerberos_ticket").and_raise(
@@ -246,12 +242,10 @@ def test_koji_build_target_not_supported(github_pr_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        SRPMBuildModel(id=1, success=True)
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (flexmock(id=1, success=True), flexmock())
     )
-    flexmock(KojiBuildModel).should_receive("get_or_create").and_return(
-        KojiBuildModel(id=1)
-    )
+    flexmock(KojiBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     response = helper.run_koji_build()
@@ -285,12 +279,12 @@ def test_koji_build_with_multiple_targets(github_pr_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        SRPMBuildModel(id=1, success=True)
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (flexmock(id=1, success=True), flexmock())
     )
-    flexmock(KojiBuildModel).should_receive("get_or_create").and_return(
-        KojiBuildModel(id=1)
-    ).and_return(KojiBuildModel(id=2))
+    flexmock(KojiBuildModel).should_receive("create").and_return(
+        flexmock(id=1)
+    ).and_return(flexmock(id=2))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     # koji build
@@ -344,12 +338,10 @@ def test_koji_build_failed(github_pr_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        SRPMBuildModel(id=2, success=True)
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (flexmock(id=2, success=True), flexmock())
     )
-    flexmock(KojiBuildModel).should_receive("get_or_create").and_return(
-        KojiBuildModel(id=1)
-    )
+    flexmock(KojiBuildModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     # koji build
@@ -391,10 +383,10 @@ def test_koji_build_failed_srpm(github_pr_event):
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
     flexmock(PackitAPI).should_receive("create_srpm").and_raise(Exception, "some error")
-    flexmock(SRPMBuildModel).should_receive("create").and_return(
-        SRPMBuildModel(id=2, success=False)
+    flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
+        (flexmock(id=2, success=False), flexmock())
     )
-    flexmock(KojiBuildModel).should_receive("get_or_create").never()
+    flexmock(KojiBuildModel).should_receive("create").never()
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
 
     result = helper.run_koji_build()
@@ -423,7 +415,7 @@ def test_koji_build_non_scratch(github_pr_event):
         flexmock(source_project=flexmock())
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(KojiBuildModel).should_receive("get_or_create").never()
+    flexmock(KojiBuildModel).should_receive("create").never()
 
     result = helper.run_koji_build()
     assert result["success"]

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -46,69 +46,68 @@ def test_get_logs(client):
     state = "success"
     build_id = 2
 
-    project = flexmock()
-    project.namespace = "john-foo"
-    project.repo_name = "bar"
+    project_mock = flexmock()
+    project_mock.namespace = "john-foo"
+    project_mock.repo_name = "bar"
 
-    pr = flexmock()
-    pr.job_trigger_model_type = JobTriggerModelType.pull_request
-    pr.pr_id = 234
-    pr.project = project
+    pr_mock = flexmock()
+    pr_mock.job_trigger_model_type = JobTriggerModelType.pull_request
+    pr_mock.pr_id = 234
+    pr_mock.project = project_mock
 
-    srpm = flexmock()
-    srpm.url = "https://some.random.copr.subdomain.org/my_srpm.srpm"
-    srpm.build_submitted_time = datetime(
+    srpm_build_mock = flexmock()
+    srpm_build_mock.id = 11
+    srpm_build_mock.url = "https://some.random.copr.subdomain.org/my_srpm.srpm"
+    srpm_build_mock.build_submitted_time = datetime(
         year=2020, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
     )
 
-    c = flexmock()
-    c.target = chroot
-    c.build_id = str(build_id)
-    c.srpm_build_id = 11
-    c.status = state
-    c.srpm_build = srpm
-    c.web_url = (
+    copr_build_mock = flexmock()
+    copr_build_mock.target = chroot
+    copr_build_mock.build_id = str(build_id)
+    copr_build_mock.status = state
+    copr_build_mock.web_url = (
         "https://copr.fedorainfracloud.org/coprs/john-foo-bar/john-foo-bar/build/2/"
     )
-    c.build_logs_url = "https://localhost:5000/build/2/foo-1-x86_64/logs"
-    c.owner = "packit"
-    c.build_submitted_time = datetime(
+    copr_build_mock.build_logs_url = "https://localhost:5000/build/2/foo-1-x86_64/logs"
+    copr_build_mock.owner = "packit"
+    copr_build_mock.build_submitted_time = datetime(
         year=2020, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
     )
-    c.project_name = "example_project"
-    c.should_receive("get_trigger_object").and_return(pr)
-    c.should_receive("get_project").and_return(project)
-    c.should_receive("get_srpm_build").and_return(srpm)
+    copr_build_mock.project_name = "example_project"
+    copr_build_mock.should_receive("get_trigger_object").and_return(pr_mock)
+    copr_build_mock.should_receive("get_project").and_return(project_mock)
+    copr_build_mock.should_receive("get_srpm_build").and_return(srpm_build_mock)
 
-    flexmock(CoprBuildModel).should_receive("get_by_id").and_return(c)
+    flexmock(CoprBuildModel).should_receive("get_by_id").and_return(copr_build_mock)
 
     url = "/copr-build/1"
     logs_url = get_copr_build_info_url_from_flask(1)
     assert logs_url.endswith(url)
 
     resp = client.get(url).data.decode()
-    assert f"srpm-build/{c.srpm_build_id}/logs" in resp
-    assert c.web_url in resp
-    assert c.build_logs_url in resp
-    assert c.target in resp
+    assert f"srpm-build/{srpm_build_mock.id}/logs" in resp
+    assert copr_build_mock.web_url in resp
+    assert copr_build_mock.build_logs_url in resp
+    assert copr_build_mock.target in resp
     assert "Status: success" in resp
     assert "You can install" in resp
 
     assert "Download SRPM" in resp
-    assert srpm.url in resp
+    assert srpm_build_mock.url in resp
 
 
 def test_get_srpm_logs(client):
-    srpm_build = flexmock()
-    srpm_build.id = 2
-    srpm_build.logs = "asd\nqwe"
+    srpm_build_mock = flexmock()
+    srpm_build_mock.id = 2
+    srpm_build_mock.logs = "asd\nqwe"
 
-    flexmock(SRPMBuildModel).should_receive("get_by_id").and_return(srpm_build)
+    flexmock(SRPMBuildModel).should_receive("get_by_id").and_return(srpm_build_mock)
 
     url = "/srpm-build/2/logs"
     logs_url = get_srpm_log_url_from_flask(2)
     assert logs_url.endswith(url)
 
     resp = client.get(url).data.decode()
-    assert srpm_build.logs in resp
-    assert f"build {srpm_build.id}" in resp
+    assert srpm_build_mock.logs in resp
+    assert f"build {srpm_build_mock.id}" in resp

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -37,6 +37,7 @@ from ogr import GithubService, GitlabService, PagureService
 from packit_service.config import ServiceConfig
 from packit_service.models import (
     CoprBuildModel,
+    JobTriggerModel,
     get_sa_session,
     SRPMBuildModel,
     PullRequestModel,
@@ -148,6 +149,7 @@ def clean_db():
         session.query(BugzillaModel).delete()
 
         session.query(RunModel).delete()
+        session.query(JobTriggerModel).delete()
 
         session.query(GitBranchModel).delete()
         session.query(ProjectReleaseModel).delete()

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -11,7 +11,6 @@ from packit_service.models import (
     GitBranchModel,
     GitProjectModel,
     InstallationModel,
-    JobTriggerModel,
     JobTriggerModelType,
     KojiBuildModel,
     ProjectAuthenticationIssueModel,
@@ -71,7 +70,7 @@ def test_create_copr_build(clean_before_and_after, a_copr_build_for_pr):
     assert a_copr_build_for_pr.project_name == "the-project-name"
     assert a_copr_build_for_pr.owner == "the-owner"
     assert a_copr_build_for_pr.web_url == "https://copr.something.somewhere/123456"
-    assert a_copr_build_for_pr.srpm_build.logs == "some\nboring\nlogs"
+    assert a_copr_build_for_pr.get_srpm_build().logs == "some\nboring\nlogs"
     assert a_copr_build_for_pr.target == "fedora-42-x86_64"
     assert a_copr_build_for_pr.status == "pending"
     # Since datetime.utcnow() will return different results in every time its called,
@@ -155,7 +154,7 @@ def test_create_koji_build(clean_before_and_after, a_koji_build_for_pr):
     assert a_koji_build_for_pr.build_id == "123456"
     assert a_koji_build_for_pr.commit_sha == "80201a74d96c"
     assert a_koji_build_for_pr.web_url == "https://koji.something.somewhere/123456"
-    assert a_koji_build_for_pr.srpm_build.logs == "some\nboring\nlogs"
+    assert a_koji_build_for_pr.get_srpm_build().logs == "some\nboring\nlogs"
     assert a_koji_build_for_pr.target == "fedora-42-x86_64"
     assert a_koji_build_for_pr.status == "pending"
     # Since datetime.utcnow() will return different results in every time its called,
@@ -258,23 +257,23 @@ def test_errors_while_doing_db(clean_before_and_after):
         assert len(session.query(PullRequestModel).all()) == 1
 
 
-# return srpm builds in given range
-def test_get_srpm_builds(clean_before_and_after, srpm_build_model):
+def test_get_srpm_builds_in_give_range(
+    clean_before_and_after, srpm_build_model_with_new_run_for_pr
+):
     builds_list = SRPMBuildModel.get(0, 10)
-    assert len(builds_list) == 1
+    assert len(list(builds_list)) == 1
     assert builds_list[0].success is True
 
 
-# return all copr builds in table
 def test_get_all_builds(clean_before_and_after, multiple_copr_builds):
     builds_list = list(CoprBuildModel.get_all())
-    assert len(builds_list) == 3
-    # we just wanna check if result is iterable
-    # order doesn't matter, so all of them are set to pending in supplied data
-    assert builds_list[1].status == "pending"
+    assert len({builds_list[i].id for i in range(4)})
+    # All builds has to have exactly one RunModel connected
+    assert all(len(build.runs) == 1 for build in builds_list)
+    # All builds has to have a different RunModel connected.
+    assert len({build.runs[0] for build in builds_list}) == 4
 
 
-# return all copr builds with given build_id
 def test_get_all_build_id(clean_before_and_after, multiple_copr_builds):
     builds_list = list(CoprBuildModel.get_all_by_build_id(str(123456)))
     assert len(builds_list) == 2
@@ -289,21 +288,25 @@ def test_get_by_build_id(clean_before_and_after, multiple_copr_builds):
     build_a = CoprBuildModel.get_by_build_id(SampleValues.build_id, SampleValues.target)
     assert build_a.project_name == "the-project-name"
     assert build_a.target == "fedora-42-x86_64"
+
     build_b = CoprBuildModel.get_by_build_id(
         SampleValues.build_id, SampleValues.different_target
     )
     assert build_b.project_name == "the-project-name"
     assert build_b.target == "fedora-43-x86_64"
+
     build_c = CoprBuildModel.get_by_build_id(
-        SampleValues.different_build_id, SampleValues.target
+        SampleValues.another_different_build_id, SampleValues.target
     )
     assert build_c.project_name == "different-project-name"
 
 
 def test_get_all_by_owner_and_project(clean_before_and_after, multiple_copr_builds):
     builds_list = list(
-        CoprBuildModel.get_all_by_owner_and_project(
-            owner=SampleValues.owner, project_name=SampleValues.project
+        CoprBuildModel.get_all_by_owner_and_project_and_target(
+            owner=SampleValues.owner,
+            project_name=SampleValues.project,
+            target=SampleValues.target,
         )
     )
     assert len(builds_list) == 2
@@ -356,11 +359,14 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
         repo_name="the-repo-name",
         project_url="https://github.com/the-namespace/the-repo-name",
     )
-    pr1_trigger = JobTriggerModel.get_or_create(
-        type=JobTriggerModelType.pull_request, trigger_id=pr1.id
+    # SRPMBuildModel is (sadly) not shared between Koji and Copr builds.
+    srpm_build_for_copr, run_model_for_copr = SRPMBuildModel.create_with_new_run(
+        "asd\nqwe\n", success=True, trigger_model=pr1
     )
-    srpm_build = SRPMBuildModel.create("asd\nqwe\n", success=True, trigger_model=pr1)
-    copr_build = CoprBuildModel.get_or_create(
+    srpm_build_for_koji, run_model_for_koji = SRPMBuildModel.create_with_new_run(
+        "asd\nqwe\n", success=True, trigger_model=pr1
+    )
+    copr_build = CoprBuildModel.create(
         build_id="123456",
         commit_sha="687abc76d67d",
         project_name="SomeUser-hello-world-9",
@@ -368,26 +374,34 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
         web_url="https://copr.something.somewhere/123456",
         target=SampleValues.target,
         status="pending",
-        srpm_build=srpm_build,
-        trigger_model=pr1,
+        run_model=run_model_for_copr,
     )
-    koji_build = KojiBuildModel.get_or_create(
+    koji_build = KojiBuildModel.create(
         build_id="987654",
         commit_sha="687abc76d67d",
         web_url="https://copr.something.somewhere/123456",
         target=SampleValues.target,
         status="pending",
-        srpm_build=srpm_build,
-        trigger_model=pr1,
+        run_model=run_model_for_koji,
     )
 
-    assert copr_build in pr1_trigger.copr_builds
-    assert koji_build in pr1_trigger.koji_builds
-    assert srpm_build in pr1_trigger.srpm_builds
+    assert copr_build in pr1.get_copr_builds()
+    assert koji_build in pr1.get_koji_builds()
 
-    assert srpm_build.job_trigger.get_trigger_object() == pr1
-    assert copr_build.job_trigger.get_trigger_object() == pr1
-    assert koji_build.job_trigger.get_trigger_object() == pr1
+    assert srpm_build_for_copr in pr1.get_srpm_builds()
+    assert srpm_build_for_koji in pr1.get_srpm_builds()
+
+    assert copr_build.get_job_trigger_model() == koji_build.get_job_trigger_model()
+
+    assert srpm_build_for_copr.get_trigger_object() == pr1
+    assert srpm_build_for_koji.get_trigger_object() == pr1
+    assert copr_build.get_trigger_object() == pr1
+    assert koji_build.get_trigger_object() == pr1
+
+    assert len(koji_build.runs) == 1
+    assert koji_build.runs[0] == run_model_for_koji
+    assert len(copr_build.runs) == 1
+    assert copr_build.runs[0] == run_model_for_copr
 
 
 def test_tmt_test_run(clean_before_and_after, a_new_test_run_pr):
@@ -407,11 +421,18 @@ def test_tmt_test_run(clean_before_and_after, a_new_test_run_pr):
 
 def test_tmt_test_multiple_runs(clean_before_and_after, multiple_new_test_runs):
     assert multiple_new_test_runs
-    assert multiple_new_test_runs[1].pipeline_id == "123457"
-    assert multiple_new_test_runs[2].pipeline_id == "98765"
+    assert multiple_new_test_runs[0].pipeline_id == SampleValues.pipeline_id
+    assert multiple_new_test_runs[1].pipeline_id == SampleValues.different_pipeline_id
+
     with get_sa_session() as session:
         test_runs = session.query(TFTTestRunModel).all()
-        assert len(test_runs) == 3
+        assert len(test_runs) == 4
+        # Separate RunModel for each TFTTestRunModel
+        assert len({m.runs[0] for m in multiple_new_test_runs}) == 4
+        # Exactly one RunModel for each TFTTestRunModel
+        assert all(len(m.runs) == 1 for m in multiple_new_test_runs)
+        # Two JobTriggerModels:
+        assert len({m.get_trigger_object() for m in multiple_new_test_runs}) == 2
 
 
 def test_tmt_test_run_set_status(clean_before_and_after, a_new_test_run_pr):
@@ -430,18 +451,28 @@ def test_tmt_test_run_get_project(clean_before_and_after, a_new_test_run_pr):
     assert a_new_test_run_pr.get_project().repo_name == "the-repo-name"
 
 
+def test_tmt_test_run_get_copr_build(
+    clean_before_and_after, a_copr_build_for_pr, a_new_test_run_pr
+):
+    assert len(a_new_test_run_pr.runs) == 1
+    assert a_new_test_run_pr.runs[0].copr_build == a_copr_build_for_pr
+
+
 def test_tmt_test_run_get_pr_id(clean_before_and_after, a_new_test_run_pr):
     assert a_new_test_run_pr.status == TestingFarmResult.new
     assert a_new_test_run_pr.get_pr_id() == 342
 
 
-def test_tmt_test_run_set_web_url(clean_before_and_after, pr_model):
+def test_tmt_test_run_set_web_url(
+    clean_before_and_after, srpm_build_model_with_new_run_for_pr
+):
+    _, run_model = srpm_build_model_with_new_run_for_pr
     test_run_model = TFTTestRunModel.create(
         pipeline_id="123456",
         commit_sha="687abc76d67d",
         target=SampleValues.target,
         status=TestingFarmResult.new,
-        trigger_model=pr_model,
+        run_model=run_model,
     )
     assert not test_run_model.web_url
     new_url = (
@@ -451,66 +482,87 @@ def test_tmt_test_run_set_web_url(clean_before_and_after, pr_model):
     test_run_model.set_web_url(new_url)
     assert test_run_model.web_url == new_url
 
-    b = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
-    assert b
-    assert b.web_url == new_url
+    test_run_for_pipeline_id = TFTTestRunModel.get_by_pipeline_id(
+        test_run_model.pipeline_id
+    )
+    assert test_run_for_pipeline_id
+    assert test_run_for_pipeline_id.web_url == new_url
 
 
-def test_tmt_test_get_by_pipeline_id_pr(clean_before_and_after, pr_model):
+def test_tmt_test_get_by_pipeline_id_pr(
+    clean_before_and_after, pr_model, srpm_build_model_with_new_run_for_pr
+):
+    _, run_model = srpm_build_model_with_new_run_for_pr
     test_run_model = TFTTestRunModel.create(
         pipeline_id="123456",
         commit_sha="687abc76d67d",
         target=SampleValues.target,
         status=TestingFarmResult.new,
-        trigger_model=pr_model,
+        run_model=run_model,
     )
 
-    b = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
-    assert b
-    assert b.job_trigger.get_trigger_object() == pr_model
+    test_run_for_pipeline_id = TFTTestRunModel.get_by_pipeline_id(
+        test_run_model.pipeline_id
+    )
+    assert test_run_for_pipeline_id
+    assert test_run_for_pipeline_id.get_trigger_object() == pr_model
 
 
 def test_tmt_test_get_range(clean_before_and_after, multiple_new_test_runs):
     assert multiple_new_test_runs
     results = TFTTestRunModel.get_range(0, 10)
-    assert len(results) == 3
+    assert len(results) == 4
 
 
-def test_tmt_test_get_by_pipeline_id_branch_push(clean_before_and_after, branch_model):
+def test_tmt_test_get_by_pipeline_id_branch_push(
+    clean_before_and_after,
+    branch_model,
+    srpm_build_model_with_new_run_for_branch,
+    a_copr_build_for_branch_push,
+):
+    _, run_model = srpm_build_model_with_new_run_for_branch
     test_run_model = TFTTestRunModel.create(
         pipeline_id="123456",
         commit_sha="687abc76d67d",
         target=SampleValues.target,
         status=TestingFarmResult.new,
-        trigger_model=branch_model,
+        run_model=run_model,
     )
 
-    b = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
-    assert b
-    assert b.job_trigger.get_trigger_object() == branch_model
+    test_run = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
+    assert test_run
+    assert test_run.get_trigger_object() == branch_model
 
 
-def test_tmt_test_get_by_pipeline_id_release(clean_before_and_after, release_model):
+def test_tmt_test_get_by_pipeline_id_release(
+    clean_before_and_after,
+    release_model,
+    srpm_build_model_with_new_run_for_release,
+    a_copr_build_for_release,
+):
+    _, run_model = srpm_build_model_with_new_run_for_release
     test_run_model = TFTTestRunModel.create(
         pipeline_id="123456",
         commit_sha="687abc76d67d",
         target=SampleValues.target,
         status=TestingFarmResult.new,
-        trigger_model=release_model,
+        run_model=run_model,
     )
 
-    b = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
-    assert b
-    assert b.job_trigger.get_trigger_object() == release_model
+    test_run = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
+    assert test_run
+    assert test_run.get_trigger_object() == release_model
 
 
-def test_pr_id_property_for_srpm_build(srpm_build_model):
-    project_pr = srpm_build_model.get_pr_id()
+def test_pr_id_property_for_srpm_build(srpm_build_model_with_new_run_for_pr):
+    srpm_build, _ = srpm_build_model_with_new_run_for_pr
+    project_pr = srpm_build.get_pr_id()
     assert isinstance(project_pr, int)
 
 
-def test_project_property_for_srpm_build(srpm_build_model):
-    project = srpm_build_model.get_project()
+def test_project_property_for_srpm_build(srpm_build_model_with_new_run_for_pr):
+    srpm_build, _ = srpm_build_model_with_new_run_for_pr
+    project = srpm_build.get_project()
     assert isinstance(project, GitProjectModel)
     assert project.namespace == "the-namespace"
     assert project.repo_name == "the-repo-name"
@@ -610,7 +662,7 @@ def test_get_installation_by_account(
 def test_pr_get_copr_builds(
     clean_before_and_after, a_copr_build_for_pr, different_pr_model
 ):
-    pr_model = a_copr_build_for_pr.job_trigger.get_trigger_object()
+    pr_model = a_copr_build_for_pr.get_trigger_object()
     assert a_copr_build_for_pr in pr_model.get_copr_builds()
     assert not different_pr_model.get_copr_builds()
 
@@ -618,15 +670,16 @@ def test_pr_get_copr_builds(
 def test_pr_get_koji_builds(
     clean_before_and_after, a_koji_build_for_pr, different_pr_model
 ):
-    pr_model = a_koji_build_for_pr.job_trigger.get_trigger_object()
+    pr_model = a_koji_build_for_pr.get_trigger_object()
     assert a_koji_build_for_pr in pr_model.get_koji_builds()
     assert not different_pr_model.get_koji_builds()
 
 
 def test_pr_get_srpm_builds(
-    clean_before_and_after, a_copr_build_for_pr, srpm_build_model
+    clean_before_and_after, srpm_build_model_with_new_run_for_pr, a_copr_build_for_pr
 ):
-    pr_model = a_copr_build_for_pr.job_trigger.get_trigger_object()
+    srpm_build_model, _ = srpm_build_model_with_new_run_for_pr
+    pr_model = a_copr_build_for_pr.get_trigger_object()
     assert srpm_build_model in pr_model.get_srpm_builds()
 
 

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -6,21 +6,21 @@ from datetime import datetime, timedelta
 from sqlalchemy.exc import ProgrammingError
 
 from packit_service.models import (
-    ProjectReleaseModel,
-    PullRequestModel,
-    JobTriggerModelType,
-    GitBranchModel,
+    BugzillaModel,
     CoprBuildModel,
-    get_sa_session,
-    KojiBuildModel,
-    SRPMBuildModel,
-    JobTriggerModel,
-    TestingFarmResult,
-    TFTTestRunModel,
+    GitBranchModel,
     GitProjectModel,
     InstallationModel,
-    BugzillaModel,
+    JobTriggerModel,
+    JobTriggerModelType,
+    KojiBuildModel,
     ProjectAuthenticationIssueModel,
+    ProjectReleaseModel,
+    PullRequestModel,
+    SRPMBuildModel,
+    TFTTestRunModel,
+    TestingFarmResult,
+    get_sa_session,
 )
 from tests_requre.conftest import SampleValues
 

--- a/tests_requre/database/test_tasks.py
+++ b/tests_requre/database/test_tasks.py
@@ -75,10 +75,10 @@ def packit_build_752():
         project_url="https://github.com/packit-service/packit",
     )
 
-    srpm_build = SRPMBuildModel.create(
+    srpm_build, run_model = SRPMBuildModel.create_with_new_run(
         "asd\nqwe\n", success=True, trigger_model=pr_model
     )
-    yield CoprBuildModel.get_or_create(
+    yield CoprBuildModel.create(
         build_id=str(BUILD_ID),
         commit_sha="687abc76d67d",
         project_name="packit-service-packit-752",
@@ -89,8 +89,7 @@ def packit_build_752():
         ),
         target="fedora-rawhide-x86_64",
         status="pending",
-        srpm_build=srpm_build,
-        trigger_model=pr_model,
+        run_model=run_model,
     )
 
 

--- a/tests_requre/service/test_views.py
+++ b/tests_requre/service/test_views.py
@@ -11,7 +11,7 @@ def test_get_build_logs_for_build_pr(clean_before_and_after, a_copr_build_for_pr
     assert "Builds for the-namespace/the-repo-name: PR #342" in response
     assert a_copr_build_for_pr.status in response
     assert a_copr_build_for_pr.target in response
-    assert str(a_copr_build_for_pr.srpm_build_id) in response
+    assert str(a_copr_build_for_pr.get_srpm_build().id) in response
     assert a_copr_build_for_pr.build_logs_url in response
     assert f"Status: {a_copr_build_for_pr.status}" in response
     assert "For more info see" in response
@@ -36,7 +36,7 @@ def test_get_build_logs_for_build_branch_push(
     assert "Builds for the-namespace/the-repo-name: branch build-branch" in response
     assert a_copr_build_for_branch_push.status in response
     assert a_copr_build_for_branch_push.target in response
-    assert str(a_copr_build_for_branch_push.srpm_build_id) in response
+    assert str(a_copr_build_for_branch_push.get_srpm_build().id) in response
     assert a_copr_build_for_branch_push.build_logs_url in response
     assert f"Status: {a_copr_build_for_branch_push.status}" in response
     assert "For more info see" in response
@@ -61,7 +61,7 @@ def test_get_build_logs_for_build_release(
     assert "Builds for the-namespace/the-repo-name: release v1.0.2" in response
     assert a_copr_build_for_release.status in response
     assert a_copr_build_for_release.target in response
-    assert str(a_copr_build_for_release.srpm_build_id) in response
+    assert str(a_copr_build_for_release.get_srpm_build().id) in response
     assert a_copr_build_for_release.build_logs_url in response
     assert f"Status: {a_copr_build_for_release.status}" in response
     assert "For more info see" in response
@@ -76,8 +76,11 @@ def test_get_build_logs_for_build_release(
     )
 
 
-def test_srpm_logs_view(client, clean_before_and_after, srpm_build_model):
+def test_srpm_logs_view(
+    client, clean_before_and_after, srpm_build_model_with_new_run_for_pr
+):
     # Logs view uses the id of the SRPMBuildModel not CoprBuildModel
+    srpm_build_model, _ = srpm_build_model_with_new_run_for_pr
     response = client.get(
         url_for("builds.get_srpm_build_logs_by_id", id_=srpm_build_model.id)
     )
@@ -99,7 +102,7 @@ def test_copr_build_info_view(client, clean_before_and_after, multiple_copr_buil
     assert "Builds for the-namespace/the-repo-name: PR #342" in response
     assert build.status in response
     assert build.target in response
-    assert str(build.srpm_build_id) in response
+    assert str(build.get_srpm_build().id) in response
     assert build.build_logs_url in response
     assert f"Status: {build.status}" in response
     assert "For more info see" in response
@@ -115,7 +118,7 @@ def test_koji_build_info_view(client, clean_before_and_after, a_koji_build_for_p
     assert "Builds for the-namespace/the-repo-name: PR #342" in response
     assert a_koji_build_for_pr.status in response
     assert a_koji_build_for_pr.target in response
-    assert str(a_koji_build_for_pr.srpm_build_id) in response
+    assert str(a_koji_build_for_pr.get_srpm_build().id) in response
     assert a_koji_build_for_pr.build_logs_url in response
     assert f"Status: {a_koji_build_for_pr.status}" in response
     assert "For more info see" in response


### PR DESCRIPTION
Introduce a `RunModel` that represents one pipeline.

Fixes #895 

Connects `JobTriggerModel` (and triggers like `PullRequestModel` via that model) with
build/test models like `SRPMBuildModel`, `CoprBuildModel`, `KojiBuildModel`, and `TFTTestRunModel`.

* One model of each build/test model can be connected.
* Each build/test model can be connected to multiple RunModels (e.g. on retrigger).
* Each RunModel has to be connected to exactly one `JobTriggerModel`.
* There can be multiple `RunModel`s for one `JobTriggerModel`.
  (e.g. For each push to PR, there will be a new `RunModel`, but the same `JobTriggerModel`.)


TODO:
- [x] Fix the tests.
- [x] Fix database tests
- [x] Improve/clean the database tests
- [x] Prepare migrations.
- [x] Test the migration on real data (db dump of prod/stage)
    - [x] stage
    - [x] prod
- [x] Add timestamp for `RunModel` and `TFTTestRunModel`.