### PR TITLE
Support testing in toolbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,5 +90,16 @@ check-inside-openshift: service worker test_image
 check-inside-openshift-zuul: test_image
 	ANSIBLE_STDOUT_CALLBACK=debug $(AP) files/check-inside-openshift.yaml
 
+setup-inside-toolbox:
+	@if [[ ! -e /run/.toolboxenv ]]; then \
+		echo "Not running in a toolbox!"; \
+		exit 1; \
+	fi
+	dnf install -y ansible
+	SOURCE_BRANCH=$(SOURCE_BRANCH) ANSIBLE_STDOUT_CALLBACK=debug $(AP) files/setup-toolbox.yaml
+
+check-inside-toolbox:
+	bash files/test_in_toolbox.sh packit_service
+
 requre-purge-files:
 	pre-commit run requre-purge --all-files --verbose --hook-stage manual

--- a/files/setup-toolbox.yaml
+++ b/files/setup-toolbox.yaml
@@ -1,0 +1,4 @@
+---
+- include: install-deps.yaml
+- include: install-deps-worker.yaml
+- include: recipe-tests.yaml

--- a/files/test_in_toolbox.sh
+++ b/files/test_in_toolbox.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+TOOLBOX_NAME=$1
+
+(toolbox list | grep -q $TOOLBOX_NAME) || {
+	toolbox create -c $TOOLBOX_NAME
+	toolbox run -c $TOOLBOX_NAME sudo make setup-toolbox
+}
+
+toolbox run -c $TOOLBOX_NAME make check


### PR DESCRIPTION
- Add Makefile target for
  - Setting up from inside toolbox
  - Testing in toolbox (checks if exists + sets it up if necessary)
- Script that checks if toolbox exists, otherwise sets it up
- Playbook with necesary targets

Signed-off-by: Matej Focko <mfocko@redhat.com>