### PR TITLE
Status before building SRPM

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -30,6 +30,8 @@ PERMISSIONS_ERROR_WRITE_OR_ADMIN = (
     "can trigger Packit-as-a-Service"
 )
 
+TASK_ACCEPTED = "The task was accepted :+1:"
+
 COPR_SUCC_STATE = "succeeded"
 COPR_FAILED_STATE = "failed"
 COPR_API_SUCC_STATE = 1

--- a/packit_service/worker/build/__init__.py
+++ b/packit_service/worker/build/__init__.py
@@ -22,8 +22,10 @@
 
 from packit_service.worker.build.build_helper import BaseBuildJobHelper
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
+from packit_service.worker.build.koji_build import KojiBuildJobHelper
 
 __all__ = [
     CoprBuildJobHelper.__name__,
     BaseBuildJobHelper.__name__,
+    KojiBuildJobHelper.__name__,
 ]

--- a/packit_service/worker/build/babysit.py
+++ b/packit_service/worker/build/babysit.py
@@ -29,7 +29,7 @@ from packit_service.constants import (
     COPR_SUCC_STATE,
 )
 from packit_service.models import CoprBuildModel
-from packit_service.service.events import AbstractCoprBuildEvent, EventData, FedmsgTopic
+from packit_service.service.events import AbstractCoprBuildEvent, FedmsgTopic
 from packit_service.worker.handlers import CoprBuildEndHandler
 from packit_service.worker.jobs import get_config_for_handler_kls
 
@@ -96,7 +96,6 @@ def check_copr_build(build_id: int) -> bool:
             CoprBuildEndHandler(
                 package_config=event.package_config,
                 job_config=job_config,
-                data=EventData.from_event_dict(event.get_dict()),
-                copr_event=event,
+                event=event.get_dict(),
             ).run()
     return True

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -190,12 +190,6 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         return self.api.copr_helper.copr_client.build_proxy.get(build_id)
 
     def run_copr_build(self) -> TaskResults:
-
-        if not (self.job_build or self.job_tests):
-            msg = "No copr_build or tests job defined."
-            # we can't report it to end-user at this stage
-            return TaskResults(success=False, details={"msg": msg})
-
         self.report_status_to_all(
             description="Building SRPM ...",
             state=CommitStatus.pending,

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -30,7 +30,7 @@ from packit.config.package_config import PackageConfig
 from packit.exceptions import PackitCommandFailedError
 from packit_service import sentry_integration
 from packit_service.config import ServiceConfig
-from packit_service.constants import KOJI_PRODUCTION_BUILDS_ISSUE, MSG_RETRIGGER
+from packit_service.constants import MSG_RETRIGGER
 from packit_service.models import KojiBuildModel
 from packit_service.service.events import EventData
 from packit_service.service.urls import (
@@ -114,15 +114,6 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         return self._supported_koji_targets
 
     def run_koji_build(self) -> TaskResults:
-        if not self.is_scratch:
-            msg = "Non-scratch builds not possible from upstream."
-            self.report_status_to_all(
-                description=msg,
-                state=CommitStatus.error,
-                url=KOJI_PRODUCTION_BUILDS_ISSUE,
-            )
-            return TaskResults(success=True, details={"msg": msg})
-
         self.report_status_to_all(
             description="Building SRPM ...", state=CommitStatus.pending
         )

--- a/packit_service/worker/handlers/__init__.py
+++ b/packit_service/worker/handlers/__init__.py
@@ -40,6 +40,7 @@ from packit_service.worker.handlers.github_handlers import (
     ProposeDownstreamHandler,
     TestingFarmHandler,
     CoprBuildHandler,
+    KojiBuildHandler,
 )
 from packit_service.worker.handlers.testing_farm_handlers import (
     TestingFarmResultsHandler,
@@ -57,4 +58,5 @@ __all__ = [
     TestingFarmResultsHandler.__name__,
     CoprBuildHandler.__name__,
     TestingFarmHandler.__name__,
+    KojiBuildHandler.__name__,
 ]

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -284,13 +284,13 @@ class JobHandler(Handler):
         self,
         package_config: PackageConfig,
         job_config: JobConfig,
-        data: EventData,
+        event: dict,
     ):
         # build helper needs package_config to resolve dependencies b/w tests and build jobs
         self.package_config = package_config
         # always use job_config to pick up values, use package_config only for package_config.jobs
         self.job_config = job_config
-        self.data = data
+        self.data = EventData.from_event_dict(event)
 
         self._db_trigger: Optional[AbstractTriggerDbType] = None
         self._project: Optional[GitProject] = None

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -318,15 +318,14 @@ class JobHandler(Handler):
         )
         logger.debug(f"Running handler {str(self)} for {job_type}")
         job_results: Dict[str, TaskResults] = {}
-        if self.pre_check():
-            current_time = datetime.now().strftime(DATETIME_FORMAT)
-            result_key = f"{job_type}-{current_time}"
-            job_results[result_key] = self.run_n_clean()
-            logger.debug("Job finished!")
+        current_time = datetime.now().strftime(DATETIME_FORMAT)
+        result_key = f"{job_type}-{current_time}"
+        job_results[result_key] = self.run_n_clean()
+        logger.debug("Job finished!")
 
-            for result in job_results.values():
-                if not (result and result["success"]):
-                    logger.error(result["details"]["msg"])
+        for result in job_results.values():
+            if not (result and result["success"]):
+                logger.error(result["details"]["msg"])
 
         return job_results
 

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -49,7 +49,6 @@ from packit_service.service.events import (
     AbstractCoprBuildEvent,
     CoprBuildStartEvent,
     DistGitCommitEvent,
-    EventData,
     KojiBuildEvent,
 )
 from packit_service.service.urls import (
@@ -88,12 +87,12 @@ class FedmsgHandler(JobHandler):
         self,
         package_config: PackageConfig,
         job_config: JobConfig,
-        data: EventData,
+        event: dict,
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
-            data=data,
+            event=event,
         )
         self._pagure_service = None
 
@@ -114,15 +113,15 @@ class DistGitCommitHandler(FedmsgHandler):
         self,
         package_config: PackageConfig,
         job_config: JobConfig,
-        data: EventData,
+        event: dict,
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
-            data=data,
+            event=event,
         )
-        self.branch = data.event_dict.get("branch")
-        self.dg_branch = data.event_dict.get("dg_branch")
+        self.branch = event.get("branch")
+        self.dg_branch = event.get("dg_branch")
 
     def run(self) -> TaskResults:
         self.upstream_local_project = LocalProject(
@@ -151,15 +150,14 @@ class AbstractCoprBuildReportHandler(FedmsgHandler):
         self,
         package_config: PackageConfig,
         job_config: JobConfig,
-        data: EventData,
-        copr_event: AbstractCoprBuildEvent,
+        event: dict,
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
-            data=data,
+            event=event,
         )
-        self.copr_event = copr_event
+        self.copr_event = AbstractCoprBuildEvent.from_event_dict(event)
         self._build = None
         self._db_trigger = None
 
@@ -386,18 +384,14 @@ class KojiBuildReportHandler(FedmsgHandler):
     task_name = TaskName.koji_build_report
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        koji_event: KojiBuildEvent,
+        self, package_config: PackageConfig, job_config: JobConfig, event: dict
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
-            data=data,
+            event=event,
         )
-        self.koji_event = koji_event
+        self.koji_event: KojiBuildEvent = KojiBuildEvent.from_event_dict(event)
         self._db_trigger: Optional[AbstractTriggerDbType] = None
         self._build: Optional[KojiBuildModel] = None
 

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -53,7 +53,6 @@ from packit_service.models import (
     InstallationModel,
 )
 from packit_service.service.events import (
-    EventData,
     InstallationEvent,
     IssueCommentEvent,
     IssueCommentGitlabEvent,
@@ -96,18 +95,18 @@ class GithubAppInstallationHandler(JobHandler):
         self,
         package_config: PackageConfig,
         job_config: JobConfig,
-        data: EventData,
-        installation_event: InstallationEvent,
+        event: dict,
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
-            data=data,
+            event=event,
         )
-        self.installation_event = installation_event
-        self.account_type = installation_event.account_type
-        self.account_login = installation_event.account_login
-        self.sender_login = installation_event.sender_login
+
+        self.installation_event = InstallationEvent.from_event_dict(event)
+        self.account_type = self.installation_event.account_type
+        self.account_login = self.installation_event.account_login
+        self.sender_login = self.installation_event.sender_login
         self._project = self.service_config.get_project(
             url="https://github.com/packit/notifications"
         )
@@ -160,13 +159,13 @@ class ProposeDownstreamHandler(JobHandler):
         self,
         package_config: PackageConfig,
         job_config: JobConfig,
-        data: EventData,
-        task: Task,
+        event: dict,
+        task: Task = None,
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
-            data=data,
+            event=event,
         )
         self.task = task
 
@@ -272,12 +271,12 @@ class CoprBuildHandler(JobHandler):
         self,
         package_config: PackageConfig,
         job_config: JobConfig,
-        data: EventData,
+        event: dict,
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
-            data=data,
+            event=event,
         )
 
         self._copr_build_helper: Optional[CoprBuildJobHelper] = None
@@ -337,12 +336,12 @@ class KojiBuildHandler(JobHandler):
         self,
         package_config: PackageConfig,
         job_config: JobConfig,
-        data: EventData,
+        event: dict,
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
-            data=data,
+            event=event,
         )
 
         # lazy property
@@ -419,14 +418,14 @@ class TestingFarmHandler(JobHandler):
         self,
         package_config: PackageConfig,
         job_config: JobConfig,
-        data: EventData,
+        event: dict,
         chroot: Optional[str] = None,
         build_id: Optional[int] = None,
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
-            data=data,
+            event=event,
         )
         self.chroot = chroot
         self.build_id = build_id

--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -21,13 +21,12 @@
 # SOFTWARE.
 
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from ogr.abstract import CommitStatus, PullRequest
 from packit.config import JobConfig, PackageConfig
 from packit_service.models import BugzillaModel
 from packit_service.service.events import (
-    EventData,
     PullRequestLabelAction,
     PullRequestLabelPagureEvent,
 )
@@ -48,24 +47,18 @@ class PagurePullRequestLabelHandler(JobHandler):
     task_name = TaskName.pagure_pr_label
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        labels: List[str],
-        action: PullRequestLabelAction,
-        base_repo_owner: str,
-        base_repo_name: str,
-        base_repo_namespace: str,
+        self, package_config: PackageConfig, job_config: JobConfig, event: dict
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, data=data
+            package_config=package_config,
+            job_config=job_config,
+            event=event,
         )
-        self.labels = set(labels)
-        self.action = action
-        self.base_repo_owner = base_repo_owner
-        self.base_repo_name = base_repo_name
-        self.base_repo_namespace = base_repo_namespace
+        self.labels = set(event.get("labels"))
+        self.action = PullRequestLabelAction(event.get("action"))
+        self.base_repo_owner = event.get("base_repo_owner")
+        self.base_repo_name = event.get("base_repo_name")
+        self.base_repo_namespace = event.get("base_repo_namespace")
 
         self.pr: PullRequest = self.project.get_pr(self.data.pr_id)
         # lazy properties

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -5,7 +5,7 @@
 This file defines classes for job handlers specific for Testing farm
 """
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from ogr import GitlabService
 from ogr.abstract import CommitStatus
@@ -14,7 +14,6 @@ from packit.config.package_config import PackageConfig
 
 from packit_service.models import AbstractTriggerDbType, TFTTestRunModel
 from packit_service.service.events import (
-    EventData,
     TestResult,
     TestingFarmResult,
     TestingFarmResultsEvent,
@@ -37,26 +36,22 @@ class TestingFarmResultsHandler(JobHandler):
         self,
         package_config: PackageConfig,
         job_config: JobConfig,
-        data: EventData,
-        tests: List[TestResult],
-        result: TestingFarmResult,
-        pipeline_id: str,
-        log_url: str,
-        copr_chroot: str,
-        summary: str,
+        event: dict,
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
-            data=data,
+            event=event,
         )
 
-        self.tests = tests
-        self.result = result
-        self.pipeline_id = pipeline_id
-        self.log_url = log_url
-        self.copr_chroot = copr_chroot
-        self.summary = summary
+        self.tests = [TestResult(**test) for test in event.get("tests", [])]
+        self.result = (
+            TestingFarmResult(event.get("result")) if event.get("result") else None
+        )
+        self.pipeline_id = event.get("pipeline_id")
+        self.log_url = event.get("log_url")
+        self.copr_chroot = event.get("copr_chroot")
+        self.summary = event.get("summary")
         self._db_trigger: Optional[AbstractTriggerDbType] = None
 
     @property

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -28,7 +28,6 @@ from packit.config import JobConfig, JobConfigTriggerType, JobType, PackageConfi
 from packit.config.job_config import JobMetadataConfig
 from packit_service.config import ServiceConfig
 from packit_service.models import GitBranchModel, PullRequestModel
-from packit_service.service.events import EventData
 from packit_service.worker.handlers import JobHandler
 from packit_service.worker.handlers.github_handlers import CoprBuildHandler
 
@@ -58,7 +57,7 @@ def test_handler_cleanup(tmp_path, trick_p_s_with_k8s):
         trigger=JobConfigTriggerType.pull_request,
         metadata=JobMetadataConfig(),
     )
-    j = JobHandler(package_config=pc, job_config=jc, data=flexmock())
+    j = JobHandler(package_config=pc, job_config=jc, event={})
 
     flexmock(j).should_receive("service_config").and_return(c)
 
@@ -94,7 +93,7 @@ def test_precheck(github_pr_event):
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
         ),
-        data=EventData.from_event_dict(github_pr_event.get_dict()),
+        event=github_pr_event.get_dict(),
     )
     assert copr_build_handler.pre_check()
 
@@ -119,7 +118,7 @@ def test_precheck_push(github_push_event):
             trigger=JobConfigTriggerType.commit,
             metadata=JobMetadataConfig(branch="build-branch"),
         ),
-        data=EventData.from_event_dict(github_push_event.get_dict()),
+        event=github_push_event.get_dict(),
     )
 
     assert copr_build_handler.pre_check()
@@ -145,6 +144,6 @@ def test_precheck_push_to_a_different_branch(github_push_event):
             trigger=JobConfigTriggerType.commit,
             metadata=JobMetadataConfig(branch="bad-branch"),
         ),
-        data=EventData.from_event_dict(github_push_event.get_dict()),
+        event=github_push_event.get_dict(),
     )
     assert not copr_build_handler.pre_check()

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -24,12 +24,19 @@ import os
 import pytest
 from flexmock import flexmock
 
+from ogr.abstract import CommitStatus
+from ogr.services.github import GithubProject
 from packit.config import JobConfig, JobConfigTriggerType, JobType, PackageConfig
 from packit.config.job_config import JobMetadataConfig
 from packit_service.config import ServiceConfig
+from packit_service.constants import KOJI_PRODUCTION_BUILDS_ISSUE
 from packit_service.models import GitBranchModel, PullRequestModel
 from packit_service.worker.handlers import JobHandler
-from packit_service.worker.handlers.github_handlers import CoprBuildHandler
+from packit_service.worker.handlers.github_handlers import (
+    CoprBuildHandler,
+    KojiBuildHandler,
+)
+from packit_service.worker.reporting import StatusReporter
 
 
 @pytest.fixture()
@@ -147,3 +154,41 @@ def test_precheck_push_to_a_different_branch(github_push_event):
         event=github_push_event.get_dict(),
     )
     assert not copr_build_handler.pre_check()
+
+
+def test_precheck_koji_build_non_scratch(github_pr_event):
+    flexmock(PullRequestModel).should_receive("get_or_create").with_args(
+        pr_id=342,
+        namespace="packit-service",
+        repo_name="packit",
+        project_url="https://github.com/packit-service/packit",
+    ).and_return(
+        flexmock(id=342, job_config_trigger_type=JobConfigTriggerType.pull_request)
+    )
+    flexmock(StatusReporter).should_receive("set_status").with_args(
+        state=CommitStatus.error,
+        description="Non-scratch builds not possible from upstream.",
+        check_name="packit-stg/production-build-bright-future",
+        url=KOJI_PRODUCTION_BUILDS_ISSUE,
+    ).and_return().once()
+    flexmock(GithubProject).should_receive("can_merge_pr").and_return(True)
+    koji_build_handler = KojiBuildHandler(
+        package_config=PackageConfig(
+            jobs=[
+                JobConfig(
+                    type=JobType.production_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata=JobMetadataConfig(
+                        targets=["bright-future"], scratch=False
+                    ),
+                ),
+            ]
+        ),
+        job_config=JobConfig(
+            type=JobType.production_build,
+            trigger=JobConfigTriggerType.pull_request,
+            metadata=JobMetadataConfig(targets=["bright-future"], scratch=False),
+        ),
+        event=github_pr_event.get_dict(),
+    )
+    assert not koji_build_handler.pre_check()

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -28,11 +28,15 @@ from celery.canvas import Signature
 from flexmock import flexmock
 from github import Github
 
+from ogr.abstract import CommitStatus
 from ogr.services.github import GithubProject
 from packit.config import JobConfigTriggerType
 from packit.local_project import LocalProject
 from packit_service.config import ServiceConfig
-from packit_service.constants import SANDCASTLE_WORK_DIR
+from packit_service.constants import (
+    SANDCASTLE_WORK_DIR,
+    TASK_ACCEPTED,
+)
 from packit_service.models import PullRequestModel
 from packit_service.service.db_triggers import AddPullRequestDbTrigger
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
@@ -194,6 +198,11 @@ def test_pr_comment_copr_build_handler(
         "https://github.com/the-namespace/the-repo"
     )
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(CoprBuildJobHelper).should_receive("report_status_to_all").with_args(
+        description=TASK_ACCEPTED,
+        state=CommitStatus.pending,
+        url="",
+    ).once()
     flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(pr_copr_build_comment_event)
@@ -225,6 +234,11 @@ def test_pr_comment_build_handler(
     )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(CoprBuildJobHelper).should_receive("report_status_to_all").with_args(
+        description=TASK_ACCEPTED,
+        state=CommitStatus.pending,
+        url="",
+    ).once()
     flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(pr_build_comment_event)
@@ -290,6 +304,11 @@ def test_pr_comment_production_build_handler(pr_production_build_comment_event):
     )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(KojiBuildJobHelper).should_receive("report_status_to_all").with_args(
+        description=TASK_ACCEPTED,
+        state=CommitStatus.pending,
+        url="",
+    ).once()
     flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(pr_production_build_comment_event)
@@ -354,6 +373,11 @@ def test_pr_embedded_command_handler(
     )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(CoprBuildJobHelper).should_receive("report_status_to_all").with_args(
+        description=TASK_ACCEPTED,
+        state=CommitStatus.pending,
+        url="",
+    ).once()
     flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(pr_embedded_command_comment_event)
@@ -366,7 +390,6 @@ def test_pr_embedded_command_handler(
         event=event_dict,
         job_config=job_config,
     )
-
     assert first_dict_value(results["job"])["success"]
 
 

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -38,7 +38,6 @@ from packit.config.job_config import JobMetadataConfig
 from packit.exceptions import PackitCommandFailedError
 from packit.upstream import Upstream
 from packit_service import sentry_integration
-from packit_service.constants import KOJI_PRODUCTION_BUILDS_ISSUE
 from packit_service.config import ServiceConfig
 from packit_service.models import SRPMBuildModel, KojiBuildModel
 from packit_service.service.db_triggers import AddPullRequestDbTrigger
@@ -392,34 +391,6 @@ def test_koji_build_failed_srpm(github_pr_event):
     result = helper.run_koji_build()
     assert not result["success"]
     assert "SRPM build failed" in result["details"]["msg"]
-
-
-def test_koji_build_non_scratch(github_pr_event):
-    trigger = flexmock(
-        job_config_trigger_type=JobConfigTriggerType.pull_request, id=123
-    )
-    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
-    helper = build_helper(
-        event=github_pr_event,
-        metadata=JobMetadataConfig(targets=["bright-future"]),
-        db_trigger=trigger,
-    )
-    flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.error,
-        description="Non-scratch builds not possible from upstream.",
-        check_name="packit-stg/production-build-bright-future",
-        url=KOJI_PRODUCTION_BUILDS_ISSUE,
-    ).and_return()
-
-    flexmock(GitProject).should_receive("get_pr").and_return(
-        flexmock(source_project=flexmock())
-    )
-    flexmock(GitProject).should_receive("set_commit_status").and_return().never()
-    flexmock(KojiBuildModel).should_receive("create").never()
-
-    result = helper.run_koji_build()
-    assert result["success"]
-    assert "Non-scratch builds not possible from upstream." in result["details"]["msg"]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -18,7 +18,6 @@ from packit_service.service.events import (
     TestingFarmResultsEvent as TFResultsEvent,
     TestingFarmResult as TFResult,
     TestResult as TResult,
-    EventData,
 )
 from packit_service.worker.handlers import TestingFarmResultsHandler as TFResultsHandler
 from packit_service.worker.reporting import StatusReporter
@@ -191,15 +190,7 @@ def test_testing_farm_response(
         project_url="https://github.com/packit/ogr",
     ).get_dict()
     test_farm_handler = TFResultsHandler(
-        package_config=flexmock(),
-        job_config=flexmock(),
-        data=EventData.from_event_dict(event_dict),
-        tests=tests_tests,
-        result=tests_result,
-        pipeline_id="id",
-        log_url="some url",
-        copr_chroot="fedora-rawhide-x86_64",
-        summary=tests_message,
+        package_config=flexmock(), job_config=flexmock(), event=event_dict
     )
     flexmock(StatusReporter).should_receive("report").with_args(
         state=status_status,


### PR DESCRIPTION
- move all checks to pre-check methods of CoprBuildHandler/KojiBuildHandler (so that we don't create handler tasks that won't really run the builds)
- do the precheck in `process_message` task (for this refactor the handlers argument processing), only if pre-check succeeds, set status about accepted task (in case of CoprBuildHandler/KojiBuildHandler) and then create Celery handler task

Fixes #1038 