### PR TITLE
Install setup_env_in_openshift.sh in /usr/bin/

### DIFF
--- a/files/run_httpd.sh
+++ b/files/run_httpd.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-source /src/files/setup_env_in_openshift.sh
+source /usr/bin/setup_env_in_openshift.sh
 
 pushd /src
 # if all containers started at the same time, pg is definitely not ready to serve

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -16,7 +16,7 @@ else
   LOGLEVEL="DEBUG"
 fi
 
-source /src/files/setup_env_in_openshift.sh
+source /usr/bin/setup_env_in_openshift.sh
 
 mkdir --mode=0700 -p "${PACKIT_HOME}/.ssh"
 pushd "${PACKIT_HOME}/.ssh"

--- a/files/tasks/common.yaml
+++ b/files/tasks/common.yaml
@@ -18,7 +18,7 @@
 - name: Let's make sure {{ packit_service_path }} is present
   assert:
     that:
-      - "src_path.stat.isdir"
+      - src_path.stat.isdir
 - name: Install packit-service from {{ packit_service_path }}
   pip:
     name: "{{ packit_service_path }}"
@@ -27,3 +27,7 @@
   file:
     state: absent
     path: ~/.cache/
+- name: Copy setup_env_in_openshift.sh
+  copy:
+    src: setup_env_in_openshift.sh
+    dest: /usr/bin/setup_env_in_openshift.sh


### PR DESCRIPTION
4a4c14616 cleans /src/ so the file can't be there.
It doesn't need to be executable since we just source it.