### PR TITLE
Use 'load' instead of 'load_config' when loading configuration

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -158,7 +158,7 @@ class ServiceConfig(Config):
         # required to avoid circular imports
         from packit_service.schema import ServiceConfigSchema
 
-        config = ServiceConfigSchema().load_config(raw_dict)
+        config = ServiceConfigSchema().load(raw_dict)
 
         config.server_name = raw_dict.get("server_name", "localhost:5000")
 

--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -53,7 +53,7 @@ class only_once(object):
 
 # wrappers for dumping/loading of configs
 def load_package_config(package_config: PackageConfig):
-    return PackageConfigSchema().load_config(package_config) if package_config else None
+    return PackageConfigSchema().load(package_config) if package_config else None
 
 
 def dump_package_config(package_config: PackageConfig):
@@ -61,7 +61,7 @@ def dump_package_config(package_config: PackageConfig):
 
 
 def load_job_config(job_config: JobConfig):
-    return JobConfigSchema().load_config(job_config) if job_config else None
+    return JobConfigSchema().load(job_config) if job_config else None
 
 
 def dump_job_config(job_config: JobConfig):


### PR DESCRIPTION
'load_config' was kept around in Packit for backwards compatibility with
the Packit Service code. Let's get rid of this usage here, so that
Packit code can be cleaned up.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>