### PR TITLE
Remove dry-run from packit-service

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,6 @@ def global_service_config():
         GithubService(token="token"),
         GitlabService(token="token"),
     }
-    service_config.dry_run = False
     service_config.server_name = "localhost"
     service_config.github_requests_log_path = "/path"
     ServiceConfig.service_config = service_config
@@ -82,7 +81,6 @@ def dump_http_com():
         # conf._pagure_user_token = os.environ.get("PAGURE_TOKEN", "test")
         # conf._pagure_fork_token = os.environ.get("PAGURE_FORK_TOKEN", "test")
         conf._github_token = os.getenv("GITHUB_TOKEN", None)
-        conf.dry_run = True
         target_path: Path = SAVED_HTTPD_REQS / path
         target_path.parent.mkdir(parents=True, exist_ok=True)
         conf.github_requests_log_path = str(target_path)

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -185,7 +185,6 @@ class TestEvents:
             GithubService(token="token"),
             GitlabService(token="token"),
         }
-        service_config.dry_run = False
         service_config.github_requests_log_path = "/path"
         ServiceConfig.service_config = service_config
 
@@ -949,7 +948,6 @@ class TestCentOSEventParser:
             GithubService(token="12345"),
             PagureService(instance_url="https://git.stg.centos.org", token="6789"),
         }
-        service_config.dry_run = False
         service_config.github_requests_log_path = "/path"
         ServiceConfig.service_config = service_config
 

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -132,7 +132,6 @@ def global_service_config():
         GitlabService(token="token"),
         PagureService(token="token", instance_url="https://git.stg.centos.org"),
     }
-    service_config.dry_run = False
     service_config.github_requests_log_path = "/path"
     service_config.server_name = "localhost"
     ServiceConfig.service_config = service_config


### PR DESCRIPTION
dry_run is set in several places, but never tested.

Fixes packit/packit#1006

(for packit-service).

Signed-off-by: Ben Crocker <bcrocker@redhat.com>