### PR TITLE
Testing Farm wants to see 200 as a response to POST to /testing-farm/resuts

### DIFF
--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -33,7 +33,7 @@ payload = ns.model(
 
 @ns.route("/results")
 class TestingFarmResults(Resource):
-    @ns.response(HTTPStatus.ACCEPTED, "Test results accepted and being processed")
+    @ns.response(HTTPStatus.OK, "Notification has been accepted")
     @ns.response(HTTPStatus.BAD_REQUEST, "Bad request data")
     @ns.response(HTTPStatus.UNAUTHORIZED, "Testing farm secret validation failed")
     @ns.expect(payload)
@@ -60,7 +60,7 @@ class TestingFarmResults(Resource):
             name="task.steve_jobs.process_message", kwargs={"event": msg}
         )
 
-        return "Test results accepted", HTTPStatus.ACCEPTED
+        return "Test results accepted", HTTPStatus.OK
 
     @staticmethod
     def validate_testing_farm_request():


### PR DESCRIPTION
Fixes #987

Long time ago we used to actually send 200, but then (9a0380b) I (don't ask why) changed it to ACCEPTED (202).

I'm leaving /webhooks/github & /webhooks/gitlab responding with ACCEPTED (202).
I haven't found any rule in
https://docs.github.com/en/developers/webhooks-and-events/webhooks
just one screenshot showing 202 as a response to webhook:
https://docs.github.com/en/github-ae@latest/developers/webhooks-and-events/testing-webhooks#response