### PR TITLE
Gitlab: allow webhook token for whole group/namespace

### DIFF
--- a/packit_service/service/api/webhooks.py
+++ b/packit_service/service/api/webhooks.py
@@ -177,8 +177,13 @@ class GitlabWebhook(Resource):
         )
 
         if not project_authentication_issue:
-            token = jwt.encode(
+            token_project = jwt.encode(
                 {"namespace": parsed_url.namespace, "repo_name": parsed_url.repo},
+                config.gitlab_token_secret,
+                algorithm="HS256",
+            ).decode("utf-8")
+            token_group = jwt.encode(
+                {"namespace": parsed_url.namespace},
                 config.gitlab_token_secret,
                 algorithm="HS256",
             ).decode("utf-8")
@@ -188,11 +193,16 @@ class GitlabWebhook(Resource):
 
             project.create_issue(
                 title="Packit-Service Authentication",
-                body=f"To configure Packit-Service with `{parsed_url.repo}` you need to\n"
-                f"configure the webhook settings. Head to {project.get_web_url()}/hooks and add\n"
-                "the following Secret Token to authenticate requests coming to Packit:\n"
+                body=f"To configure Packit-Service you need to configure a webhook.\n"
+                f"Head to {project.get_web_url()}/hooks and add\n"
+                "the following Secret token to authenticate requests coming to Packit:\n"
                 "```\n"
-                f"{token}\n"
+                f"{token_project}\n"
+                "```\n"
+                "\n"
+                "Or if you want to configure a Group Hook (Gitlab EE) the Secret token would be:\n"
+                "```\n"
+                f"{token_group}\n"
                 "```\n"
                 "\n"
                 "Packit also needs rights to set commit status to merge requests. Please, grant\n"
@@ -230,7 +240,7 @@ class GitlabWebhook(Resource):
         token = request.headers["X-Gitlab-Token"]
 
         if token in config.gitlab_webhook_tokens:
-            logger.debug("Deprecation Warning: Old Gitlab tokens used.")
+            logger.debug("Deprecation Warning: Old/static Gitlab tokens used.")
             return
 
         gitlab_token_secret = config.gitlab_token_secret
@@ -253,18 +263,20 @@ class GitlabWebhook(Resource):
 
         project_data = json.loads(request.data)["project"]
         parsed_url = parse_git_repo(potential_url=project_data["http_url"])
-        token_namespace = token_decoded["namespace"]
-        token_repo_name = token_decoded["repo_name"]
 
-        if (token_namespace, token_repo_name) == (
-            parsed_url.namespace,
-            parsed_url.repo,
+        # "repo_name" might be missing in token_decoded if the token is for group/namespace
+        if token_decoded["namespace"] != parsed_url.namespace or (
+            "repo_name" in token_decoded
+            and token_decoded["repo_name"] != parsed_url.repo
         ):
-            logger.debug("Payload signature is OK.")
-        else:
-            msg_failed_validation = "X-Gitlab-Token does not match the project."
+            msg_failed_validation = (
+                "Decoded X-Gitlab-Token does not match namespace[/project]."
+            )
             logger.warning(msg_failed_validation)
+            logger.debug(f"decoded: {token_decoded}, url: {parsed_url}")
             raise ValidationFailed(msg_failed_validation)
+
+        logger.debug("Payload signature is OK.")
 
     @staticmethod
     def interested():

--- a/tests/unit/test_webhooks.py
+++ b/tests/unit/test_webhooks.py
@@ -55,13 +55,37 @@ def test_validate_signature(mock_config, headers, is_good):
     [
         (
             {
+                # token generated for specific repo
+                # jwt.encode({"namespace": "multi/part/namespace", "repo_name": "repo"},
+                #            "gitlab-token-secret", algorithm="HS256")
                 "X-Gitlab-Token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
                 "eyJuYW1lc3BhY2UiOiJtdWx0aS9wYXJ0L25hbWVzcGFjZSIsInJlcG9fbmFtZSI6InJlcG8ifQ."
                 "r5-khuzdQJ3b15KZt3E1AqFXjtKfFn_Q1BBwkq04Mf8"
             },
             True,
         ),
-        ({"X-Gitlab-Token": "guyirhgrehjguyrhg"}, False),
+        (
+            {
+                # token generated for whole group/namespace
+                # jwt.encode({"namespace": "multi/part/namespace"},
+                #            "gitlab-token-secret", algorithm="HS256")
+                "X-Gitlab-Token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+                "eyJuYW1lc3BhY2UiOiJtdWx0aS9wYXJ0L25hbWVzcGFjZSJ9."
+                "WNasZgIU91hMwKtGeGCILjPIDLU-PpL5rww-BEAzMgU"
+            },
+            True,
+        ),
+        (
+            {
+                # token generated for a different repo
+                # jwt.encode({"namespace": "multi/part/namespace", "repo_name": "repo2"},
+                #            "gitlab-token-secret", algorithm="HS256")
+                "X-Gitlab-Token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+                "eyJuYW1lc3BhY2UiOiJtdWx0aS9wYXJ0L25hbWVzcGFjZSIsInJlcG9fbmFtZSI6InJlcG8yIn0."
+                "vyQYbtmaCyHfDKpfmyk_uAn9QvDulnaIy2wZ1xgc-uI"
+            },
+            False,
+        ),
         ({"X-Gitlab-Token": "None"}, False),
         ({}, False),
     ],
@@ -85,7 +109,6 @@ def test_validate_token(mock_config, headers, is_good):
     with Flask(__name__).test_request_context():
         payload = {
             "project": {
-                "path_with_namespace": "multi/part/namespace/repo",
                 "http_url": "https://gitlab.com/multi/part/namespace/repo.git",
             }
         }


### PR DESCRIPTION
With Group Hooks (Gitlab EE only) we can setup a webhook for whole group/namespace.
In that case the same token would be sent with events from each repo, so the token can't be encoded with a repo name, only with the namespace.

When we receive/decode the token we now accept tokens without repo_name as well.