### PR TITLE
Revert filtering of issues created by Packit

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -228,7 +228,8 @@ class PackageConfigGetter:
     def create_issue_if_needed(
         project: GitProject, message: str, details: str = ""
     ) -> Optional[Issue]:
-        issues = project.get_issue_list(author=project.service.user.get_username())
+        # TODO: Improve filtering
+        issues = project.get_issue_list()
 
         if "[packit] Invalid config" in (x.title for x in issues):
             return None

--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -25,10 +25,10 @@ class StatusReporter:
         logger.debug(
             f"Status reporter will report for {project}, commit={commit_sha}, pr={pr_id}"
         )
-        self.project = project
-        self._project_with_commit = None
-        self.commit_sha = commit_sha
-        self.pr_id = pr_id
+        self.project: GitProject = project
+        self._project_with_commit: Optional[GitProject] = None
+        self.commit_sha: str = commit_sha
+        self.pr_id: Optional[int] = pr_id
 
     @property
     def project_with_commit(self) -> GitProject:
@@ -80,7 +80,7 @@ class StatusReporter:
         pr = self.project.get_pr(self.pr_id)
         if hasattr(pr, "set_flag") and pr.head_commit == self.commit_sha:
             logger.debug("Setting the PR status (pagure only).")
-            pr.set_flag(
+            pr.set_flag(  # type: ignore
                 username=check_name,
                 comment=description,
                 url=url,


### PR DESCRIPTION
GitHub App does not have PyGithub instance, thus we cannot get username.
GitLab does not have `app/` prefix => cannot be guessed from deployment.

Related to: https://sentry.io/organizations/red-hat-0p/issues/2361275931/