### PR TITLE
Avoid no details in TestingFarmHandler result dictionary

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -227,9 +227,10 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
         return TaskResults(
             success=False,
-            details={"msg": f"Failed testing farm targets: '{failed.keys()}'."}.update(
-                failed
-            ),
+            details={
+                "msg": f"Failed testing farm targets: '{failed.keys()}'.",
+                **failed,
+            },
         )
 
     def run_testing_farm(self, build: "CoprBuildModel", chroot: str) -> TaskResults:


### PR DESCRIPTION
`update` changes the dictionary, but returns None

Related to #1036 