### PR TITLE
Rewrite jobs.py::get_packit_commands_from_comment

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -119,24 +119,17 @@ def get_packit_commands_from_comment(comment: str) -> List[str]:
         logger.debug("Empty comment, nothing to do.")
         return []
 
-    cmd_start_index = comment.find(REQUESTED_PULL_REQUEST_COMMENT)
+    comment_lines = comment_parts.split("\n")
 
-    if cmd_start_index == -1:
-        logger.debug(f"comment '{comment}' is not handled by packit-service.")
-        return []
+    for line in comment_lines:
+        (packit_mark, *packit_command) = line.split(maxsplit=3)
+        # packit_command[0] has the first cmd and [1] has the second, if needed.
 
-    (packit_mark, *packit_command) = comment[cmd_start_index:].split(maxsplit=3)
-    # packit_command[0] has the first cmd and [1] has the second, if needed.
+        if packit_mark == REQUESTED_PULL_REQUEST_COMMENT:
+            if packit_command:
+                return packit_command
 
-    if packit_mark != REQUESTED_PULL_REQUEST_COMMENT:
-        logger.debug(f"comment '{comment}' is not handled by packit-service.")
-        return []
-
-    if not packit_command:
-        logger.debug(f"comment '{comment}' does not contain a packit-service command.")
-        return []
-
-    return packit_command
+    return []
 
 
 def get_handlers_for_comment(comment: str) -> Set[Type[JobHandler]]:

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -317,6 +317,8 @@ def test_pr_comment_production_build_handler(pr_production_build_comment_event):
         " stuff",
         " \n ",
         "x ",
+        """comment with embedded /packit build not recognized
+        unless /packit command is on line by itself""",
     ),
 )
 def test_pr_comment_invalid(comment):
@@ -334,7 +336,7 @@ def test_pr_comment_invalid(comment):
         " /packit build ",
         "asd\n/packit build\n",
         "asd\n /packit build \n",
-        "Should be fixed now, lets /packit build it.",
+        "Should be fixed now, let's\n /packit build\n it.",
     ),
 )
 def test_pr_embedded_command_handler(


### PR DESCRIPTION
Rewrite jobs.py::get_packit_commands_from_comment to recognize
/packit commands
only when they appear alone on a line, possibly with whitespace.

Fixes #1025.

Signed-off-by: Ben Crocker <bcrocker@redhat.com>