### PR TITLE
Add mapping for Oracle Linux for internal TF

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -218,7 +218,12 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         * CentOS-x ->  CentOS-x-latest
         * CentOS-Stream-8 -> RHEL-8.5.0-Nightly
         """
-        compose = distro.title().replace("Centos", "CentOS").replace("Rhel", "RHEL")
+        compose = (
+            distro.title()
+            .replace("Centos", "CentOS")
+            .replace("Rhel", "RHEL")
+            .replace("Oraclelinux", "Oracle-Linux")
+        )
         if compose == "CentOS-Stream":
             compose = "CentOS-Stream-8"
 
@@ -237,6 +242,10 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
                 return "RHEL-7-LatestReleased"
             if compose == "RHEL-8":
                 return "RHEL-8.5.0-Nightly"
+            if compose == "Oracle-Linux-7":
+                return "Oracle-Linux-7.9"
+            if compose == "Oracle-Linux-8":
+                return "Oracle-Linux-8.4"
         else:
             response = self.send_testing_farm_request(endpoint="composes")
             if response.status_code == 200:

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -140,6 +140,8 @@ def test_testing_farm_response(
         ("centos-stream-x86_64", "centos-stream", "x86_64", True),
         ("epel-7-x86_64", "rhel-7", "x86_64", True),
         ("epel-8-x86_64", "rhel-8", "x86_64", True),
+        ("oraclelinux-7-x86_64", "oraclelinux-7", "x86_64", True),
+        ("oraclelinux-8-x86_64", "oraclelinux-8", "x86_64", True),
     ],
 )
 def test_chroot2distro_arch(chroot, distro, arch, use_internal_tf):
@@ -179,6 +181,8 @@ def test_chroot2distro_arch(chroot, distro, arch, use_internal_tf):
         ("Centos-8", "CentOS-8-latest", True),
         ("rhel-7", "RHEL-7-LatestReleased", True),
         ("rhel-8", "RHEL-8.5.0-Nightly", True),
+        ("oraclelinux-7", "Oracle-Linux-7.9", True),
+        ("oraclelinux-8", "Oracle-Linux-8.4", True),
     ],
 )
 def test_distro2compose(distro, compose, use_internal_tf):


### PR DESCRIPTION
Signed-off-by: Frantisek Lachman <flachman@redhat.com>

Fixes: packit/packit-service#1164

@thrix @bocekm

---

You can use `oraclelinux-7`/`oraclelinux-8` chroots for build and test your package for Oracle Linux.
