### PR TITLE
Add fedpkg-stage to worker deps

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -38,6 +38,7 @@
           - dnf-plugins-core
           # oc rsync /sandcastle -> sandcastle pod
           - rsync
+          - fedpkg-stage
         state: present
     - import_tasks: tasks/install-packit-deps.yaml
     - import_tasks: tasks/install-ogr-deps.yaml


### PR DESCRIPTION
After merging packit/packit-service#773 and other related PRs, we will use `fedpkg-stage` instead of `fedpkg` in staging.
I added it as a dependency here since it will be used only in packit-service for now, not packit itself. WDYT, should I rather move this to packit?