### PR TITLE
Error message is in 'errors', not 'message'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,9 @@ test_image: files/install-deps-worker.yaml files/install-deps.yaml files/recipe-
 	$(CONTAINER_ENGINE) build --rm -t $(TEST_IMAGE) -f files/docker/Dockerfile.tests --build-arg SOURCE_BRANCH=$(SOURCE_BRANCH) .
 
 check_in_container:
-	$(CONTAINER_ENGINE) pull $(TEST_IMAGE)
 	@# don't use -ti here in CI, TTY is not allocated in zuul
 	echo $(SOURCE_BRANCH)
-	$(CONTAINER_ENGINE) run --rm \
+	$(CONTAINER_ENGINE) run --rm --pull=always \
 		--env COV_REPORT \
 		--env TEST_TARGET \
 		--env COLOR \

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -594,8 +594,8 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         RequestResponse(
             status_code=400,
             ok=False,
-            content=b'{"message": "some error"}',
-            json={"message": "some error"},
+            content=b'{"errors": "some error"}',
+            json={"errors": "some error"},
         )
     )
 


### PR DESCRIPTION
When a TF refuses a new test request, it sends back
```yaml
reason: 'Bad Request'
errors: (e.g.) {'environments': {'0': {'arch': "must be one of: 'x86_64'"}}}
```

While the reason is nicer, it doesn't contain any info so users would need to wait for us to tell them what actually happened.

So far we've hit only the unsupported arch error, so let's extract it from the error json.

https://github.com/adrianreber/criu/pull/6#issuecomment-820304422