### PR TITLE
[Dockerfiles] Don't COPY everything

### DIFF
--- a/files/docker/Dockerfile.tests
+++ b/files/docker/Dockerfile.tests
@@ -29,6 +29,9 @@ RUN ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml &
     ansible-playbook -vv -c local -i localhost, files/recipe-tests.yaml && \
     dnf clean all
 
-COPY . ./
+# setuptools-scm
+COPY .git/ .git/
+COPY packit_service/ packit_service/
+COPY setup.* ./
 
 RUN pip3 install -e . && pip3 check && rm -rf ~/.cache/*

--- a/files/docker/Dockerfile.worker
+++ b/files/docker/Dockerfile.worker
@@ -19,15 +19,13 @@ COPY files/ ./files/
 RUN ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
     && dnf clean all
 
-COPY setup.py setup.cfg .git_archival.txt .gitattributes ./
+COPY setup.* .git_archival.txt .gitattributes ./
 # setuptools-scm
-COPY .git ./.git
-COPY packit_service/ ./packit_service/
+COPY .git/ .git/
+COPY packit_service/ packit_service/
 
 RUN git rev-parse HEAD >/.packit-service.git.commit.hash \
     && git show --quiet --format=%B HEAD >/.packit-service.git.commit.message \
     && ansible-playbook -vv -c local -i localhost, files/recipe-worker.yaml
-
-COPY . ./
 
 CMD ["/usr/bin/run_worker.sh"]

--- a/files/docker/hooks/build
+++ b/files/docker/hooks/build
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# setting cwd to build context location defined in Dcker Hub build configuration -> build rules
-# required because this script is executed in Dockerfile location instead of provided
-# build context location, which is root for $DOCKERFILE_PATH
-cd /src/${BUILD_CODE}/${BUILD_PATH}
-
-docker build -t $IMAGE_NAME -f $DOCKERFILE_PATH --build-arg SOURCE_BRANCH=$SOURCE_BRANCH .


### PR DESCRIPTION
This was first added in 447f215fa without an explanation and I don't see why we'd need all those files.
I'm going to reuse the image in hardly and don't want them.

I tried the image locally via docker-compose and all looks fine.