### PR TITLE
Use 'dump' instead of 'dump_config' when saving configuration

### DIFF
--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -57,7 +57,7 @@ def load_package_config(package_config: PackageConfig):
 
 
 def dump_package_config(package_config: PackageConfig):
-    return PackageConfigSchema().dump_config(package_config) if package_config else None
+    return PackageConfigSchema().dump(package_config) if package_config else None
 
 
 def load_job_config(job_config: JobConfig):
@@ -65,7 +65,7 @@ def load_job_config(job_config: JobConfig):
 
 
 def dump_job_config(job_config: JobConfig):
-    return JobConfigSchema().dump_config(job_config) if job_config else None
+    return JobConfigSchema().dump(job_config) if job_config else None
 
 
 def pretty_time(time: datetime) -> Optional[str]:


### PR DESCRIPTION
'dump_config' was kept around in Packit for backwards compatibility with
the Packit Service code. Let's get rid of this usage here, so that
Packit code can be cleaned up.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>