### PR TITLE
Fix handling of separately processed events

### DIFF
--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -309,12 +309,14 @@ class JobHandler(Handler):
         If pre-check succeeds, run the job for the specific handler.
         :return: Dict [str, TaskResults]
         """
-        job_type = self.job_config.type if self.job_config else self.type
+        job_type = (
+            self.job_config.type.value if self.job_config else self.task_name.value
+        )
         logger.debug(f"Running handler {str(self)} for {job_type}")
         job_results: Dict[str, TaskResults] = {}
         if self.pre_check():
             current_time = datetime.now().strftime(DATETIME_FORMAT)
-            result_key = f"{job_type.value}-{current_time}"
+            result_key = f"{job_type}-{current_time}"
             job_results[result_key] = self.run_n_clean()
             logger.debug("Job finished!")
 

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -371,12 +371,12 @@ class SteveJobs:
 
         # installation is handled differently b/c app is installed to GitHub account
         # not repository, so package config with jobs is missing
-        if isinstance(event, InstallationEvent):
+        if isinstance(event_object, InstallationEvent):
             GithubAppInstallationHandler.get_signature(
                 event=event_object, job=None
             ).apply_async()
         # Label/Tag added event handler is run even when the job is not configured in package
-        elif isinstance(event, PullRequestLabelPagureEvent):
+        elif isinstance(event_object, PullRequestLabelPagureEvent):
             PagurePullRequestLabelHandler.get_signature(
                 event=event_object,
                 job=None,
@@ -384,5 +384,15 @@ class SteveJobs:
         else:
             # Processing the jobs from the config.
             processing_results = self.process_jobs(event_object)
+
+        if processing_results is None:
+            processing_results = [
+                TaskResults.create_from(
+                    success=True,
+                    msg="Job created.",
+                    job_config=None,
+                    event=event_object,
+                )
+            ]
 
         return processing_results

--- a/packit_service/worker/result.py
+++ b/packit_service/worker/result.py
@@ -34,12 +34,11 @@ class TaskResults(dict):
             "package_config": dump_package_config(event.package_config),
         }
 
-        if job_config:
-            details.update(
-                {
-                    "job": job_config.type.value,
-                    "job_config": dump_job_config(job_config),
-                }
-            )
+        details.update(
+            {
+                "job": job_config.type.value if job_config else None,
+                "job_config": dump_job_config(job_config),
+            }
+        )
 
         return cls(success=success, details=details)

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -1,0 +1,50 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import json
+
+from celery.canvas import Signature
+from flexmock import flexmock
+
+from ogr.services.github import GithubProject
+from packit_service.config import ServiceConfig
+from packit_service.constants import SANDCASTLE_WORK_DIR
+from packit_service.models import (
+    InstallationModel,
+)
+from packit_service.worker.jobs import SteveJobs
+from packit_service.worker.tasks import run_installation_handler
+from packit_service.worker.allowlist import Allowlist
+from tests.spellbook import DATA_DIR, first_dict_value, get_parameters_from_results
+
+
+def installation_event():
+    return json.loads(
+        (DATA_DIR / "webhooks" / "github" / "installation_created.json").read_text()
+    )
+
+
+def test_installation():
+    config = ServiceConfig()
+    config.command_handler_work_dir = SANDCASTLE_WORK_DIR
+    flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
+
+    flexmock(InstallationModel).should_receive("create").once()
+    flexmock(Allowlist).should_receive("add_account").with_args(
+        "packit-service", "jpopelka"
+    ).and_return(False)
+    flexmock(GithubProject).should_receive("create_issue").once()
+
+    flexmock(Signature).should_receive("apply_async").once()
+    processing_results = SteveJobs().process_message(installation_event())
+    event_dict, job, job_config, package_config = get_parameters_from_results(
+        processing_results
+    )
+
+    results = run_installation_handler(
+        package_config=package_config,
+        event=event_dict,
+        job_config=job_config,
+    )
+
+    assert first_dict_value(results["job"])["success"]


### PR DESCRIPTION
We need to assign handlers for `InstallationEvent` and `PullRequestLabelPagureEvent` directly, but we were doing:
```python
if isinstance(event, InstallationEvent):
```
 where the `event` was the original dictionary and not the parsed object, therefore this was always False. Therefore the installations were not handled properly and issues in notifications repo were not created.