### PR TITLE
Support a subset of chroots for builds, tests

### DIFF
--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -40,6 +40,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         metadata: EventData,
         db_trigger,
         job_config: JobConfig,
+        targets_override: Optional[Set[str]] = None,
     ):
         super().__init__(
             service_config=service_config,
@@ -48,6 +49,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
             metadata=metadata,
             db_trigger=db_trigger,
             job_config=job_config,
+            targets_override=targets_override,
         )
         self.msg_retrigger: str = MSG_RETRIGGER.format(
             job="build", command="production-build", place="pull request"
@@ -61,32 +63,17 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         return self.job_build and self.job_build.metadata.scratch
 
     @property
-    def build_targets(self) -> Set[str]:
+    def build_targets_all(self) -> Set[str]:
         """
-        Return the targets/chroots to build.
-
-        (Used when submitting the koji/copr build and as a part of the commit status name.)
-
-        1. If the job is not defined, use the test chroots.
-        2. If the job is defined without targets, use "fedora-stable".
+        Return all valid Koji targets/chroots from config.
         """
         return get_koji_targets(*self.configured_build_targets)
 
     @property
-    def tests_targets(self) -> Set[str]:
+    def tests_targets_all(self) -> Set[str]:
         """
         [not used now]
-
-        Return the list of targets/chroots used in testing farm.
-        Has to be a sub-set of the `build_targets`.
-
-        (Used when submitting the koji/copr build and as a part of the commit status name.)
-
-        Return an empty list if there is no job configured.
-
-        If not defined:
-        1. use the build_targets if the job si configured
-        2. use "fedora-stable" alias otherwise
+        Return all valid test targets/chroots from config.
         """
         return get_koji_targets(*self.configured_tests_targets)
 

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -96,18 +96,11 @@ class TestingFarmHandler(JobHandler):
             metadata=self.data,
             db_trigger=self.db_trigger,
             job_config=self.job_config,
+            targets_override={self.chroot} if self.chroot else None,
         )
 
-        if self.data.event_type in (
-            PullRequestCommentGithubEvent.__name__,
-            MergeRequestCommentGitlabEvent.__name__,
-            PullRequestCommentPagureEvent.__name__,
-        ):
-            logger.debug(f"Test job config: {testing_farm_helper.job_tests}")
-            targets = list(testing_farm_helper.tests_targets)
-        else:
-            targets = [self.chroot]
-
+        logger.debug(f"Test job config: {testing_farm_helper.job_tests}")
+        targets = list(testing_farm_helper.tests_targets)
         logger.debug(f"Targets to run the tests: {targets}")
         targets_with_builds = {}
         for target in targets:

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional, Tuple, Set
 
 import requests
 from ogr.abstract import GitProject
@@ -38,6 +38,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         metadata: EventData,
         db_trigger,
         job_config: JobConfig,
+        targets_override: Optional[Set[str]] = None,
     ):
         super().__init__(
             service_config=service_config,
@@ -46,6 +47,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             metadata=metadata,
             db_trigger=db_trigger,
             job_config=job_config,
+            targets_override=targets_override,
         )
 
         self.session = requests.session()

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -182,7 +182,7 @@ def test_pr_comment_copr_build_handler(
         "https://github.com/the-namespace/the-repo"
     )
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return([])
+    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(set())
     flexmock(CoprBuildJobHelper).should_receive("report_status_to_all").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -220,7 +220,7 @@ def test_pr_comment_build_handler(
     )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return([])
+    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(set())
     flexmock(CoprBuildJobHelper).should_receive("report_status_to_all").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -366,7 +366,7 @@ def test_pr_embedded_command_handler(
     )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return([])
+    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(set())
     flexmock(CoprBuildJobHelper).should_receive("report_status_to_all").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -466,7 +466,7 @@ def test_pr_test_command_handler(pr_embedded_command_comment_event):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(copr_build).should_receive("get_valid_build_targets").twice().and_return(
-        ["test-target"]
+        {"test-target"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
         flexmock(status=PG_COPR_BUILD_STATUS_SUCCESS)
@@ -541,7 +541,7 @@ def test_pr_test_command_handler_no_build(pr_embedded_command_comment_event):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(Signature).should_receive("apply_async").twice()
     flexmock(copr_build).should_receive("get_valid_build_targets").twice().and_return(
-        ["test-target"]
+        {"test-target"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return()
     flexmock(TestingFarmJobHelper).should_receive("job_owner").and_return("owner")

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -20,6 +20,7 @@ from packit_service.worker.events import (
 )
 from packit_service.models import TestingFarmResult as TFResult
 
+from packit_service.worker.build import copr_build as cb
 from packit_service.worker.handlers import TestingFarmResultsHandler as TFResultsHandler
 from packit_service.worker.handlers import TestingFarmHandler
 from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
@@ -531,6 +532,10 @@ def test_trigger_build(copr_build, run_new_build):
         flexmock(TFJobHelper).should_receive("run_testing_farm").and_return(
             TaskResults(success=True, details={})
         )
+
+    flexmock(cb).should_receive("get_valid_build_targets").and_return(
+        {"target", "another-target"}
+    )
 
     tf_handler = TestingFarmHandler(package_config, job_config, event, "target")
     tf_handler.run()


### PR DESCRIPTION
Fixes #1203 

This PR introduces a new optional parameter for Helper classes `targets_override`, if it is not None, it is used instead of using all targets from config (but only targets which are configured are used). Example for copr build:

```yaml
jobs:
- job: copr_build
  trigger: pull_request
  metadata:
    targets:
    - fedora-rawhide
    - epel-all
```
and
```python
targets_override = {fedora-rawhide-x86_64}
```

-> the builds will be created only for `fedora-rawhide-x86_64`

---

N/A
