### PR TITLE
Add run_ids to API and extend TF endpoint

### DIFF
--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -91,6 +91,7 @@ class CoprBuildItem(Resource):
             "copr_project": build.project_name,
             "copr_owner": build.owner,
             "srpm_build_id": build.get_srpm_build().id,
+            "run_ids": sorted(run.id for run in build.runs),
         }
 
         build_dict.update(get_project_info_from_build(build))

--- a/packit_service/service/api/koji_builds.py
+++ b/packit_service/service/api/koji_builds.py
@@ -85,6 +85,7 @@ class KojiBuildItem(Resource):
             # from old data, sometimes build_logs_url is same and sometimes different to web_url
             "build_logs_url": build.build_logs_url,
             "srpm_build_id": build.get_srpm_build().id,
+            "run_ids": sorted(run.id for run in build.runs),
         }
 
         build_dict.update(get_project_info_from_build(build))

--- a/packit_service/service/api/srpm_builds.py
+++ b/packit_service/service/api/srpm_builds.py
@@ -72,6 +72,7 @@ class SRPMBuildItem(Resource):
             "build_submitted_time": optional_time(build.build_submitted_time),
             "url": build.url,
             "logs": build.logs,
+            "run_ids": sorted(run.id for run in build.runs),
         }
 
         build_dict.update(get_project_info_from_build(build))

--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -148,6 +148,8 @@ class TestingFarmResult(Resource):
             "chroot": test_run_model.target,
             "commit_sha": test_run_model.commit_sha,
             "web_url": test_run_model.web_url,
+            "copr_build_id": test_run_model.runs[0].copr_build_id,
+            "run_ids": sorted(run.id for run in test_run_model.runs),
         }
 
         build_dict.update(get_project_info_from_build(test_run_model))


### PR DESCRIPTION
- Add run IDs to endpoints which are related
- Add COPR build ID to testing farm endpoint

Signed-off-by: Matej Focko <mfocko@redhat.com>