### PR TITLE
Install python3-flexmock-0.10.4 in test image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ check:
 	find . -name "*.pyc" -exec rm {} \;
 	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --color=$(COLOR) --verbose --showlocals --cov=packit_service --cov-report=$(COV_REPORT) $(TEST_TARGET)
 
+# In most cases you don't need to build your test-image, the one in registry should be all you need.
+# But if you think you need your (because of some new dependency, for example),
+# remove the '--pull=always' in check-in-container target before running it.
 build-test-image: files/install-deps-worker.yaml files/install-deps.yaml files/recipe-tests.yaml
 	$(CONTAINER_ENGINE) build --rm -t $(TEST_IMAGE) -f files/docker/Dockerfile.tests --build-arg SOURCE_BRANCH=$(SOURCE_BRANCH) .
 

--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -5,7 +5,8 @@
     - name: Install test RPM dependencies
       dnf:
         name:
-          - python3-flexmock
+          # 0.10.5 causes a regression
+          - python3-flexmock-0.10.4
           - tar
           - rsync
         state: present


### PR DESCRIPTION
This is just a workaround and something better will need to be done once that build disappears from fedora repos.

I spent some time trying to figure out the cause, but gave up as I have better things to do.

The tests here will fail anyway, because the image is cached in the registry, i.e. we first need to merge this to build the new tests image.

---

N/A
