### PR TITLE
Make main task name configurable

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -56,6 +56,8 @@ ALLOWLIST_CONSTANTS = {
 
 CELERY_DEFAULT_QUEUE_NAME = "short-running"
 
+CELERY_DEFAULT_MAIN_TASK_NAME = "task.steve_jobs.process_message"
+
 
 class KojiBuildState(Enum):
     """

--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -3,12 +3,14 @@
 
 import logging
 from http import HTTPStatus
+from os import getenv
 
 from flask import request
 from flask_restx import Namespace, Resource, fields
 
 from packit_service.celerizer import celery_app
 from packit_service.config import ServiceConfig
+from packit_service.constants import CELERY_DEFAULT_MAIN_TASK_NAME
 from packit_service.models import TFTTestRunModel, optional_time
 from packit_service.service.api.errors import ValidationFailed
 from packit_service.service.api.parsers import indices, pagination_arguments
@@ -57,7 +59,8 @@ class TestingFarmResults(Resource):
         # so make sure we don't confuse this with something else
         msg["source"] = "testing-farm"
         celery_app.send_task(
-            name="task.steve_jobs.process_message", kwargs={"event": msg}
+            name=getenv("CELERY_MAIN_TASK_NAME") or CELERY_DEFAULT_MAIN_TASK_NAME,
+            kwargs={"event": msg},
         )
 
         return "Test results accepted", HTTPStatus.OK

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -7,7 +7,11 @@ from typing import List, Optional
 
 from celery import Task
 from packit_service.celerizer import celery_app
-from packit_service.constants import DEFAULT_RETRY_LIMIT, DEFAULT_RETRY_BACKOFF
+from packit_service.constants import (
+    DEFAULT_RETRY_LIMIT,
+    DEFAULT_RETRY_BACKOFF,
+    CELERY_DEFAULT_MAIN_TASK_NAME,
+)
 from packit_service.utils import load_job_config, load_package_config
 from packit_service.worker.build.babysit import check_copr_build
 from packit_service.worker.handlers.abstract import TaskName
@@ -50,12 +54,14 @@ class HandlerTaskWithRetry(Task):
     retry_backoff = int(getenv("CELERY_RETRY_BACKOFF", DEFAULT_RETRY_BACKOFF))
 
 
-@celery_app.task(name="task.steve_jobs.process_message", bind=True)
+@celery_app.task(
+    name=getenv("CELERY_MAIN_TASK_NAME") or CELERY_DEFAULT_MAIN_TASK_NAME, bind=True
+)
 def process_message(
     self, event: dict, topic: str = None, source: str = None
 ) -> List[TaskResults]:
     """
-    Base celery task for processing messages.
+    Main celery task for processing messages.
 
     :param event: event data
     :param topic: event topic


### PR DESCRIPTION
To be hardly ;-) utilized, as discussed in
https://github.com/packit/hardly/pull/11#discussion_r668688299

The 'or' is used so that we use the default even when the env. var. is set to empty string.