### PR TITLE
Install scripts for worker after deleting /src

### DIFF
--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -21,3 +21,10 @@
         src: run_worker.sh
         dest: /usr/bin/run_worker.sh
         mode: 0777
+    - name: Install scripts
+      copy:
+        src: "{{ item }}"
+        dest: /usr/bin/
+        mode: 0777
+      with_fileglob:
+        - scripts/*.py

--- a/files/scripts/allowlist.py
+++ b/files/scripts/allowlist.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import click
 
 from packit_service.worker.allowlist import Allowlist

--- a/files/scripts/webhook.py
+++ b/files/scripts/webhook.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 Generator of webhooks
 """


### PR DESCRIPTION
Since the contents of ‹/src› directory is deleted to be reused for hardly,
install the scripts (mainly ‹allowlist.py›) in ‹/usr/bin› and add shebangs
to be able to run the scripts without specifying interpreter explicitly.

Signed-off-by: Matej Focko <mfocko@redhat.com>