### PR TITLE
fix tmt plan name

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -152,7 +152,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             "test": {
                 "fmf": {
                     "url": TESTING_FARM_INSTALLABILITY_TEST_URL,
-                    "name": "/packit/install-and-verify",
+                    "name": "/packit/installation",
                 },
             },
             "environments": [


### PR DESCRIPTION
Recently, Testing Farm started to recognize plan names
and the provided value was actually the test name.

All jobs using the install and verify test are now
failing due to this change.

```
$ tmt
Found 1 test: /packit/install-and-verify.
Found 1 plan: /packit/installation.
Found 0 stories.
```

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>