### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+TODO:
+
+- [ ] ‹fill in›
+
+<!-- notes for reviewers -->
+
+<!-- Links to other issues or pull requests,
+     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
+       (‹namespace›/‹repository›!‹ID of PR› respectively)
+-->
+
+Fixes
+
+Related to
+
+Merge before/after
+
+---
+
+<!-- release notes for blog follow -->


### PR DESCRIPTION
Add PR template to simplify adding release notes for blog post to the PRs
and ensure unified format across our projects and PRs.

Signed-off-by: Matej Focko <mfocko@redhat.com>