### PR TITLE
COPR builds API bug fixes and enhancements

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -785,6 +785,9 @@ class CoprBuildModel(ProjectAndTriggersConnector, Base):
                     # Merge chroots and statuses from different rows into one
                     func.array_agg(psql_array([CoprBuildModel.target])).label("target"),
                     func.array_agg(psql_array([CoprBuildModel.status])).label("status"),
+                    func.array_agg(psql_array([CoprBuildModel.id])).label(
+                        "packit_id_per_chroot"
+                    ),
                 )
                 .group_by(CoprBuildModel.build_id)  # Group by identical element(s)
                 .order_by(desc("new_id"))[first:last]

--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -32,6 +32,7 @@ class CoprBuildsList(Resource):
             build_info = CoprBuildModel.get_by_build_id(build.build_id, None)
             project_info = build_info.get_project()
             build_dict = {
+                "packit_id": build.id,
                 "project": build_info.project_name,
                 "build_id": build.build_id,
                 "status_per_chroot": {},

--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -32,7 +32,7 @@ class CoprBuildsList(Resource):
             build_info = CoprBuildModel.get_by_build_id(build.build_id, None)
             project_info = build_info.get_project()
             build_dict = {
-                "packit_id": build.id,
+                "packit_id": build_info.id,
                 "project": build_info.project_name,
                 "build_id": build.build_id,
                 "status_per_chroot": {},
@@ -47,10 +47,12 @@ class CoprBuildsList(Resource):
                 "project_url": project_info.project_url,
             }
 
-            for count, chroot in enumerate(build.target):
+            for i, chroot in enumerate(build.target):
                 # [0] because sqlalchemy returns a single element sub-list
-                build_dict["status_per_chroot"][chroot[0]] = build.status[count][0]
-                build_dict["packit_id_per_chroot"][chroot[0]] = build.new_id
+                build_dict["status_per_chroot"][chroot[0]] = build.status[i][0]
+                build_dict["packit_id_per_chroot"][
+                    chroot[0]
+                ] = build.packit_id_per_chroot[i][0]
 
             result.append(build_dict)
 

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -104,6 +104,13 @@ def test_get_merged_chroots(clean_before_and_after, too_many_copr_builds):
     # two merged chroots so two statuses
     assert len(builds_list[0].status) == 2
     assert len(builds_list[0].target) == 2
+
+    # check that IDs are different
+    assert (
+        builds_list[0].packit_id_per_chroot[0][0]
+        != builds_list[0].packit_id_per_chroot[1][0]
+    )
+
     assert builds_list[1].status[0][0] == "success"
     assert builds_list[2].target[0][0] == "fedora-42-x86_64"
 


### PR DESCRIPTION
1. Add missing `packit_id` to the list of builds
2. Do not discard `packit_id` of separate chroots

---
Related to packit/dashboard#86
Fixes #982