### PR TITLE
[build targets] use targets both from build job and test job

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -156,31 +156,28 @@ class BaseBuildJobHelper:
         """
         Return the targets to build.
 
-        1. If the job is not defined, use the test_targets.
-        2. If the job is defined, but not the targets, use "fedora-stable" alias otherwise.
+        1. Use targets defined for build job and targets defined for test job.
+        2. Use "fedora-stable" alias if neither defined.
         """
-        if (
-            (not self.job_build or not self.job_build.metadata.targets)
-            and self.job_tests
-            and self.job_tests.metadata.targets
-        ):
-            return self.configured_tests_targets
+        targets = set()
+        if self.job_build:
+            targets.update(self.job_build.metadata.targets)
 
-        if self.job_build and self.job_build.metadata.targets:
-            return self.job_build.metadata.targets
+        if self.job_tests:
+            targets.update(self.job_tests.metadata.targets)
 
-        return {"fedora-stable"}
+        return targets or {"fedora-stable"}
 
     @property
     def configured_tests_targets(self) -> Set[str]:
         """
-        Return the list of chroots used in the testing farm.
-        Has to be a sub-set of the `build_chroots`.
+        Return the targets used in the testing farm.
+        Has to be a sub-set of the `configured_build_targets`.
 
-        Return an empty list if there is no job configured.
+        Return an empty set if there is no test job configured.
 
         If not defined:
-        1. use the build_chroots if the job si configured
+        1. use the `configured_build_targets` if the build job is configured
         2. use "fedora-stable" alias otherwise
         """
         if not self.job_tests:

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -1,7 +1,6 @@
 import pytest
 from flexmock import flexmock
 
-import packit_service
 from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
 from packit.config.job_config import JobMetadataConfig
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
@@ -34,7 +33,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 )
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
+            set(STABLE_VERSIONS),
             set(),
             id="build_with_targets",
         ),
@@ -47,7 +46,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 )
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
+            set(STABLE_VERSIONS),
             set(),
             id="build_with_targets&pr_comment",
         ),
@@ -60,7 +59,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 )
             ],
             JobConfigTriggerType.release,
-            STABLE_CHROOTS,
+            set(STABLE_VERSIONS),
             set(),
             id="build_with_targets&release",
         ),
@@ -73,7 +72,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 )
             ],
             JobConfigTriggerType.commit,
-            STABLE_CHROOTS,
+            set(STABLE_VERSIONS),
             set(),
             id="build_with_targets&push",
         ),
@@ -91,7 +90,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 ),
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
+            set(STABLE_VERSIONS),
             set(),
             id="build_with_targets&pull_request_with_pr_and_push_defined",
         ),
@@ -109,7 +108,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 ),
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
+            set(STABLE_VERSIONS),
             set(),
             id="build_with_targets&pr_comment_with_pr_and_push_defined",
         ),
@@ -127,7 +126,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 ),
             ],
             JobConfigTriggerType.commit,
-            STABLE_CHROOTS,
+            set(STABLE_VERSIONS),
             set(),
             id="build_with_targets&push_with_pr_and_push_defined",
         ),
@@ -139,7 +138,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 )
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
+            {"fedora-stable"},
             set(),
             id="build_without_targets",
         ),
@@ -151,8 +150,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 )
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
-            STABLE_CHROOTS,
+            {"fedora-stable"},
+            {"fedora-stable"},
             id="test_without_targets",
         ),
         pytest.param(
@@ -164,8 +163,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 )
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
-            STABLE_CHROOTS,
+            set(STABLE_VERSIONS),
+            set(STABLE_VERSIONS),
             id="test_with_targets",
         ),
         pytest.param(
@@ -180,8 +179,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 ),
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
-            STABLE_CHROOTS,
+            {"fedora-stable"},
+            {"fedora-stable"},
             id="build_without_target&test_without_targets",
         ),
         pytest.param(
@@ -197,8 +196,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 ),
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
-            STABLE_CHROOTS,
+            set(STABLE_VERSIONS),
+            set(STABLE_VERSIONS),
             id="build_with_target&test_without_targets",
         ),
         pytest.param(
@@ -214,8 +213,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 ),
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
-            STABLE_CHROOTS,
+            set(STABLE_VERSIONS),
+            set(STABLE_VERSIONS),
             id="build_without_target&test_with_targets",
         ),
         pytest.param(
@@ -251,7 +250,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 ),
             ],
             JobConfigTriggerType.commit,
-            STABLE_CHROOTS,
+            {"fedora-stable"},
             set(),
             id="build[pr+commit]&test[pr]&commit",
         ),
@@ -271,8 +270,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 ),
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
-            STABLE_CHROOTS,
+            {"fedora-stable"},
+            {"fedora-stable"},
             id="build[pr+commit]&test[pr]&pr",
         ),
         pytest.param(
@@ -288,8 +287,8 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 ),
             ],
             JobConfigTriggerType.commit,
-            STABLE_CHROOTS,
-            STABLE_CHROOTS,
+            {"fedora-stable"},
+            {"fedora-stable"},
             id="build[pr+commit]&test[commit]&commit",
         ),
         pytest.param(
@@ -305,7 +304,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.commit),
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
+            {"fedora-stable"},
             set(),
             id="build[pr+commit]&test[commit]&pr",
         ),
@@ -328,7 +327,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 ),
             ],
             JobConfigTriggerType.commit,
-            STABLE_CHROOTS,
+            {"fedora-stable"},
             set(),
             id="build[pr+commit+release]&test[pr]&commit",
         ),
@@ -352,20 +351,25 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
         pytest.param(
             [
                 JobConfig(
-                    type=JobType.production_build,
+                    type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
                     metadata=JobMetadataConfig(targets=STABLE_VERSIONS),
-                )
+                ),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata=JobMetadataConfig(targets=["fedora-rawhide"]),
+                ),
             ],
             JobConfigTriggerType.pull_request,
-            STABLE_CHROOTS,
-            set(),
-            id="koji_build_with_targets_for_pr",
+            set(STABLE_VERSIONS + ["fedora-rawhide"]),
+            {"fedora-rawhide"},
+            id="build_with_mixed_build_tests",
         ),
     ],
 )
 def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
-    copr_build_handler = CoprBuildJobHelper(
+    copr_build_helper = CoprBuildJobHelper(
         service_config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         job_config=jobs[0],  # BuildHelper looks at all jobs in the end
@@ -374,15 +378,11 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
         db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
     )
 
-    flexmock(packit_service.worker.build.copr_build).should_receive(
-        "get_valid_build_targets"
-    ).and_return(build_chroots).and_return(test_chroots)
+    assert copr_build_helper.package_config.jobs
+    assert [j.type for j in copr_build_helper.package_config.jobs]
 
-    assert copr_build_handler.package_config.jobs
-    assert [j.type for j in copr_build_handler.package_config.jobs]
-
-    assert copr_build_handler.build_targets == build_chroots
-    assert copr_build_handler.tests_targets == test_chroots
+    assert copr_build_helper.configured_build_targets == build_chroots
+    assert copr_build_helper.configured_tests_targets == test_chroots
 
 
 @pytest.mark.parametrize(
@@ -720,7 +720,7 @@ def test_build_handler_job_and_test_properties(
     result_job_build,
     result_job_tests,
 ):
-    copr_build_handler = CoprBuildJobHelper(
+    copr_build_helper = CoprBuildJobHelper(
         service_config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         job_config=init_job,
@@ -729,11 +729,11 @@ def test_build_handler_job_and_test_properties(
         db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
     )
 
-    assert copr_build_handler.package_config.jobs
-    assert [j.type for j in copr_build_handler.package_config.jobs]
+    assert copr_build_helper.package_config.jobs
+    assert [j.type for j in copr_build_helper.package_config.jobs]
 
-    assert copr_build_handler.job_build == result_job_build
-    assert copr_build_handler.job_tests == result_job_tests
+    assert copr_build_helper.job_build == result_job_build
+    assert copr_build_helper.job_tests == result_job_tests
 
 
 @pytest.mark.parametrize(
@@ -954,7 +954,7 @@ def test_build_handler_job_and_test_properties(
 def test_copr_project_and_namespace(
     jobs, job_config_trigger_type, job_owner, job_project
 ):
-    copr_build_handler = CoprBuildJobHelper(
+    copr_build_helper = CoprBuildJobHelper(
         service_config=flexmock(deployment="stg"),
         package_config=PackageConfig(jobs=jobs),
         job_config=jobs[0],  # BuildHelper looks at all jobs in the end
@@ -966,12 +966,12 @@ def test_copr_project_and_namespace(
         metadata=flexmock(pr_id=None, identifier="the-event-identifier"),
         db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
     )
-    copr_build_handler._api = flexmock(
+    copr_build_helper._api = flexmock(
         copr_helper=flexmock(copr_client=flexmock(config={"username": "nobody"}))
     )
 
-    assert copr_build_handler.job_project == job_project
-    assert copr_build_handler.job_owner == job_owner
+    assert copr_build_helper.job_project == job_project
+    assert copr_build_helper.job_owner == job_owner
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When we have configuration like this:
```yaml
jobs:
- job: copr_build
  trigger: pull_request
  metadata:
    targets:
    - fedora-stable-x86_64

- job: tests
  trigger: pull_request
  metadata:
    targets:
    - fedora-rawhide-x86_64
 ```
 build for targets both from build job and test job (currently the build would not run for `fedora-rawhide-x86_64`).
 
 The tests were testing only mocked functionality, so there are some changes. They now test the `configured_build_targets` and `configured_test_targets` instead of the `build_targets` and `test_targets` which call `get_valid_build_targets` which uses Copr and Bodhi, so now we check the targets used as input for `get_valid_build_targets`.
 
 Related to #976 