### PR TITLE
Unpin flexmock

### DIFF
--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -5,8 +5,7 @@
     - name: Install test RPM dependencies
       dnf:
         name:
-          # 0.10.5 causes a regression
-          - python3-flexmock-0.10.4
+          - python3-flexmock
           - tar
           - rsync
         state: present


### PR DESCRIPTION
0.10.6, which fixes problems we saw with 0.10.5, has been pushed to stable.
Tried locally, works OK.

---

N/A
