### PR TITLE
[DistGitCommitEvent] Remove the trigger object in get_dict()

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -866,6 +866,7 @@ class DistGitCommitEvent(AbstractForgeIndependentEvent):
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
         result = super().get_dict()
         result["topic"] = result["topic"].value
+        result.pop("_db_trigger")
         return result
 
     @property


### PR DESCRIPTION
As we do in some other tasks, remove the trigger object so that the dict is serializable and task can be sent (we have the db ID of the trigger in the dict).

[Sentry error](https://sentry.io/organizations/red-hat-0p/issues/2310730457/?project=1767823&query=is%3Aunresolved): `Object of type GitBranchModel is not JSON serializable`