### PR TITLE
Speed up CI by using pre-built tests image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,9 +199,6 @@ We have multiple test categories within packit-service:
 
 You can run unit and integration tests locally in a container:
 
-    docker pull docker.io/usercont/base && \
-    make worker && \
-    make test_image && \
     make check_in_container
 
 To select a subset of the whole test suite, set `TEST_TARGET`. For example to

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASE_IMAGE ?= docker.io/usercont/base
+BASE_IMAGE ?= quay.io/packit/base
 SERVICE_IMAGE ?= docker.io/usercont/packit-service:dev
 WORKER_IMAGE ?= docker.io/usercont/packit-worker:dev
 WORKER_IMAGE_PROD ?= docker.io/usercont/packit-worker:prod

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ check:
 test_image: files/install-deps-worker.yaml files/install-deps.yaml files/recipe-tests.yaml
 	$(CONTAINER_ENGINE) build --rm -t $(TEST_IMAGE) -f files/docker/Dockerfile.tests --build-arg SOURCE_BRANCH=$(SOURCE_BRANCH) .
 
-check_in_container: test_image
+check_in_container:
+	$(CONTAINER_ENGINE) pull $(TEST_IMAGE)
 	@# don't use -ti here in CI, TTY is not allocated in zuul
 	echo $(SOURCE_BRANCH)
 	$(CONTAINER_ENGINE) run --rm \
@@ -75,7 +76,7 @@ check-in-container-tomas:
 		$(TEST_IMAGE) make check "TEST_TARGET=$(TEST_TARGET)"
 
 # deploy a pod with tests and run them
-check-inside-openshift: service worker test_image
+check-inside-openshift: service worker
 	@# http://timmurphy.org/2015/09/27/how-to-get-a-makefile-directory-path/
 	@# sadly the hostPath volume doesn't work:
 	@#   Invalid value: "hostPath": hostPath volumes are not allowed to be used
@@ -84,7 +85,7 @@ check-inside-openshift: service worker test_image
 	ANSIBLE_STDOUT_CALLBACK=debug $(AP) -K -e path_to_secrets=$(PATH_TO_SECRETS) files/deployment.yaml
 	ANSIBLE_STDOUT_CALLBACK=debug $(AP) files/check-inside-openshift.yaml
 
-check-inside-openshift-zuul: test_image
+check-inside-openshift-zuul:
 	ANSIBLE_STDOUT_CALLBACK=debug $(AP) files/check-inside-openshift.yaml
 
 setup-inside-toolbox:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BASE_IMAGE ?= quay.io/packit/base
 SERVICE_IMAGE ?= docker.io/usercont/packit-service:dev
 WORKER_IMAGE ?= docker.io/usercont/packit-worker:dev
 WORKER_IMAGE_PROD ?= docker.io/usercont/packit-worker:prod
-TEST_IMAGE ?= packit-service-tests
+TEST_IMAGE ?= quay.io/packit/packit-service-tests
 TEST_TARGET ?= ./tests/unit ./tests/integration/
 CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
 ANSIBLE_PYTHON ?= /usr/bin/python3
@@ -32,12 +32,9 @@ check:
 	find . -name "*.pyc" -exec rm {} \;
 	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --color=$(COLOR) --verbose --showlocals --cov=packit_service --cov-report=$(COV_REPORT) $(TEST_TARGET)
 
-# first run 'make worker'
-test_image: files/install-deps.yaml files/recipe-tests.yaml
+test_image: files/install-deps-worker.yaml files/install-deps.yaml files/recipe-tests.yaml
 	$(CONTAINER_ENGINE) build --rm -t $(TEST_IMAGE) -f files/docker/Dockerfile.tests --build-arg SOURCE_BRANCH=$(SOURCE_BRANCH) .
 
-# If you haven't run this for some time, run 'make worker' first.
-# 'worker' is not a dependency here because we don't want to rebuild images everytime.
 check_in_container: test_image
 	@# don't use -ti here in CI, TTY is not allocated in zuul
 	echo $(SOURCE_BRANCH)

--- a/files/check-inside-openshift.yaml
+++ b/files/check-inside-openshift.yaml
@@ -40,6 +40,46 @@
       command: oc whoami --show-server
       register: oc_server
 
+    - name: Create PVC for volume to be mounted to /src
+      k8s:
+        host: "{{ oc_server.stdout }}"
+        api_key: "{{ kubeconfig_token.stdout }}"
+        validate_certs: no
+        namespace: "{{ oc_project.stdout }}"
+        resource_definition: "{{ lookup('file', './test-src-pvc.yaml') }}"
+    - name: Start pod which mounts test-src-pvc to /src
+      k8s:
+        host: "{{ oc_server.stdout }}"
+        api_key: "{{ kubeconfig_token.stdout }}"
+        validate_certs: no
+        namespace: "{{ oc_project.stdout }}"
+        resource_definition: "{{ lookup('file', './test-src-mounter.yaml') }}"
+    - name: Wait for the pod to be running so we can rsync the files
+      k8s:
+        host: "{{ oc_server.stdout }}"
+        api_key: "{{ kubeconfig_token.stdout }}"
+        validate_certs: no
+        namespace: "{{ oc_project.stdout }}"
+        name: mount-src
+        api_version: v1
+        kind: Pod
+        wait: yes
+        wait_condition:
+          type: Ready
+        wait_timeout: 100
+    - name: rsync ../ to pod:/src
+      command: oc rsync ../ mount-src:/src --no-perms
+    - name: Delete the pod with mounted /src
+      k8s:
+        host: "{{ oc_server.stdout }}"
+        api_key: "{{ kubeconfig_token.stdout }}"
+        validate_certs: no
+        namespace: "{{ oc_project.stdout }}"
+        name: mount-src
+        api_version: v1
+        kind: Pod
+        state: absent
+
     - name: Delete old test job if it exists
       k8s:
         host: "{{ oc_server.stdout }}"

--- a/files/check-inside-openshift.yaml
+++ b/files/check-inside-openshift.yaml
@@ -77,10 +77,6 @@
     # https://github.com/ansible/ansible/issues/55221#issuecomment-501792651
     - name: create test job in openshift
       shell: oc process -f {{ test_job_template_path }} | oc create -f -
-    - name: Create directory for response files
-      file:
-        path: ../tests/test_data
-        state: directory
     - name: Wait for tests to finish
       k8s:
         host: "{{ oc_server.stdout }}"

--- a/files/check-inside-openshift.yaml
+++ b/files/check-inside-openshift.yaml
@@ -39,6 +39,7 @@
     - name: get server
       command: oc whoami --show-server
       register: oc_server
+
     - name: Delete old test job if it exists
       k8s:
         host: "{{ oc_server.stdout }}"
@@ -73,6 +74,7 @@
         wait_condition:
           type: Complete
         wait_timeout: 300
+
     # Why k8s module can't be used here:
     # https://github.com/ansible/ansible/issues/55221#issuecomment-501792651
     - name: create test job in openshift
@@ -93,17 +95,19 @@
       ignore_errors: yes # we want to see logs either way
     - name: get test results
       k8s_info:
-        kind: Job
         host: "{{ oc_server.stdout }}"
         api_key: "{{ kubeconfig_token.stdout }}"
         validate_certs: no
         namespace: "{{ oc_project.stdout }}"
+        kind: Job
+        name: "{{ tests_job_name }}"
       register: test_results
     - name: get test logs
       command: oc logs job/{{ tests_job_name }}
       # if the tests fail, halt
     - name: get test result
       shell: oc get job {{ tests_job_name }} -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' | grep True
+
       # run a new pod, mount the PV with the recorded responses to the new pod
     - name: start pod which will gather the data
       shell: oc process -f {{ get_data_template_path }} | oc create -f -

--- a/files/docker/Dockerfile
+++ b/files/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Image for the web service (httpd), for celery worker see files/docker/Dockerfile.worker
 
-FROM docker.io/usercont/base
+FROM quay.io/packit/base
 
 ARG SOURCE_BRANCH
 RUN  if [[ -z $SOURCE_BRANCH ]]; then \

--- a/files/docker/Dockerfile.tests
+++ b/files/docker/Dockerfile.tests
@@ -1,6 +1,6 @@
 # For running tests locally, see check_in_container target in Makefile
 
-FROM docker.io/usercont/packit-worker:dev
+FROM quay.io/packit/base
 
 ARG SOURCE_BRANCH
 RUN  if [[ -z $SOURCE_BRANCH ]]; then \
@@ -9,13 +9,25 @@ echo -e "\nMissing SOURCE_BRANCH build argument! Please add \
 This is the branch used when installing other Packit projects (e.g. ogr, packit).\n" && exit 1;\
 fi
 
-# Since we use worker base image, we need to install service deps manually
-RUN ansible-playbook -vv -c local -i localhost, files/install-deps.yaml
+ENV USER=packit \
+    HOME=/home/packit
 
-RUN set -ex; mkdir -p ${HOME}/.config \
-    && ln -s $(pwd)/files/packit-service.yaml ${HOME}/.config/packit-service.yaml \
-    && ansible-playbook -vv -c local -i localhost, files/recipe-tests.yaml
+WORKDIR /src
 
-# we are doing the same here as in worker Df so that we don't need to rerun the
-# playbook above for every code change: iterating fast <3
+COPY files/ ./files/
+
+# Install worker & service & tests deps
+RUN ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml && \
+    ansible-playbook -vv -c local -i localhost, files/install-deps.yaml && \
+    ansible-playbook -vv -c local -i localhost, files/recipe-tests.yaml && \
+    dnf clean all
+
+RUN set -ex; \
+    mkdir -m 0777 /sandcastle && \
+    mkdir -m 0776 -p ${HOME} && \
+    mkdir -p ${HOME}/.config && \
+    ln -s $(pwd)/files/packit-service.yaml ${HOME}/.config/packit-service.yaml
+
 COPY . ./
+
+RUN pip3 install -e . && pip3 check && rm -rf ~/.cache/*

--- a/files/docker/Dockerfile.worker
+++ b/files/docker/Dockerfile.worker
@@ -1,6 +1,6 @@
 # Celery worker which runs tasks (packit) from the web service
 
-FROM docker.io/usercont/base
+FROM quay.io/packit/base
 
 ARG SOURCE_BRANCH
 RUN  if [[ -z $SOURCE_BRANCH ]]; then \

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -1,11 +1,11 @@
 ---
-- name: Install dependencies for packit-service worker.
+- name: Install dependencies for packit-service worker
   hosts: all
   vars:
     source_branch: "{{ lookup('env', 'SOURCE_BRANCH') }}"
   tasks:
     - import_tasks: tasks/process-source-branch.yaml
-    - name: Install all RPM/python packages needed to run packit-service worker.
+    - name: Install all RPM/python packages needed to run packit-service worker
       dnf:
         name:
           - python3-ipdb # for easy debugging

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -1,11 +1,11 @@
 ---
-- name: Install dependencies for packit-service.
+- name: Install dependencies for packit-service
   hosts: all
   vars:
     source_branch: "{{ lookup('env', 'SOURCE_BRANCH') }}"
   tasks:
     - import_tasks: tasks/process-source-branch.yaml
-    - name: Install all RPM/python packages needed to run packit-service.
+    - name: Install all RPM/python packages needed to run packit-service
       dnf:
         name:
           - python3-ipdb # for easy debugging

--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -12,7 +12,7 @@
     - name: Install pip deps
       pip:
         name:
-          - git+https://github.com/packit/requre.git
+          - requre
           - pytest
           - pytest-cov
           - pytest-flask

--- a/files/test-in-openshift-get-data.yaml
+++ b/files/test-in-openshift-get-data.yaml
@@ -18,7 +18,7 @@ objects:
       restartPolicy: Never
       containers:
         - name: packit-tests
-          image: packit-service-tests:latest
+          image: quay.io/packit/packit-service-tests:latest
           imagePullPolicy: Never # IfNotPresent
           workingDir: /src
           volumeMounts:

--- a/files/test-in-openshift-get-data.yaml
+++ b/files/test-in-openshift-get-data.yaml
@@ -19,7 +19,8 @@ objects:
       containers:
         - name: packit-tests
           image: quay.io/packit/packit-service-tests:latest
-          imagePullPolicy: Never # IfNotPresent
+          # If tag is latest, defaults to Always.
+          # imagePullPolicy: Never # IfNotPresent
           workingDir: /src
           volumeMounts:
             - mountPath: /tmp/test_data

--- a/files/test-in-openshift.yaml
+++ b/files/test-in-openshift.yaml
@@ -25,7 +25,8 @@ objects:
           containers:
             - name: packit-tests
               image: quay.io/packit/packit-service-tests:latest
-              imagePullPolicy: Never # IfNotPresent
+              # If tag is latest, defaults to Always.
+              # imagePullPolicy: Never # IfNotPresent
               workingDir: /src
               env:
                 - name: POSTGRESQL_USER

--- a/files/test-in-openshift.yaml
+++ b/files/test-in-openshift.yaml
@@ -24,7 +24,7 @@ objects:
           restartPolicy: Never
           containers:
             - name: packit-tests
-              image: packit-service-tests:latest
+              image: quay.io/packit/packit-service-tests:latest
               imagePullPolicy: Never # IfNotPresent
               workingDir: /src
               env:

--- a/files/test-in-openshift.yaml
+++ b/files/test-in-openshift.yaml
@@ -18,6 +18,9 @@ objects:
             - name: packit-config
               secret:
                 secretName: packit-config
+            - name: test-src-pv
+              persistentVolumeClaim:
+                claimName: test-src-pvc
             - name: test-data-pv
               persistentVolumeClaim:
                 claimName: test-data-pvc
@@ -54,8 +57,10 @@ objects:
                   mountPath: /secrets
                 - name: packit-config
                   mountPath: /home/packit/.config
-                - mountPath: /tmp/test_data
-                  name: test-data-pv
+                - name: test-src-pv
+                  mountPath: /src
+                - name: test-data-pv
+                  mountPath: /tmp/test_data
               command: ["bash", "/src/files/run_tests.sh"]
       backoffLimit: 1
   - apiVersion: v1

--- a/files/test-src-mounter.yaml
+++ b/files/test-src-mounter.yaml
@@ -1,0 +1,18 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: mount-src
+spec:
+  volumes:
+    - name: test-src-pv
+      persistentVolumeClaim:
+        claimName: test-src-pvc
+  restartPolicy: Never
+  containers:
+    - name: packit-tests
+      image: quay.io/packit/packit-service-tests:latest
+      volumeMounts:
+        - mountPath: /src
+          name: test-src-pv
+      command: ["bash", "-c", "sleep 10000"]

--- a/files/test-src-pvc.yaml
+++ b/files/test-src-pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-src-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/files/zuul-tests-requre.yaml
+++ b/files/zuul-tests-requre.yaml
@@ -10,21 +10,6 @@
       file:
         path: "{{ project_dir }}/secrets/dev"
         state: directory
-    #  - name: Copy secrets to packit-service dir
-    #    copy:
-    #      src: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/packit-service/deployment'].src_dir }}/secrets/dev/{{ item }}"
-    #      dest: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/secrets/dev/{{ item }}"
-    #      remote_src: yes
-    #    with_items:
-    #    - packit-service.yaml
-    #    - copr
-    #    - ssh_config
-    #    - fedora.toml
-    #    - private-key.pem
-    #    - privkey.pem
-    #    - fullchain.pem
-    #    - fedora.keytab
-    #    - sentry_key
     - name: Run tests which are executed within openshift
       command: make check-inside-openshift-zuul
       args:

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -12,8 +12,8 @@
           - podman
         state: present
       become: true
-    - name: Build the worker image
-      command: "make worker"
+    - name: Build the tests image
+      command: "make test_image"
       args:
         chdir: "{{ project_dir }}"
       environment:

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -12,12 +12,6 @@
           - podman
         state: present
       become: true
-    - name: Build the tests image
-      command: "make test_image"
-      args:
-        chdir: "{{ project_dir }}"
-      environment:
-        SOURCE_BRANCH: "{{ zuul.branch }}"
     - name: Run tests within a container
       command: "make check_in_container"
       args:


### PR DESCRIPTION
We now have [tests image in Quay.io](https://quay.io/repository/packit/packit-service-tests) which is re-built on a push to this repo.
When we run tests, we don't rebuild the image (as we used to), but use the `quay.io/packit/packit-service-tests` and mount sources into its `/src`.

Pros:
- [packit-service-tests](https://github.com/packit/packit-service/blob/main/.zuul.yaml#L14) run about 2min instead of 8min
- [packit-service-tests-requre](https://github.com/packit/packit-service/blob/main/.zuul.yaml#L20) are a bit faster, around 17min instead of 18min - the most time takes spawning an Openshift cluster and building `worker:dev` & `service:dev`. It's actually 2 tests (1. tests with pre-recorded responses, 2. deployment test), but we run them together because spawning an Openshift cluster is such an expensive operation. If we split it, we could use pre-built `worker:dev` & `service:dev` for the requre test, which would speed up it a lot. But we need to build them for the deployment test anyway, which would again take (with spawning a cluster for it) about 18min so all tests together would take the same time as now.

Cons:
- If a PR adds a new dependency to [worker](https://github.com/packit/packit-service/blob/main/files/install-deps-worker.yaml) or [service](https://github.com/packit/packit-service/blob/main/files/install-deps.yaml) that dependency won't be in the test image during the tests run and the tests will probably fail. Work-around is to `make test_image` and `podman push`.