### PR TITLE
Remove deprecated gitlab_webhook_tokens

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -81,7 +81,6 @@ class ServiceConfig(Config):
         bugzilla_api_key: str = "",
         bugz_namespaces: List[str] = None,
         bugz_branches: List[str] = None,
-        gitlab_webhook_tokens: List[str] = None,
         enabled_private_namespaces: Union[Set[str], List[str]] = None,
         gitlab_token_secret: str = "",
         projects_to_sync: List[ProjectToSync] = None,
@@ -120,10 +119,6 @@ class ServiceConfig(Config):
         # for flask SERVER_NAME so we can create links to logs
         self.server_name: str = ""
 
-        # Makeshift for now to authenticate webhooks coming from gitlab instances
-        # Old way of authenticating
-        self.gitlab_webhook_tokens: Set[str] = set(gitlab_webhook_tokens or [])
-
         # Gitlab token secret to decode JWT tokens
         self.gitlab_token_secret: str = gitlab_token_secret
 
@@ -160,7 +155,6 @@ class ServiceConfig(Config):
             f"fas_password='{hide(self.fas_password)}', "
             f"bugzilla_url='{self.bugzilla_url}', "
             f"bugzilla_api_key='{hide(self.bugzilla_api_key)}', "
-            f"gitlab_webhook_tokens='{self.gitlab_webhook_tokens}',"
             f"gitlab_token_secret='{hide(self.gitlab_token_secret)}',"
             f"enabled_private_namespaces='{self.enabled_private_namespaces}',"
             f"server_name='{self.server_name}', "

--- a/packit_service/schema.py
+++ b/packit_service/schema.py
@@ -56,7 +56,6 @@ class ServiceConfigSchema(UserConfigSchema):
     bugz_branches = fields.List(fields.String())
     admins = fields.List(fields.String())
     server_name = fields.String()
-    gitlab_webhook_tokens = fields.List(fields.String())
     gitlab_token_secret = fields.String()
     enabled_private_namespaces = fields.List(fields.String())
     projects_to_sync = fields.List(fields.Nested(ProjectToSyncSchema), missing=None)

--- a/packit_service/service/api/webhooks.py
+++ b/packit_service/service/api/webhooks.py
@@ -239,10 +239,6 @@ class GitlabWebhook(Resource):
 
         token = request.headers["X-Gitlab-Token"]
 
-        if token in config.gitlab_webhook_tokens:
-            logger.debug("Deprecation Warning: Old/static Gitlab tokens used.")
-            return
-
         gitlab_token_secret = config.gitlab_token_secret
         if not gitlab_token_secret:
             msg = "'gitlab_token_secret' not specified in the config."

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -51,7 +51,6 @@ def service_config_valid():
         "command_handler_k8s_namespace": "packit-test-sandbox",
         "admins": ["Dasher", "Dancer", "Vixen", "Comet", "Blitzen"],
         "server_name": "hub.packit.org",
-        "gitlab_webhook_tokens": ["token1", "token2", "token3", "aged"],
         "gitlab_token_secret": "jwt_secret",
         "enabled_private_namespaces": [
             "gitlab.com/private/namespace",
@@ -79,7 +78,6 @@ def test_parse_valid(service_config_valid):
     assert config.admins == {"Dasher", "Dancer", "Vixen", "Comet", "Blitzen"}
     assert config.server_name == "hub.packit.org"
     assert config.gitlab_token_secret == "jwt_secret"
-    assert config.gitlab_webhook_tokens == {"token1", "token2", "token3", "aged"}
     assert config.enabled_private_namespaces == {
         "gitlab.com/private/namespace",
         "github.com/other-private-namespace",
@@ -149,7 +147,6 @@ def test_config_opts(sc):
     assert sc.webhook_secret is not None
     assert sc.validate_webhooks is not None
     assert sc.gitlab_token_secret is not None
-    assert sc.gitlab_webhook_tokens is not None
 
 
 @pytest.mark.skipif(

--- a/tests/unit/test_webhooks.py
+++ b/tests/unit/test_webhooks.py
@@ -15,7 +15,6 @@ def mock_config():
     config = flexmock(ServiceConfig)
     config.webhook_secret = "testing-secret"
     config.gitlab_token_secret = "gitlab-token-secret"
-    config.gitlab_webhook_tokens = []
     config.validate_webhooks = True
     return config
 


### PR DESCRIPTION
In #1090 support for group/namespace hooks was added.
In https://gitlab.com/redhat/centos-stream/src/cups/-/merge_requests/2 we tested it works OK.
It's time to remove the now useless gitlab_webhook_tokens.