### PR TITLE
Fix running tests if there is no build or failed build

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -889,19 +889,26 @@ class CoprBuildModel(ProjectAndTriggersConnector, Base):
             return query.first()
 
     @classmethod
-    def get_all_by_owner_and_project_and_target(
+    def get_all_by_owner_project_target_commit(
         cls,
         owner: str,
         project_name: str,
         target: str,
+        commit_sha: str,
     ) -> Optional[Iterable["CoprBuildModel"]]:
         """
         All owner/project_name builds sorted from latest to oldest
+        with the given target and commit_sha.
         """
         with get_sa_session() as session:
             query = (
                 session.query(CoprBuildModel)
-                .filter_by(owner=owner, project_name=project_name, target=target)
+                .filter_by(
+                    owner=owner,
+                    project_name=project_name,
+                    target=target,
+                    commit_sha=commit_sha,
+                )
                 .order_by(CoprBuildModel.build_id.desc())
             )
             return query.all()

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -516,7 +516,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     )
 
     flexmock(CoprBuildModel).should_receive(
-        "get_all_by_owner_and_project_and_target"
+        "get_all_by_owner_project_target_commit"
     ).and_return([copr_build_pr])
 
     run_testing_farm_handler(

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -309,12 +309,15 @@ def test_get_by_build_id(clean_before_and_after, multiple_copr_builds):
     assert build_c.project_name == "different-project-name"
 
 
-def test_get_all_by_owner_and_project(clean_before_and_after, multiple_copr_builds):
+def test_get_all_by_owner_project_target_commit(
+    clean_before_and_after, multiple_copr_builds
+):
     builds_list = list(
-        CoprBuildModel.get_all_by_owner_and_project_and_target(
+        CoprBuildModel.get_all_by_owner_project_target_commit(
             owner=SampleValues.owner,
             project_name=SampleValues.project,
             target=SampleValues.target,
+            commit_sha=SampleValues.ref,
         )
     )
     assert len(builds_list) == 2


### PR DESCRIPTION
This mainly changes the behaviour for tests triggered by `/packit test`
- If there is a missing build for some target, trigger a new task to build in Copr.
- If the latest Copr build has failed status for some target, set the Github check/status for that target so that user is informed about this and run tests for the other targets (currently, the tests are submitted also for failed builds and we got later failure from TF, [example](https://github.com/packit/hello-world/pull/426/checks?check_run_id=3238411179)). We can discuss this behaviour and it can be improved in the future e.g. to run the build.

Fixes #1182 

---
The behaviour of running tests triggered by `/packit test` comment was improved. If there is no existing Copr build when the tests are triggered, Packit service should now react and create a new build. Also when the last Copr build status is failed, tests are not submitted and users are informed about this.