### PR TITLE
Don't set empty string as URL for Github check runs

### DIFF
--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -319,7 +319,9 @@ class StatusReporterGithubChecks(StatusReporterGithubStatuses):
             self.project_with_commit.create_check_run(
                 name=check_name,
                 commit_sha=self.commit_sha,
-                url=url,
+                url=url
+                if url
+                else None,  # must use the http or https scheme, cannot be ""
                 status=state_to_set
                 if isinstance(state_to_set, GithubCheckRunStatus)
                 else GithubCheckRunStatus.completed,

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -876,7 +876,7 @@ def test_copr_build_fails_in_packit(github_pr_event):
         flexmock(GithubProject).should_receive("create_check_run").with_args(
             name=templ.format(ver=v),
             commit_sha="528b803be6f93e19ca4130bf4976f2800a3004c4",
-            url="",
+            url=None,
             status=GithubCheckRunStatus.in_progress,
             conclusion=None,
             output=create_github_check_run_output("Building SRPM ...", ""),
@@ -934,7 +934,7 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
         flexmock(GithubProject).should_receive("create_check_run").with_args(
             name=templ.format(ver=v),
             commit_sha="528b803be6f93e19ca4130bf4976f2800a3004c4",
-            url="",
+            url=None,
             status=GithubCheckRunStatus.in_progress,
             conclusion=None,
             output=create_github_check_run_output("Building SRPM ...", ""),
@@ -943,7 +943,7 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
         flexmock(GithubProject).should_receive("create_check_run").with_args(
             name=templ.format(ver=v),
             commit_sha="528b803be6f93e19ca4130bf4976f2800a3004c4",
-            url="",
+            url=None,
             status=GithubCheckRunStatus.completed,
             conclusion=GithubCheckRunResult.failure,
             output=create_github_check_run_output(


### PR DESCRIPTION
Just tested the check runs https://github.com/packit/hello-world/pull/396 and empty URL is not allowed for the check runs:
 `Failed to set status check, setting status as a fallback: 422 {"message": "Validation Failed", "errors": [{"resource": "CheckRun", "code": "custom", "field": "details_url", "message": "details_url must use the http or https scheme"}], "documentation_url": "https://docs.github.com/rest/reference/checks#create-a-check-run "}`