### PR TITLE
Babysit Copr builds for 8 hours

### DIFF
--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -68,9 +68,10 @@ def process_message(
 @celery_app.task(
     bind=True,
     name="task.babysit_copr_build",
-    retry_backoff=60,  # retry again in 60s, 120s, 240s, 480s...
-    retry_backoff_max=60 * 60 * 8,  # is 8 hours okay? gcc/kernel build really long
-    max_retries=7,
+    retry_backoff=30,  # retry again in 30s, 60s, 120s, 240s...
+    retry_backoff_max=3600,  # at most, wait for an hour between retries
+    max_retries=14,  # retry 14 times; with the backoff values above this is ~8 hours
+    retry_jitter=False,  # do not jitter, as it might considerably reduce the total wait time
 )
 def babysit_copr_build(self, build_id: int):
     """check status of a copr build and update it in DB"""


### PR DESCRIPTION
And really mean it this time :)

The main issue was, that the default of 'retry_jitter' is true, which
meant that waiting time between two retries was a random number between
0 and the current backoff. This had a high chance to considerably reduce
the total waiting time, and this is why the MaxRetriesExceededErrors
were so frequent in Sentry.

The other issue was that although 'retry_backoff_max' was set to 8
hours, setting 'max_retries' to only 7 caused the maximum waiting time
never actually reach 8 hours. It reached only 1920 seconds, which
resulted in a maximum total waiting time of barely an hour. Wait times
can be longer than this, if Copr is busy.

With the current numbers reaching 8 hours of total wait time is actually
possible. Here is the table for the calculation:

| Retry | Backoff (seconds) |
|-------:|-------------------:|
|     1 |                30 |
|     2 |                60 |
|     3 |               120 |
|     4 |               240 |
|     5 |               480 |
|     6 |               960 |
|     7 |              1920 |
|     8 |              3600 | After the 7th retry we try every hour.
|     9 |              3600 |
|    10 |              3600 |
|    11 |              3600 |
|    12 |              3600 |
|    13 |              3600 |
|    14 |              3600 |
| Total |             29010 |
|       |          ~8 hours |

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>