### PR TITLE
Do not log failed GitLab status as error + refactor later

### DIFF
--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -175,7 +175,7 @@ class StatusReporter:
             if e.response_code != 400:
                 # 403: No permissions to set status, falling back to comment
                 # 404: Commit has not been found, e.g. used target project on GitLab
-                logger.error(
+                logger.debug(
                     f"Failed to set status for {self.commit_sha}, commenting on"
                     f" commit as a fallback: {str(e)}"
                 )

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -26,6 +26,7 @@ from celery import Celery
 from copr.v3 import Client
 from flexmock import flexmock
 
+import gitlab
 import packit
 import packit_service
 from ogr.abstract import GitProject, CommitStatus
@@ -1435,10 +1436,13 @@ def test_copr_build_success_gitlab_comment(gitlab_mr_event):
         )
     )
     flexmock(GitProject).should_receive("request_access").and_return()
-    flexmock(GitProject).should_receive("pr_comment").and_return()
     flexmock(BaseBuildJobHelper).should_receive("is_reporting_allowed").and_return(
         False
     )
+    flexmock(GitProject).should_receive("set_commit_status").and_raise(
+        gitlab.GitlabCreateError(response_code=403)
+    )
+    flexmock(GitProject).should_receive("commit_comment").and_return()
     flexmock(GitProject).should_receive("get_pr").and_return(
         flexmock(
             comment=flexmock().should_receive("comment").and_return().mock(),


### PR DESCRIPTION
TODO:
- [ ] refactor
   **currently**: if there are no permissions we ask for them and report via comment (PR or commit comment)
   I've noticed TF bypasses it and posts commit comments... with regards to refactoring I suggest to just post commit comments as a fallback; on the other hand, there is also an option to use `.comment` that prefers PR comment to commit comment

Since the status is more tied to the commit itself rather than PR (and commit comments are shown in PRs), I suggest commenting only on commits.
   

Signed-off-by: Matej Focko <mfocko@redhat.com>