### PR TITLE
Explicitly specify the ref for installability tests

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -20,6 +20,7 @@ CONFIG_FILE_NAME = "packit-service.yaml"
 
 TESTING_FARM_API_URL = "https://api.dev.testing-farm.io/v0.1/"
 TESTING_FARM_INSTALLABILITY_TEST_URL = "https://gitlab.com/testing-farm/tests"
+TESTING_FARM_INSTALLABILITY_TEST_REF = "main"
 
 MSG_RETRIGGER = (
     "You can retrigger the {job} by adding a comment (`/packit {command}`) "

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -14,7 +14,10 @@ from packit.exceptions import PackitConfigException
 from packit.utils import nested_get
 
 from packit_service.config import ServiceConfig
-from packit_service.constants import TESTING_FARM_INSTALLABILITY_TEST_URL
+from packit_service.constants import (
+    TESTING_FARM_INSTALLABILITY_TEST_URL,
+    TESTING_FARM_INSTALLABILITY_TEST_REF,
+)
 from packit_service.models import CoprBuildModel, TFTTestRunModel, TestingFarmResult
 from packit_service.sentry_integration import send_to_sentry
 from packit_service.worker.events import EventData
@@ -153,6 +156,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             "test": {
                 "fmf": {
                     "url": TESTING_FARM_INSTALLABILITY_TEST_URL,
+                    "ref": TESTING_FARM_INSTALLABILITY_TEST_REF,
                     "name": "/packit/installation",
                 },
             },


### PR DESCRIPTION
The 'master' branch was renamed to 'main' in the test-repo,
but Testing Farm still defaults to 'master', which makes the tests to
fail.

Be explicit about the branch name to work around this.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>