### PR TITLE
Check for merge conflicts before creating SRPM

### DIFF
--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -182,7 +182,8 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             # pagure requires "valid url"
             url="",
         )
-        self.create_srpm_if_needed()
+        if results := self.create_srpm_if_needed():
+            return results
 
         if not self.srpm_model.success:
             msg = "SRPM build failed, check the logs for details."

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -100,7 +100,8 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         self.report_status_to_all(
             description="Building SRPM ...", state=BaseCommitStatus.running
         )
-        self.create_srpm_if_needed()
+        if results := self.create_srpm_if_needed():
+            return results
 
         if not self.srpm_model.success:
             msg = "SRPM build failed, check the logs for details."


### PR DESCRIPTION
In addition to merging pull request changes into base branch before
running SRPM build, check for potential merge conflicts and set neutral
status, if detected.

Related to packit/packit#1344

Merge after packit/packit#1344 (To ensure image is rebuilt with the latest packit)

---

<!-- release notes for changelog/blog follow -->

Packit Service now runs Copr and Koji builds and following tests on Testing Farm for pull requests on the code that would be a result of merging into the target branch. In case merge conflicts occur during preparation of SRPM, you can find more info in the SRPM logs.