### PR TITLE
[parse TF results] return original commit_sha as ref in case of install test

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -16,6 +16,7 @@ SANDCASTLE_PVC = "SANDCASTLE_PVC"
 CONFIG_FILE_NAME = "packit-service.yaml"
 
 TESTING_FARM_API_URL = "https://api.dev.testing-farm.io/v0.1/"
+TESTING_FARM_INSTALLABILITY_TEST_URL = "https://gitlab.com/testing-farm/tests"
 
 MSG_RETRIGGER = (
     "You can retrigger the {job} by adding a comment (`/packit {command}`) "

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -13,6 +13,7 @@ from packit.config.package_config import PackageConfig
 from packit.exceptions import PackitConfigException
 
 from packit_service.config import ServiceConfig
+from packit_service.constants import TESTING_FARM_INSTALLABILITY_TEST_URL
 from packit_service.models import CoprBuildModel, TFTTestRunModel, TestingFarmResult
 from packit_service.sentry_integration import send_to_sentry
 from packit_service.service.events import EventData
@@ -109,7 +110,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             "api_key": self.service_config.testing_farm_secret,
             "test": {
                 "fmf": {
-                    "url": "https://gitlab.com/testing-farm/tests",
+                    "url": TESTING_FARM_INSTALLABILITY_TEST_URL,
                 },
             },
             "environments": [

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -130,9 +130,8 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         }
 
     def is_fmf_configured(self) -> bool:
-        source_project = self.project.get_pr(self.metadata.pr_id).source_project
         try:
-            source_project.get_file_content(
+            self.project.get_file_content(
                 path=".fmf/version", ref=self.metadata.commit_sha
             )
             return True


### PR DESCRIPTION
Fixes https://sentry.io/organizations/red-hat-0p/issues/1809076278