### PR TITLE
Use check runs for reporting in Github

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -58,6 +58,13 @@ CELERY_DEFAULT_QUEUE_NAME = "short-running"
 
 CELERY_DEFAULT_MAIN_TASK_NAME = "task.steve_jobs.process_message"
 
+MSG_MORE_DETAILS = "You can find more details about the job [here]({url}).\n\n"
+
+MSG_RERUN_NOT_SUPPORTED = (
+    "*Rerunning tasks via `Re-run` button is currently not supported, "
+    "please don't click it.*"
+)
+
 
 class KojiBuildState(Enum):
     """

--- a/packit_service/worker/allowlist.py
+++ b/packit_service/worker/allowlist.py
@@ -6,7 +6,7 @@ from typing import Any, Iterable, Optional, Union, Callable, List, Tuple, Dict
 
 from fedora.client import AuthError, FedoraServiceError
 from fedora.client.fas2 import AccountSystem
-from ogr.abstract import CommitStatus, GitProject
+from ogr.abstract import GitProject
 from packit.config.job_config import JobConfig
 from packit.exceptions import PackitException
 
@@ -34,6 +34,7 @@ from packit_service.worker.events import (
     TestingFarmResultsEvent,
 )
 from packit_service.worker.build import CoprBuildJobHelper
+from packit_service.worker.reporting import BaseCommitStatus
 
 logger = logging.getLogger(__name__)
 
@@ -297,7 +298,7 @@ class Allowlist:
                     else "User cannot trigger!"
                 )
                 job_helper.report_status_to_all(
-                    description=msg, state=CommitStatus.error, url=FAQ_URL
+                    description=msg, state=BaseCommitStatus.neutral, url=FAQ_URL
                 )
 
         return False

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List, Optional, Set, Tuple, Union
 
 from kubernetes.client.rest import ApiException
-from ogr.abstract import CommitStatus, GitProject
+from ogr.abstract import GitProject
 from ogr.exceptions import GitlabAPIException
 from ogr.services.gitlab import GitlabProject
 from packit.api import PackitAPI
@@ -23,7 +23,7 @@ from packit_service.config import Deployment, ServiceConfig
 from packit_service.models import RunModel, SRPMBuildModel
 from packit_service.worker.events import EventData
 from packit_service.trigger_mapping import are_job_types_same
-from packit_service.worker.reporting import StatusReporter
+from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 
 logger = logging.getLogger(__name__)
 
@@ -394,7 +394,7 @@ class BaseBuildJobHelper:
 
     def _report(
         self,
-        state: CommitStatus,
+        state: BaseCommitStatus,
         description: str,
         url: str = "",
         check_names: Union[str, list, None] = None,
@@ -412,9 +412,9 @@ class BaseBuildJobHelper:
             )
 
             final_commit_states = (
-                CommitStatus.success,
-                CommitStatus.failure,
-                CommitStatus.error,
+                BaseCommitStatus.success,
+                BaseCommitStatus.failure,
+                BaseCommitStatus.error,
             )
             # We are only commenting final states to avoid multiple comments for a build
             # Ignoring all other states eg. pending, running
@@ -429,7 +429,7 @@ class BaseBuildJobHelper:
         )
 
     def report_status_to_all(
-        self, description: str, state: CommitStatus, url: str = ""
+        self, description: str, state: BaseCommitStatus, url: str = ""
     ) -> None:
         self.report_status_to_build(description, state, url)
         self.report_status_to_tests(description, state, url)

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -231,7 +231,7 @@ class BaseBuildJobHelper:
     @property
     def status_reporter(self) -> StatusReporter:
         if not self._status_reporter:
-            self._status_reporter = StatusReporter(
+            self._status_reporter = StatusReporter.get_instance(
                 project=self.project,
                 commit_sha=self.metadata.commit_sha,
                 pr_id=self.metadata.pr_id,

--- a/packit_service/worker/handlers/bugzilla.py
+++ b/packit_service/worker/handlers/bugzilla.py
@@ -74,7 +74,7 @@ class BugzillaHandler(JobHandler):
     @property
     def status_reporter(self) -> StatusReporter:
         if not self._status_reporter:
-            self._status_reporter = StatusReporter(
+            self._status_reporter = StatusReporter.get_instance(
                 self.project, self.data.commit_sha, self.data.pr_id
             )
         return self._status_reporter

--- a/packit_service/worker/handlers/bugzilla.py
+++ b/packit_service/worker/handlers/bugzilla.py
@@ -5,7 +5,7 @@ import logging
 import re
 from typing import Optional
 
-from ogr.abstract import CommitStatus, PullRequest
+from ogr.abstract import PullRequest
 from packit.config import (
     JobConfig,
 )
@@ -22,7 +22,7 @@ from packit_service.worker.handlers.abstract import (
     reacts_to,
 )
 from packit_service.worker.psbugzilla import Bugzilla
-from packit_service.worker.reporting import StatusReporter
+from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 from packit_service.worker.result import TaskResults
 
 logger = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ curl {self.pr.url}.patch"""
             )
 
         self.status_reporter.set_status(
-            state=CommitStatus.success,
+            state=BaseCommitStatus.success,
             description="Bugzilla bug created.",
             check_name=f"RHBZ#{self.bz_model.bug_id}",
             url=self.bz_model.bug_url,

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import Optional
 
 from celery import signature
-from ogr.abstract import CommitStatus
 from ogr.services.github import GithubProject
 from ogr.services.gitlab import GitlabProject
 from packit.config import (
@@ -51,6 +50,7 @@ from packit_service.worker.handlers.abstract import (
     add_topic,
     FedmsgHandler,
 )
+from packit_service.worker.reporting import BaseCommitStatus
 from packit_service.worker.result import TaskResults
 
 logger = logging.getLogger(__name__)
@@ -198,7 +198,7 @@ class CoprBuildStartHandler(AbstractCoprBuildReportHandler):
 
         build_job_helper.report_status_to_all_for_chroot(
             description="RPM build is in progress...",
-            state=CommitStatus.pending,
+            state=BaseCommitStatus.running,
             url=url,
             chroot=self.copr_event.chroot,
         )
@@ -289,7 +289,7 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
         if self.copr_event.status != COPR_API_SUCC_STATE:
             failed_msg = "RPMs failed to be built."
             build_job_helper.report_status_to_all_for_chroot(
-                state=CommitStatus.failure,
+                state=BaseCommitStatus.failure,
                 description=failed_msg,
                 url=url,
                 chroot=self.copr_event.chroot,
@@ -322,13 +322,13 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
             self.project.pr_comment(pr_id=self.copr_event.pr_id, body=msg)
 
         build_job_helper.report_status_to_build_for_chroot(
-            state=CommitStatus.success,
+            state=BaseCommitStatus.success,
             description="RPMs were built successfully.",
             url=url,
             chroot=self.copr_event.chroot,
         )
         build_job_helper.report_status_to_test_for_chroot(
-            state=CommitStatus.pending,
+            state=BaseCommitStatus.pending,
             description="RPMs were built successfully.",
             url=url,
             chroot=self.copr_event.chroot,

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -9,7 +9,7 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from ogr.abstract import CommitStatus, GitProject
+from ogr.abstract import GitProject
 from packit.config import (
     JobConfig,
     JobType,
@@ -49,6 +49,7 @@ from packit_service.worker.handlers.abstract import (
     add_topic,
     FedmsgHandler,
 )
+from packit_service.worker.reporting import BaseCommitStatus
 from packit_service.worker.result import TaskResults
 
 logger = logging.getLogger(__name__)
@@ -120,7 +121,7 @@ class KojiBuildHandler(JobHandler):
             ):
                 self.koji_build_helper.report_status_to_all(
                     description=PERMISSIONS_ERROR_WRITE_OR_ADMIN,
-                    state=CommitStatus.failure,
+                    state=BaseCommitStatus.neutral,
                 )
                 return False
 
@@ -128,7 +129,7 @@ class KojiBuildHandler(JobHandler):
             msg = "Non-scratch builds not possible from upstream."
             self.koji_build_helper.report_status_to_all(
                 description=msg,
-                state=CommitStatus.error,
+                state=BaseCommitStatus.neutral,
                 url=KOJI_PRODUCTION_BUILDS_ISSUE,
             )
             return False
@@ -208,7 +209,7 @@ class KojiBuildReportHandler(FedmsgHandler):
             build.set_status("pending")
             build_job_helper.report_status_to_all_for_chroot(
                 description="RPM build is in progress...",
-                state=CommitStatus.pending,
+                state=BaseCommitStatus.running,
                 url=url,
                 chroot=build.target,
             )
@@ -216,7 +217,7 @@ class KojiBuildReportHandler(FedmsgHandler):
             build.set_status("success")
             build_job_helper.report_status_to_all_for_chroot(
                 description="RPMs were built successfully.",
-                state=CommitStatus.success,
+                state=BaseCommitStatus.success,
                 url=url,
                 chroot=build.target,
             )
@@ -224,7 +225,7 @@ class KojiBuildReportHandler(FedmsgHandler):
             build.set_status("failed")
             build_job_helper.report_status_to_all_for_chroot(
                 description="RPMs failed to be built.",
-                state=CommitStatus.failure,
+                state=BaseCommitStatus.failure,
                 url=url,
                 chroot=build.target,
             )
@@ -232,7 +233,7 @@ class KojiBuildReportHandler(FedmsgHandler):
             build.set_status("error")
             build_job_helper.report_status_to_all_for_chroot(
                 description="RPMs build was canceled.",
-                state=CommitStatus.error,
+                state=BaseCommitStatus.error,
                 url=url,
                 chroot=build.target,
             )

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -212,7 +212,7 @@ class TestingFarmResultsHandler(JobHandler):
 
         if test_run_model:
             test_run_model.set_web_url(self.log_url)
-        status_reporter = StatusReporter(
+        status_reporter = StatusReporter.get_instance(
             project=self.project, commit_sha=self.data.commit_sha, pr_id=self.data.pr_id
         )
         status_reporter.report(

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -9,7 +9,6 @@ from typing import Any
 from typing import List, Set, Type, Union
 
 from celery import group
-from ogr.abstract import CommitStatus
 from packit.config import JobConfig, PackageConfig
 
 from packit_service.config import ServiceConfig
@@ -45,6 +44,7 @@ from packit_service.worker.handlers.abstract import (
     SUPPORTED_EVENTS_FOR_HANDLER,
 )
 from packit_service.worker.parser import CentosEventParser, Parser
+from packit_service.worker.reporting import BaseCommitStatus
 from packit_service.worker.result import TaskResults
 
 REQUESTED_PULL_REQUEST_COMMENT = "/packit"
@@ -291,7 +291,7 @@ class SteveJobs:
 
                     job_helper.report_status_to_all(
                         description=TASK_ACCEPTED,
-                        state=CommitStatus.pending,
+                        state=BaseCommitStatus.pending,
                         url="",
                     )
                 signatures.append(

--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -1,18 +1,56 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-import hashlib
 import logging
-from typing import Optional, Union
+from enum import Enum
+from typing import Optional, Union, Dict
 
 import github
 import gitlab
 
 from ogr.abstract import CommitStatus, GitProject
+from ogr.services.github import GithubProject
+from ogr.services.github.check_run import (
+    create_github_check_run_output,
+    GithubCheckRunResult,
+    GithubCheckRunStatus,
+)
 from ogr.services.gitlab import GitlabProject
 from ogr.services.pagure import PagureProject
 
+from packit_service.constants import MSG_MORE_DETAILS, MSG_RERUN_NOT_SUPPORTED
+
 logger = logging.getLogger(__name__)
+
+
+class BaseCommitStatus(Enum):
+    failure = "failure"
+    neutral = "neutral"
+    success = "success"
+    pending = "pending"
+    running = "running"
+    error = "error"
+
+
+MAP_TO_COMMIT_STATUS: Dict[BaseCommitStatus, CommitStatus] = {
+    BaseCommitStatus.pending: CommitStatus.pending,
+    BaseCommitStatus.running: CommitStatus.running,
+    BaseCommitStatus.failure: CommitStatus.failure,
+    BaseCommitStatus.neutral: CommitStatus.error,
+    BaseCommitStatus.success: CommitStatus.success,
+    BaseCommitStatus.error: CommitStatus.error,
+}
+
+MAP_TO_CHECK_RUN: Dict[
+    BaseCommitStatus, Union[GithubCheckRunResult, GithubCheckRunStatus]
+] = {
+    BaseCommitStatus.pending: GithubCheckRunStatus.queued,
+    BaseCommitStatus.running: GithubCheckRunStatus.in_progress,
+    BaseCommitStatus.failure: GithubCheckRunResult.failure,
+    BaseCommitStatus.neutral: GithubCheckRunResult.neutral,
+    BaseCommitStatus.success: GithubCheckRunResult.success,
+    BaseCommitStatus.error: GithubCheckRunResult.failure,
+}
 
 
 class StatusReporter:
@@ -30,6 +68,22 @@ class StatusReporter:
         self.commit_sha: str = commit_sha
         self.pr_id: Optional[int] = pr_id
 
+    @classmethod
+    def get_instance(
+        cls, project: GitProject, commit_sha: str, pr_id: Optional[int] = None
+    ) -> "StatusReporter":
+        """
+        Get the StatusReporter instance.
+        """
+        reporter = StatusReporter
+        if isinstance(project, GithubProject):
+            reporter = StatusReporterGithubChecks
+        elif isinstance(project, GitlabProject):
+            reporter = StatusReporterGitlab
+        elif isinstance(project, PagureProject):
+            reporter = StatusReporterPagure
+        return reporter(project, commit_sha, pr_id)
+
     @property
     def project_with_commit(self) -> GitProject:
         """
@@ -44,9 +98,26 @@ class StatusReporter:
 
         return self._project_with_commit
 
+    @staticmethod
+    def get_commit_status(state: BaseCommitStatus):
+        return MAP_TO_COMMIT_STATUS[state]
+
+    @staticmethod
+    def get_check_run(state: BaseCommitStatus):
+        return MAP_TO_CHECK_RUN[state]
+
+    def set_status(
+        self,
+        state: BaseCommitStatus,
+        description: str,
+        check_name: str,
+        url: str = "",
+    ):
+        raise NotImplementedError()
+
     def report(
         self,
-        state: CommitStatus,
+        state: BaseCommitStatus,
         description: str,
         url: str = "",
         check_names: Union[str, list, None] = None,
@@ -72,28 +143,27 @@ class StatusReporter:
                 state=state, description=description, check_name=check, url=url
             )
 
-    def __set_pull_request_status(
-        self, check_name: str, description: str, url: str, state: CommitStatus
+    def _add_commit_comment_with_status(
+        self, state: BaseCommitStatus, description: str, check_name: str, url: str = ""
     ):
-        if self.pr_id is None:
-            return
-        pr = self.project.get_pr(self.pr_id)
-        if hasattr(pr, "set_flag") and pr.head_commit == self.commit_sha:
-            logger.debug("Setting the PR status (pagure only).")
-            pr.set_flag(  # type: ignore
-                username=check_name,
-                comment=description,
-                url=url,
-                status=state,
-                # For Pagure: generate a custom uid from the check_name,
-                # so that we can update flags we set previously,
-                # instead of creating new ones.
-                uid=hashlib.md5(check_name.encode()).hexdigest(),
+        body = (
+            "\n".join(
+                [
+                    f"- name: {check_name}",
+                    f"- state: {state.name}",
+                    f"- url: {url if url else 'not provided'}",
+                ]
             )
+            + f"\n\n{description}"
+        )
+        self.project.commit_comment(
+            commit=self.commit_sha,
+            body=body,
+        )
 
     def report_status_by_comment(
         self,
-        state: CommitStatus,
+        state: BaseCommitStatus,
         url: str,
         check_names: Union[str, list, None],
         description: str,
@@ -113,42 +183,70 @@ class StatusReporter:
         table = "\n".join(comment_table_rows)
         self.comment(table + f"\n### Description\n\n{description}")
 
-    def __add_commit_comment_with_status(
-        self, state: CommitStatus, description: str, check_name: str, url: str = ""
-    ):
-        body = (
-            "\n".join(
-                [
-                    f"- name: {check_name}",
-                    f"- state: {state.name}",
-                    f"- url: {url if url else 'not provided'}",
-                ]
-            )
-            + f"\n\n{description}"
-        )
-        self.project.commit_comment(
-            commit=self.commit_sha,
-            body=body,
-        )
+    def get_statuses(self):
+        self.project_with_commit.get_commit_statuses(commit=self.commit_sha)
+
+    def comment(self, body: str):
+        if self.pr_id:
+            self.project.get_pr(pr_id=self.pr_id).comment(body=body)
+        else:
+            self.project.commit_comment(commit=self.commit_sha, body=body)
+
+
+class StatusReporterPagure(StatusReporter):
+    @staticmethod
+    def get_commit_status(state: BaseCommitStatus):
+        state = StatusReporter.get_commit_status(state)
+        # Pagure has no running status
+        if state == CommitStatus.running:
+            state = CommitStatus.pending
+
+        return state
 
     def set_status(
         self,
-        state: CommitStatus,
+        state: BaseCommitStatus,
         description: str,
         check_name: str,
         url: str = "",
     ):
-        # Required because Pagure API doesn't accept empty url.
-        if not url and isinstance(self.project, PagureProject):
-            url = "https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream"
-
+        state_to_set = self.get_commit_status(state)
         logger.debug(
-            f"Setting status '{state.name}' for check '{check_name}': {description}"
+            f"Setting Pagure status '{state_to_set.name}' for check '{check_name}': {description}"
         )
 
+        # Required because Pagure API doesn't accept empty url.
+        if not url:
+            url = "https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream"
+
+        self.project_with_commit.set_commit_status(
+            self.commit_sha, state_to_set, url, description, check_name, trim=True
+        )
+
+
+class StatusReporterGitlab(StatusReporter):
+    @staticmethod
+    def get_commit_status(state: BaseCommitStatus):
+        state = StatusReporter.get_commit_status(state)
+        # Gitlab has no error status
+        if state == CommitStatus.error:
+            state = CommitStatus.failure
+        return state
+
+    def set_status(
+        self,
+        state: BaseCommitStatus,
+        description: str,
+        check_name: str,
+        url: str = "",
+    ):
+        state_to_set = self.get_commit_status(state)
+        logger.debug(
+            f"Setting Gitlab status '{state_to_set.name}' for check '{check_name}': {description}"
+        )
         try:
             self.project_with_commit.set_commit_status(
-                self.commit_sha, state, url, description, check_name, trim=True
+                self.commit_sha, state_to_set, url, description, check_name, trim=True
             )
         except gitlab.exceptions.GitlabCreateError as e:
             # Ignoring Gitlab 'enqueue' error
@@ -160,23 +258,78 @@ class StatusReporter:
                     f"Failed to set status for {self.commit_sha}, commenting on"
                     f" commit as a fallback: {str(e)}"
                 )
-                self.__add_commit_comment_with_status(
+                self._add_commit_comment_with_status(
                     state, description, check_name, url
                 )
             if e.response_code not in {400, 403, 404}:
                 raise
-        except github.GithubException:
-            self.__add_commit_comment_with_status(state, description, check_name, url)
 
-        # Also set the status of the pull-request for forges which don't do
-        # this automatically based on the flags on the last commit in the PR.
-        self.__set_pull_request_status(check_name, description, url, state)
 
-    def get_statuses(self):
-        self.project_with_commit.get_commit_statuses(commit=self.commit_sha)
+class StatusReporterGithubStatuses(StatusReporter):
+    @staticmethod
+    def get_commit_status(state: BaseCommitStatus):
+        state = StatusReporter.get_commit_status(state)
+        # Github has no running status
+        if state == CommitStatus.running:
+            state = CommitStatus.pending
+        return state
 
-    def comment(self, body: str):
-        if self.pr_id:
-            self.project.get_pr(pr_id=self.pr_id).comment(body=body)
-        else:
-            self.project.commit_comment(commit=self.commit_sha, body=body)
+    def set_status(
+        self,
+        state: BaseCommitStatus,
+        description: str,
+        check_name: str,
+        url: str = "",
+    ):
+        state_to_set = self.get_commit_status(state)
+        logger.debug(
+            f"Setting Github status '{state_to_set.name}' for check '{check_name}': {description}"
+        )
+        try:
+            self.project_with_commit.set_commit_status(
+                self.commit_sha, state_to_set, url, description, check_name, trim=True
+            )
+        except github.GithubException as e:
+            logger.debug(
+                f"Failed to set status for {self.commit_sha}, commenting on"
+                f" commit as a fallback: {str(e)}"
+            )
+            self._add_commit_comment_with_status(state, description, check_name, url)
+
+
+class StatusReporterGithubChecks(StatusReporterGithubStatuses):
+    def set_status(
+        self,
+        state: BaseCommitStatus,
+        description: str,
+        check_name: str,
+        url: str = "",
+    ):
+        state_to_set = self.get_check_run(state)
+        logger.debug(
+            f"Setting Github status check '{state_to_set.name}' for check '{check_name}':"
+            f" {description}"
+        )
+        summary = (MSG_MORE_DETAILS.format(url=url) if url else "") + (
+            MSG_RERUN_NOT_SUPPORTED
+            if state_to_set == GithubCheckRunResult.failure
+            else ""
+        )
+        try:
+            self.project_with_commit.create_check_run(
+                name=check_name,
+                commit_sha=self.commit_sha,
+                url=url,
+                status=state_to_set
+                if isinstance(state_to_set, GithubCheckRunStatus)
+                else GithubCheckRunStatus.completed,
+                conclusion=state_to_set
+                if isinstance(state_to_set, GithubCheckRunResult)
+                else None,
+                output=create_github_check_run_output(description, summary),
+            )
+        except github.GithubException as e:
+            logger.debug(
+                f"Failed to set status check, setting status as a fallback: {str(e)}"
+            )
+            super().set_status(state, description, check_name, url)

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -6,7 +6,6 @@ import os
 import pytest
 from flexmock import flexmock
 
-from ogr.abstract import CommitStatus
 from ogr.services.github import GithubProject
 from packit.config import JobConfig, JobConfigTriggerType, JobType, PackageConfig
 from packit.config.job_config import JobMetadataConfig
@@ -18,7 +17,7 @@ from packit_service.worker.handlers import (
     CoprBuildHandler,
     KojiBuildHandler,
 )
-from packit_service.worker.reporting import StatusReporter
+from packit_service.worker.reporting import StatusReporterGithubChecks, BaseCommitStatus
 
 
 @pytest.fixture()
@@ -147,8 +146,8 @@ def test_precheck_koji_build_non_scratch(github_pr_event):
     ).and_return(
         flexmock(id=342, job_config_trigger_type=JobConfigTriggerType.pull_request)
     )
-    flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.error,
+    flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
+        state=BaseCommitStatus.neutral,
         description="Non-scratch builds not possible from upstream.",
         check_name="packit-stg/production-build-bright-future",
         url=KOJI_PRODUCTION_BUILDS_ISSUE,

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -9,7 +9,6 @@ from celery.canvas import Signature
 from flexmock import flexmock
 from github import Github
 
-from ogr.abstract import CommitStatus
 from ogr.services.github import GithubProject
 from packit.config import JobConfigTriggerType
 from packit.local_project import LocalProject
@@ -31,6 +30,7 @@ from packit_service.worker.tasks import (
 )
 from packit_service.worker.testing_farm import TestingFarmJobHelper
 from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.reporting import BaseCommitStatus
 from tests.spellbook import DATA_DIR, first_dict_value, get_parameters_from_results
 
 
@@ -181,7 +181,7 @@ def test_pr_comment_copr_build_handler(
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(CoprBuildJobHelper).should_receive("report_status_to_all").with_args(
         description=TASK_ACCEPTED,
-        state=CommitStatus.pending,
+        state=BaseCommitStatus.pending,
         url="",
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
@@ -217,7 +217,7 @@ def test_pr_comment_build_handler(
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(CoprBuildJobHelper).should_receive("report_status_to_all").with_args(
         description=TASK_ACCEPTED,
-        state=CommitStatus.pending,
+        state=BaseCommitStatus.pending,
         url="",
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
@@ -287,7 +287,7 @@ def test_pr_comment_production_build_handler(pr_production_build_comment_event):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(KojiBuildJobHelper).should_receive("report_status_to_all").with_args(
         description=TASK_ACCEPTED,
-        state=CommitStatus.pending,
+        state=BaseCommitStatus.pending,
         url="",
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
@@ -360,7 +360,7 @@ def test_pr_embedded_command_handler(
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(CoprBuildJobHelper).should_receive("report_status_to_all").with_args(
         description=TASK_ACCEPTED,
-        state=CommitStatus.pending,
+        state=BaseCommitStatus.pending,
         url="",
     ).once()
     flexmock(Signature).should_receive("apply_async").once()

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -8,7 +8,7 @@ from copr.v3 import Client
 from fedora.client import AuthError, FedoraServiceError
 from fedora.client.fas2 import AccountSystem
 from flexmock import flexmock
-from ogr.abstract import GitProject, GitService, CommitStatus
+from ogr.abstract import GitProject, GitService
 from ogr.services.github import GithubProject, GithubService
 from packit.config import JobType, JobConfig, JobConfigTriggerType
 from packit.config.job_config import JobMetadataConfig
@@ -37,7 +37,7 @@ from packit_service.worker.events.enums import (
     IssueCommentAction,
 )
 from packit_service.worker.allowlist import Allowlist
-from packit_service.worker.reporting import StatusReporter
+from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 
 EXPECTED_TESTING_FARM_CHECK_NAME = "packit-stg/testing-farm-fedora-rawhide-x86_64"
 
@@ -490,7 +490,7 @@ def test_check_and_report(
     flexmock(
         GithubProject,
         pr_comment=lambda *args, **kwargs: None,
-        set_commit_status=lambda *args, **kwargs: None,
+        create_check_run=lambda *args, **kwargs: None,
         issue_comment=lambda *args, **kwargs: None,
         get_pr=lambda *args, **kwargs: flexmock(source_project=flexmock(), author=None),
     )
@@ -538,7 +538,7 @@ def test_check_and_report(
             flexmock(LocalProject).should_receive("checkout_pr").and_return(None)
             flexmock(StatusReporter).should_receive("report").with_args(
                 description="Namespace is not allowed!",
-                state=CommitStatus.error,
+                state=BaseCommitStatus.neutral,
                 url=FAQ_URL,
                 check_names=[EXPECTED_TESTING_FARM_CHECK_NAME],
             ).once()

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -6,7 +6,7 @@ from typing import Union
 import pytest
 from flexmock import flexmock
 
-from ogr.abstract import GitProject, CommitStatus
+from ogr.abstract import GitProject
 from packit.api import PackitAPI
 from packit.config import (
     PackageConfig,
@@ -34,7 +34,7 @@ from packit_service.service.urls import (
 )
 from packit_service.worker.build import koji_build
 from packit_service.worker.build.koji_build import KojiBuildJobHelper
-from packit_service.worker.reporting import StatusReporter
+from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 
 
 def build_helper(
@@ -102,13 +102,13 @@ def test_koji_build_check_names(github_pr_event):
 
     koji_build_url = get_koji_build_info_url(1)
     flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.pending,
+        state=BaseCommitStatus.running,
         description="Building SRPM ...",
         check_name="packit-stg/production-build-bright-future",
         url="",
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.pending,
+        state=BaseCommitStatus.running,
         description="Building RPM ...",
         check_name="packit-stg/production-build-bright-future",
         url=koji_build_url,
@@ -153,13 +153,13 @@ def test_koji_build_failed_kerberos(github_pr_event):
     ).never()
 
     flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.pending,
+        state=BaseCommitStatus.running,
         description="Building SRPM ...",
         check_name="packit-stg/production-build-bright-future",
         url="",
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.error,
+        state=BaseCommitStatus.error,
         description="Kerberos authentication error: the bad authentication error",
         check_name="packit-stg/production-build-bright-future",
         url=get_srpm_build_info_url(1),
@@ -205,13 +205,13 @@ def test_koji_build_target_not_supported(github_pr_event):
     ).once()
 
     flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.pending,
+        state=BaseCommitStatus.running,
         description="Building SRPM ...",
         check_name="packit-stg/production-build-nonexisting-target",
         url="",
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.error,
+        state=BaseCommitStatus.error,
         description="Target not supported: nonexisting-target",
         check_name="packit-stg/production-build-nonexisting-target",
         url=get_srpm_build_info_url(1),
@@ -299,7 +299,7 @@ def test_koji_build_failed(github_pr_event):
     ).once()
 
     flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.pending,
+        state=BaseCommitStatus.running,
         description="Building SRPM ...",
         check_name="packit-stg/production-build-bright-future",
         url="",
@@ -307,7 +307,7 @@ def test_koji_build_failed(github_pr_event):
 
     srpm_build_url = get_srpm_build_info_url(2)
     flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.error,
+        state=BaseCommitStatus.error,
         description="Submit of the build failed: some error",
         check_name="packit-stg/production-build-bright-future",
         url=srpm_build_url,
@@ -345,13 +345,13 @@ def test_koji_build_failed_srpm(github_pr_event):
     )
     srpm_build_url = get_srpm_build_info_url(2)
     flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.pending,
+        state=BaseCommitStatus.running,
         description="Building SRPM ...",
         check_name="packit-stg/production-build-bright-future",
         url="",
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
-        state=CommitStatus.failure,
+        state=BaseCommitStatus.failure,
         description="SRPM build failed, check the logs for details.",
         check_name="packit-stg/production-build-bright-future",
         url=srpm_build_url,

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -3,7 +3,6 @@
 
 import pytest
 from flexmock import flexmock
-from ogr.abstract import CommitStatus
 from packit.config import JobConfig, JobType, JobConfigTriggerType
 from packit.config.job_config import JobMetadataConfig
 from packit.local_project import LocalProject
@@ -22,7 +21,7 @@ from packit_service.models import TestingFarmResult as TFResult
 
 from packit_service.worker.handlers import TestingFarmResultsHandler as TFResultsHandler
 from packit_service.worker.handlers import TestingFarmHandler
-from packit_service.worker.reporting import StatusReporter
+from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 from packit_service.worker.testing_farm import (
     TestingFarmJobHelper as TFJobHelper,
 )
@@ -37,28 +36,28 @@ from celery import Signature
         pytest.param(
             TFResult.passed,
             "some summary",
-            CommitStatus.success,
+            BaseCommitStatus.success,
             "some summary",
             id="passed_and_summary_provided",
         ),
         pytest.param(
             TFResult.passed,
             None,
-            CommitStatus.success,
+            BaseCommitStatus.success,
             "Tests passed ...",
             id="passed_and_summary_not_provided",
         ),
         pytest.param(
             TFResult.failed,
             "some summary",
-            CommitStatus.failure,
+            BaseCommitStatus.failure,
             "some summary",
             id="failed_and_summary_provided",
         ),
         pytest.param(
             TFResult.failed,
             None,
-            CommitStatus.failure,
+            BaseCommitStatus.failure,
             "Tests failed ...",
             id="failed_and_summary_not_provided",
         ),

--- a/tests_requre/database/test_tasks.py
+++ b/tests_requre/database/test_tasks.py
@@ -147,9 +147,9 @@ def test_check_copr_build(clean_before_and_after, packit_build_752):
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
+    flexmock(GithubProject).should_receive("create_check_run").and_return().once()
     flexmock(GithubProject).should_receive("get_pr_comments").and_return([])
     flexmock(GithubProject).should_receive("pr_comment").and_return()
-    flexmock(GithubProject).should_receive("set_commit_status").and_return().once()
     flexmock(GithubProject).should_receive("get_git_urls").and_return(
         {"git": "https://github.com/packit-service/packit.git"}
     )


### PR DESCRIPTION
- create BaseCommitStatus to unify statuses and checks
- create subclasses of StatusReporter for each forge
- StatusReporterGithubStatuses parent class for StatusReporterGithubChecks so that we can fallback to statuses (e.g. no permissions for checks)
- improved mapping of statuses which don't exist for some forge (e.g. Gitlab has running status, Github and Pagure not), therefore  some statuses changed from pending to running `e.g. Build in progress...` 
- neutral statuses for permission problems 
- get rid of flagging PRs in Pagure

Implements #760, #591

TODO:

- [x] agree on the check run output form (https://github.com/packit/hello-world/pull/111/checks?check_run_id=3114072495)
- [x] figure out what to do with re-run on failed check runs