### PR TITLE
Fix parsing of comments

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -121,7 +121,7 @@ def get_packit_commands_from_comment(comment: str) -> List[str]:
 
     comment_lines = comment_parts.split("\n")
 
-    for line in comment_lines:
+    for line in filter(None, map(str.strip, comment_lines)):
         (packit_mark, *packit_command) = line.split(maxsplit=3)
         # packit_command[0] has the first cmd and [1] has the second, if needed.
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -319,6 +319,8 @@ def test_pr_comment_production_build_handler(pr_production_build_comment_event):
         "x ",
         """comment with embedded /packit build not recognized
         unless /packit command is on line by itself""",
+        "\n2nd line\n\n4th line",
+        "1st line\n\t\n\t\t\n4th line\n",
     ),
 )
 def test_pr_comment_invalid(comment):


### PR DESCRIPTION
Fixes parsing of the comment lines when looking for Packit command.
Filter out pure whitespace or empty lines.

Fixes #1073

Signed-off-by: Matej Focko <mfocko@redhat.com>