### PR TITLE
Switch from error to debug logging in allowlist

### DIFF
--- a/packit_service/worker/allowlist.py
+++ b/packit_service/worker/allowlist.py
@@ -276,7 +276,7 @@ class Allowlist:
             if not namespace_approved
             else f"Account {actor_name} has no write access nor is author of PR!"
         )
-        logger.error(msg)
+        logger.debug(msg)
         if isinstance(
             event, (PullRequestCommentGithubEvent, MergeRequestCommentGitlabEvent)
         ):
@@ -325,7 +325,7 @@ class Allowlist:
             if not namespace_approved
             else f"Account {actor_name} has no write access!"
         )
-        logger.error(msg)
+        logger.debug(msg)
         project.issue_comment(event.issue_id, msg)
         return False
 


### PR DESCRIPTION
Switch from logging action of not approved user from error to debug as
it is not a vital issue from our side and thus doesn't need to be tracked
in Sentry.

Signed-off-by: Matej Focko <mfocko@redhat.com>