### PR TITLE
Allowlist for GitLab

### DIFF
--- a/alembic/versions/800abbbb23c9_allow_multiple_forges_in_allowlist.py
+++ b/alembic/versions/800abbbb23c9_allow_multiple_forges_in_allowlist.py
@@ -1,0 +1,105 @@
+"""Allow multiple forges in allowlist
+
+Revision ID: 800abbbb23c9
+Revises: a5c06aa9ef30
+Create Date: 2021-03-25 10:43:00.679552
+
+"""
+import enum
+from typing import TYPE_CHECKING, Dict
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import Column, Integer, String, Enum, orm
+
+# from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.declarative import declarative_base
+
+
+# revision identifiers, used by Alembic.
+revision = "800abbbb23c9"
+down_revision = "a5c06aa9ef30"
+branch_labels = None
+depends_on = None
+
+
+# https://github.com/python/mypy/issues/2477#issuecomment-313984522 ^_^
+if TYPE_CHECKING:
+    Base = object
+else:
+    Base = declarative_base()
+
+ALLOWLIST_CONSTANTS = {
+    "approved_automatically": "approved_automatically",
+    "waiting": "waiting",
+    "approved_manually": "approved_manually",
+    "denied": "denied",
+}
+
+
+class AllowlistStatus(str, enum.Enum):
+    approved_automatically = ALLOWLIST_CONSTANTS["approved_automatically"]
+    waiting = ALLOWLIST_CONSTANTS["waiting"]
+    approved_manually = ALLOWLIST_CONSTANTS["approved_manually"]
+    denied = ALLOWLIST_CONSTANTS["denied"]
+
+
+class AllowlistModel(Base):
+    __tablename__ = "allowlist"
+    id = Column(Integer, primary_key=True)
+    namespace = Column(String, index=True)  # renamed from account_name
+    status = Column(Enum(AllowlistStatus))
+    fas_account = Column(String)
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "namespace": self.namespace,
+            "status": self.status,
+            "fas_account": self.fas_account,
+        }
+
+    def __repr__(self):
+        return (
+            f'<AllowlistModel(namespace="{self.namespace}", '
+            f'status="{self.status}", '
+            f'fas_account="{self.fas_account}")>'
+        )
+
+
+def upgrade():
+    op.add_column("allowlist", sa.Column("fas_account", sa.String(), nullable=True))
+
+    # rename account_name to namespace
+    op.execute("ALTER TABLE allowlist RENAME COLUMN account_name TO namespace")
+
+    # replaces creating new index and dropping old one
+    op.execute("ALTER INDEX ix_allowlist_account_name RENAME TO ix_allowlist_namespace")
+
+    # update all of the entries
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    for entry in session.query(AllowlistModel).all():
+        if "/" not in entry.namespace:
+            entry.namespace = f"github.com/{entry.namespace}"
+
+    session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    for entry in session.query(AllowlistModel).all():
+        if entry.namespace.startswith("github.com/"):
+            _, entry.namespace = entry.namespace.split("/", 1)
+    session.commit()
+
+    # drop additional information
+    op.drop_column("allowlist", "fas_account")
+
+    # rename back to account_name
+    op.execute("ALTER TABLE allowlist RENAME COLUMN namespace TO account_name")
+
+    # fix index; will it work with just rename? O.o
+    op.execute("ALTER INDEX ix_allowlist_namespace RENAME TO ix_allowlist_account_name")

--- a/files/scripts/README.md
+++ b/files/scripts/README.md
@@ -5,15 +5,15 @@ You need to login to our OpenShift cluster and list all pods.
 Approving user who is waiting on the allowlist:
 
 ```
-$ oc exec packit-worker-0 python3 /src/files/scripts/allowlist.py approve <github_account>
+$ oc exec packit-worker-0 python3 /src/files/scripts/allowlist.py approve <path_to_namespace>
 ```
 
-Once you approve the account, go to [packit-service/notifications](https://github.com/packit/notifications/issues) and close the issue with corresponding `<github_account>`.
+Once you approve the account, go to [packit-service/notifications](https://github.com/packit/notifications/issues) and close the issue with corresponding `<path_to_namespace>`.
 
 Removing user from the allowlist:
 
 ```
-$ oc exec packit-worker-0 python3 /src/files/scripts/allowlist.py remove <github_account>
+$ oc exec packit-worker-0 python3 /src/files/scripts/allowlist.py remove <path_to_namespace>
 ```
 
 Show all pending requests:

--- a/files/scripts/allowlist.py
+++ b/files/scripts/allowlist.py
@@ -1,8 +1,15 @@
 import click
+
 from packit_service.worker.allowlist import Allowlist
 
+PATH_HELP = (
+    "Full path to be {} must be in the following format: github.com/packit or "
+    "github.com/packit/packit.git for repository only"
+)
+
+
 """
-This is cli script to approve user manually after he installed github_app to repository
+This is a CLI script to interact with our allowlist.
 """
 
 
@@ -11,41 +18,28 @@ def cli():
     pass
 
 
-@click.command("approve")
-@click.argument("account_name", type=str)
-def approve(account_name):
-    """
-    Approve user who is waiting on allowlist.
-
-    :param account_name: github namespace
-    :return:
-    """
-    Allowlist().approve_account(account_name)
+@cli.command(short_help="Approve namespace.", help=PATH_HELP.format("approved"))
+@click.argument("full_path", type=str)
+def approve(full_path):
+    Allowlist().approve_namespace(full_path)
 
 
-@click.command("remove")
-@click.argument("account_name", type=str)
-def remove(account_name):
-    """
-    Remove account from allowlist
-
-    :param account_name: github namespace
-    :return:
-    """
-    Allowlist().remove_account(account_name)
+@cli.command(
+    short_help="Remove namespace from allowlist. Removes the entry.",
+    help=PATH_HELP.format("removed"),
+)
+@click.argument("full_path", type=str)
+def remove(full_path: str):
+    Allowlist().remove_namespace(full_path)
 
 
-@click.command("waiting")
+@cli.command(short_help="Show accounts waiting for an approval.")
 def waiting():
-    """
-    Show accounts waiting for approval.
-    """
-    print(f"Accounts waiting for approval: {', '.join(Allowlist().accounts_waiting())}")
+    print("Accounts waiting for approval:")
 
+    for namespace in Allowlist().accounts_waiting():
+        print(f"- {namespace}")
 
-cli.add_command(waiting)
-cli.add_command(approve)
-cli.add_command(remove)
 
 if __name__ == "__main__":
     cli()

--- a/files/scripts/allowlist.py
+++ b/files/scripts/allowlist.py
@@ -37,7 +37,7 @@ def remove(full_path: str):
 def waiting():
     print("Accounts waiting for approval:")
 
-    for namespace in Allowlist().accounts_waiting():
+    for namespace in Allowlist().waiting_namespaces():
         print(f"- {namespace}")
 
 

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -46,6 +46,7 @@ ALLOWLIST_CONSTANTS = {
     "approved_automatically": "approved_automatically",
     "waiting": "waiting",
     "approved_manually": "approved_manually",
+    "denied": "denied",
 }
 
 

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1135,7 +1135,7 @@ class AllowlistModel(Base):
 
     parent_id = Column(Integer, ForeignKey("allowlist.id"), nullable=True)
     parent = relationship("AllowlistModel", back_populates="subnamespaces")
-    subnamespaces = relationship("AllowlistModel", back_populates="parent")
+    subnamespaces = relationship("AllowlistModel")
 
     # TODO: For backward compatibility keeping account_name for now, where necessary
     # add new account or change status if it already exists

--- a/packit_service/service/api/allowlist.py
+++ b/packit_service/service/api/allowlist.py
@@ -21,8 +21,8 @@ class Allowlist(Resource):
         return [account.to_dict() for account in AllowlistModel.get_all()]
 
 
-@ns.route("/<string:namespace>")
-@ns.param("namespace", "Namespace to be queried, URL encoded")
+@ns.route("/<path:namespace>")
+@ns.param("namespace", "Namespace to be queried")
 class AllowlistItem(Resource):
     @ns.response(HTTPStatus.OK.value, "OK, allowlisted namespace details follow")
     @ns.response(HTTPStatus.NO_CONTENT.value, "namespace not in allowlist")

--- a/packit_service/service/api/allowlist.py
+++ b/packit_service/service/api/allowlist.py
@@ -21,12 +21,12 @@ class Allowlist(Resource):
         return [account.to_dict() for account in AllowlistModel.get_all()]
 
 
-@ns.route("/<string:login>")
-@ns.param("login", "Account login")
+@ns.route("/<string:namespace>")
+@ns.param("namespace", "Namespace to be queried, URL encoded")
 class AllowlistItem(Resource):
-    @ns.response(HTTPStatus.OK.value, "OK, allowlisted account details follow")
-    @ns.response(HTTPStatus.NO_CONTENT.value, "login not in allowlist")
-    def get(self, login):
+    @ns.response(HTTPStatus.OK.value, "OK, allowlisted namespace details follow")
+    @ns.response(HTTPStatus.NO_CONTENT.value, "namespace not in allowlist")
+    def get(self, namespace):
         """A specific allowlist item details"""
-        account = AllowlistModel.get_account(login)
-        return account.to_dict() if account else ("", HTTPStatus.NO_CONTENT.value)
+        entry = AllowlistModel.get_namespace(namespace)
+        return entry.to_dict() if entry else ("", HTTPStatus.NO_CONTENT.value)

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -124,7 +124,7 @@ class GithubAppInstallationHandler(JobHandler):
             fas_user=self.service_config.fas_user,
             fas_password=self.service_config.fas_password,
         )
-        if not allowlist.add_account(self.account_login, self.sender_login):
+        if not allowlist.add_namespace(self.account_login, self.sender_login):
             # Create an issue in our repository, so we are notified when someone install the app
             self.project.create_issue(
                 title=f"{self.account_type} {self.account_login} needs to be approved.",

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -124,7 +124,9 @@ class GithubAppInstallationHandler(JobHandler):
             fas_user=self.service_config.fas_user,
             fas_password=self.service_config.fas_password,
         )
-        if not allowlist.add_namespace(self.account_login, self.sender_login):
+        if not allowlist.add_namespace(
+            f"github.com/{self.account_login}", self.sender_login
+        ):
             # Create an issue in our repository, so we are notified when someone install the app
             self.project.create_issue(
                 title=f"{self.account_type} {self.account_login} needs to be approved.",

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -30,8 +30,8 @@ def test_installation():
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
 
     flexmock(InstallationModel).should_receive("create").once()
-    flexmock(Allowlist).should_receive("add_account").with_args(
-        "packit-service", "jpopelka"
+    flexmock(Allowlist).should_receive("add_namespace").with_args(
+        "github.com/packit-service", "jpopelka"
     ).and_return(False)
     flexmock(GithubProject).should_receive("create_issue").once()
 

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -105,10 +105,10 @@ class SampleValues:
     another_different_pipeline_id = "98765"
 
     # Allowlist
-    account_name = "Rayquaza"
-    different_account_name = "Deoxys"
-    another_different_acount_name = "Solgaleo"
-    yet_another_different_acount_name = "Zacian"
+    account_name = "github.com/Rayquaza"
+    different_account_name = "gitlab.com/Deoxys"
+    another_different_acount_name = "gitlab.com/Solgaleo"
+    yet_another_different_acount_name = "github.com/Zacian"
 
     # Bugzilla
     bug_id = 123456
@@ -750,21 +750,21 @@ def multiple_new_test_runs(pr_model, different_pr_model):
 @pytest.fixture()
 def multiple_allowlist_entries():
     yield [
-        AllowlistModel.add_account(
-            account_name=SampleValues.account_name, status="approved_manually"
+        AllowlistModel.add_namespace(
+            namespace=SampleValues.account_name, status="approved_manually"
         ),
-        AllowlistModel.add_account(
-            account_name=SampleValues.different_account_name, status="approved_manually"
+        AllowlistModel.add_namespace(
+            namespace=SampleValues.different_account_name, status="approved_manually"
         ),
         # Not a typo, account_name repeated intentionally to check behaviour
-        AllowlistModel.add_account(
-            account_name=SampleValues.different_account_name, status="waiting"
+        AllowlistModel.add_namespace(
+            namespace=SampleValues.different_account_name, status="waiting"
         ),
-        AllowlistModel.add_account(
-            account_name=SampleValues.another_different_acount_name, status="waiting"
+        AllowlistModel.add_namespace(
+            namespace=SampleValues.another_different_acount_name, status="waiting"
         ),
-        AllowlistModel.add_account(
-            account_name=SampleValues.yet_another_different_acount_name,
+        AllowlistModel.add_namespace(
+            namespace=SampleValues.yet_another_different_acount_name,
             status="approved_manually",
         ),
     ]
@@ -772,8 +772,8 @@ def multiple_allowlist_entries():
 
 @pytest.fixture()
 def new_allowlist_entry(clean_before_and_after):
-    yield AllowlistModel.add_account(
-        account_name=SampleValues.account_name, status="approved_manually"
+    yield AllowlistModel.add_namespace(
+        namespace=SampleValues.account_name, status="approved_manually"
     )
 
 

--- a/tests_requre/database/test_allowlist.py
+++ b/tests_requre/database/test_allowlist.py
@@ -32,17 +32,17 @@ def multiple_allowlist_entries():
     with get_sa_session() as session:
         session.query(AllowlistModel).delete()
         yield [
-            AllowlistModel.add_account(
-                account_name="Rayquaza", status="approved_manually"
+            AllowlistModel.add_namespace(
+                namespace="Rayquaza", status="approved_manually"
             ),
-            AllowlistModel.add_account(
-                account_name="Deoxys", status="approved_manually"
+            AllowlistModel.add_namespace(
+                namespace="Deoxys", status="approved_manually"
             ),
             # Not a typo, account_name repeated intentionally to check behaviour
-            AllowlistModel.add_account(account_name="Deoxys", status="waiting"),
-            AllowlistModel.add_account(account_name="Solgaleo", status="waiting"),
-            AllowlistModel.add_account(
-                account_name="Zacian", status="approved_manually"
+            AllowlistModel.add_namespace(namespace="Deoxys", status="waiting"),
+            AllowlistModel.add_namespace(namespace="Solgaleo", status="waiting"),
+            AllowlistModel.add_namespace(
+                namespace="Zacian", status="approved_manually"
             ),
         ]
 
@@ -52,33 +52,33 @@ def multiple_allowlist_entries():
 def new_allowlist_entry():
     with get_sa_session() as session:
         session.query(AllowlistModel).delete()
-        yield AllowlistModel.add_account(
-            account_name="Rayquaza", status="approved_manually"
+        yield AllowlistModel.add_namespace(
+            namespace="Rayquaza", status="approved_manually"
         )
 
 
-def test_add_account(clean_before_and_after, new_allowlist_entry):
+def test_add_namespace(clean_before_and_after, new_allowlist_entry):
     assert new_allowlist_entry.status == "approved_manually"
-    assert new_allowlist_entry.account_name == "Rayquaza"
+    assert new_allowlist_entry.namespace == "Rayquaza"
 
 
-def test_get_account(clean_before_and_after, multiple_allowlist_entries):
-    assert AllowlistModel.get_account("Rayquaza").status == "approved_manually"
-    assert AllowlistModel.get_account("Rayquaza").account_name == "Rayquaza"
-    assert AllowlistModel.get_account("Deoxys").status == "waiting"
-    assert AllowlistModel.get_account("Deoxys").account_name == "Deoxys"
-    assert AllowlistModel.get_account("Solgaleo").status == "waiting"
-    assert AllowlistModel.get_account("Solgaleo").account_name == "Solgaleo"
+def test_get_namespace(clean_before_and_after, multiple_allowlist_entries):
+    assert AllowlistModel.get_namespace("Rayquaza").status == "approved_manually"
+    assert AllowlistModel.get_namespace("Rayquaza").namespace == "Rayquaza"
+    assert AllowlistModel.get_namespace("Deoxys").status == "waiting"
+    assert AllowlistModel.get_namespace("Deoxys").namespace == "Deoxys"
+    assert AllowlistModel.get_namespace("Solgaleo").status == "waiting"
+    assert AllowlistModel.get_namespace("Solgaleo").namespace == "Solgaleo"
 
 
-def test_get_accounts_by_status(clean_before_and_after, multiple_allowlist_entries):
-    a = AllowlistModel.get_accounts_by_status("waiting")
+def test_get_namespaces_by_status(clean_before_and_after, multiple_allowlist_entries):
+    a = AllowlistModel.get_namespaces_by_status("waiting")
     assert len(list(a)) == 2
-    b = AllowlistModel.get_accounts_by_status("approved_manually")
+    b = AllowlistModel.get_namespaces_by_status("approved_manually")
     assert len(list(b)) == 2
 
 
-def test_remove_account(clean_before_and_after, multiple_allowlist_entries):
-    assert AllowlistModel.get_account("Rayquaza").account_name == "Rayquaza"
-    AllowlistModel.remove_account("Rayquaza")
-    assert AllowlistModel.get_account("Rayquaza") is None
+def test_remove_namespace(clean_before_and_after, multiple_allowlist_entries):
+    assert AllowlistModel.get_namespace("Rayquaza").namespace == "Rayquaza"
+    AllowlistModel.remove_namespace("Rayquaza")
+    assert AllowlistModel.get_namespace("Rayquaza") is None

--- a/tests_requre/service/test_api.py
+++ b/tests_requre/service/test_api.py
@@ -205,18 +205,22 @@ def test_allowlist_all(client, clean_before_and_after, new_allowlist_entry):
     """Test Allowlist API (all)"""
     response = client.get(url_for("api.allowlist_allowlist"))
     response_dict = response.json
-    assert response_dict[0]["account"] == "Rayquaza"
+    assert response_dict[0]["namespace"] == "github.com/Rayquaza"
     assert response_dict[0]["status"] == "approved_manually"
     assert len(list(response_dict)) == 1
 
 
 def test_allowlist_specific(client, clean_before_and_after, new_allowlist_entry):
     """Test Allowlist API (specific user)"""
-    user_1 = client.get(url_for("api.allowlist_allowlist_item", login="Rayquaza"))
-    assert user_1.json["account"] == "Rayquaza"
+    user_1 = client.get(
+        url_for("api.allowlist_allowlist_item", namespace="github.com/Rayquaza")
+    )
+    assert user_1.json["namespace"] == "Rayquaza"
     assert user_1.json["status"] == "approved_manually"
 
-    user_2 = client.get(url_for("api.allowlist_allowlist_item", login="Zacian"))
+    user_2 = client.get(
+        url_for("api.allowlist_allowlist_item", namespace="github.com/Zacian")
+    )
     assert user_2.status_code == 204  # No content when not in allowlist
 
 

--- a/tests_requre/service/test_api.py
+++ b/tests_requre/service/test_api.py
@@ -215,7 +215,7 @@ def test_allowlist_specific(client, clean_before_and_after, new_allowlist_entry)
     user_1 = client.get(
         url_for("api.allowlist_allowlist_item", namespace="github.com/Rayquaza")
     )
-    assert user_1.json["namespace"] == "Rayquaza"
+    assert user_1.json["namespace"] == "github.com/Rayquaza"
     assert user_1.json["status"] == "approved_manually"
 
     user_2 = client.get(


### PR DESCRIPTION
TODO:
- [x] DB migration to prefix current entries
- [ ] automatically add GitLab namespaces to waiting list
  - [x] thinking about it: **fix the bug when adding from GitHub installations**
- [x] Agree on the implementation
- [x] Decide if we should support `AllowlistStatus.denied`
- [x] Fix tests and adjust to new behaviour
- [x] Implement decided interface
- [X] Check format of events to prevent ambiguity, e.g. `https://github.com/mfocko/dotfiles.git.git` (ofc GitLab allows it)
   - [x] Shall we save it in the format `github.com/packit/packit` or `github.com/packit/packit.git`? I prefer `.git`, since on GitLab you could get your repository approved and then create subnamespace O.o
   - URLs in hooks don't contain `.git` suffix
- [x] UX of allowlisting new accounts (especially if we add hostname and support separate repositories)

Signed-off-by: Matej Focko <mfocko@redhat.com>