### PR TITLE
Increase delay in retrying failed propose-downstream

### DIFF
--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -307,7 +307,7 @@ def test_retry_propose_downstream_task(github_release_webhook):
     results = run_propose_downstream_handler(event_dict, package_config, job_config)
 
     assert not first_dict_value(results["job"])["success"]
-    assert "not able to download" in first_dict_value(results["job"])["details"]["msg"]
+    assert "Not able to download" in first_dict_value(results["job"])["details"]["msg"]
 
 
 def test_dont_retry_propose_downstream_task(github_release_webhook):


### PR DESCRIPTION
Before this, we were retrying in 15s and then in 30s.

That's too little because the action for uploading the file to PyPI [took over 1 minute](https://github.com/packit/requre/actions/runs/645692636).

With this commit, we'll retry in 1m and then again in 2m.

Related to https://github.com/packit/requre/issues/167