### PR TITLE
Shorten path to get testing farm results

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -66,6 +66,8 @@ MSG_RERUN_NOT_SUPPORTED = (
     "please don't click it.*"
 )
 
+MSG_TABLE_HEADER_WITH_DETAILS = "| Name/Job | URL |\n" "| --- | --- |\n"
+
 
 class KojiBuildState(Enum):
     """

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -259,6 +259,7 @@ class TestingFarmResultsHandler(JobHandler):
             url=get_testing_farm_info_url(test_run_model.id)
             if test_run_model
             else self.log_url,
+            links_to_external_services={"Testing Farm": self.log_url},
             check_names=TestingFarmJobHelper.get_test_check(self.copr_chroot),
         )
 

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -155,6 +155,7 @@ def test_precheck_koji_build_non_scratch(github_pr_event):
         description="Non-scratch builds not possible from upstream.",
         check_name="packit-stg/production-build-bright-future",
         url=KOJI_PRODUCTION_BUILDS_ISSUE,
+        links_to_external_services=None,
     ).and_return().once()
     flexmock(GithubProject).should_receive("can_merge_pr").and_return(True)
     koji_build_handler = KojiBuildHandler(

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -31,7 +31,7 @@ from packit.copr_helper import CoprHelper
 from packit.exceptions import FailedCreateSRPM, PackitCoprSettingsException
 from packit_service import sentry_integration
 from packit_service.config import ServiceConfig
-from packit_service.constants import MSG_MORE_DETAILS, MSG_RERUN_NOT_SUPPORTED
+from packit_service.constants import MSG_RERUN_NOT_SUPPORTED
 from packit_service.models import CoprBuildModel, SRPMBuildModel
 from packit_service.service.db_triggers import (
     AddPullRequestDbTrigger,
@@ -70,6 +70,7 @@ CACHE_CLEAR = [
 ]
 
 pytestmark = pytest.mark.usefixtures("cache_clear", "mock_get_aliases")
+create_table_content = StatusReporterGithubChecks._create_table
 
 
 @pytest.fixture(scope="module")
@@ -158,12 +159,14 @@ def test_copr_build_check_names(github_pr_event):
         description="Building SRPM ...",
         check_name="packit-stg/rpm-build-bright-future-x86_64",
         url="",
+        links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Starting RPM build...",
         check_name="packit-stg/rpm-build-bright-future-x86_64",
         url="https://test.url",
+        links_to_external_services=None,
     ).and_return()
 
     flexmock(GithubProject).should_receive("get_pr").and_return(
@@ -255,6 +258,7 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
             description="Building SRPM ...",
             check_name=f"packit-stg/rpm-build-{target}",
             url="",
+            links_to_external_services=None,
         ).and_return()
 
     for not_supported_target in ("bright-future-x86_64", "fedora-32-x86_64"):
@@ -263,6 +267,7 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
             description=f"Not supported target: {not_supported_target}",
             check_name=f"packit-stg/rpm-build-{not_supported_target}",
             url="https://test.url",
+            links_to_external_services=None,
         ).and_return()
 
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
@@ -270,6 +275,7 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
         description="Starting RPM build...",
         check_name="packit-stg/rpm-build-even-brighter-one-aarch64",
         url="https://test.url",
+        links_to_external_services=None,
     ).and_return()
 
     flexmock(GithubProject).should_receive("get_pr").and_return(
@@ -387,12 +393,14 @@ def test_copr_build_check_names_multiple_jobs(github_pr_event):
         description="Building SRPM ...",
         check_name="packit-stg/rpm-build-fedora-32-x86_64",
         url="",
+        links_to_external_services=None,
     ).and_return().once()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Starting RPM build...",
         check_name="packit-stg/rpm-build-fedora-32-x86_64",
         url="https://test.url",
+        links_to_external_services=None,
     ).and_return().once()
 
     flexmock(GithubProject).should_receive("get_pr").and_return(
@@ -472,12 +480,14 @@ def test_copr_build_check_names_custom_owner(github_pr_event):
         description="Building SRPM ...",
         check_name="packit-stg/rpm-build-bright-future-x86_64",
         url="",
+        links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Starting RPM build...",
         check_name="packit-stg/rpm-build-bright-future-x86_64",
         url="https://test.url",
+        links_to_external_services=None,
     ).and_return()
 
     flexmock(GithubProject).should_receive("get_pr").and_return(
@@ -884,7 +894,9 @@ def test_copr_build_fails_in_packit(github_pr_event):
             conclusion=GithubCheckRunResult.failure,
             output=create_github_check_run_output(
                 "SRPM build failed, check the logs for details.",
-                MSG_MORE_DETAILS.format(url="https://test.url")
+                create_table_content(
+                    url="https://test.url", links_to_external_services=None
+                )
                 + MSG_RERUN_NOT_SUPPORTED,
             ),
         ).and_return().once()
@@ -1109,12 +1121,14 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
         description="Building SRPM ...",
         check_name="packit-stg/rpm-build-bright-future-x86_64",
         url="",
+        links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporterGitlab).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Starting RPM build...",
         check_name="packit-stg/rpm-build-bright-future-x86_64",
         url="https://test.url",
+        links_to_external_services=None,
     ).and_return()
 
     mr = flexmock(source_project=flexmock())

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -108,12 +108,14 @@ def test_koji_build_check_names(github_pr_event):
         description="Building SRPM ...",
         check_name="packit-stg/production-build-bright-future",
         url="",
+        links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building RPM ...",
         check_name="packit-stg/production-build-bright-future",
         url=koji_build_url,
+        links_to_external_services=None,
     ).and_return()
 
     flexmock(GitProject).should_receive("get_pr").and_return(
@@ -159,12 +161,14 @@ def test_koji_build_failed_kerberos(github_pr_event):
         description="Building SRPM ...",
         check_name="packit-stg/production-build-bright-future",
         url="",
+        links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.error,
         description="Kerberos authentication error: the bad authentication error",
         check_name="packit-stg/production-build-bright-future",
         url=get_srpm_build_info_url(1),
+        links_to_external_services=None,
     ).and_return()
 
     flexmock(GitProject).should_receive("get_pr").and_return(
@@ -211,12 +215,14 @@ def test_koji_build_target_not_supported(github_pr_event):
         description="Building SRPM ...",
         check_name="packit-stg/production-build-nonexisting-target",
         url="",
+        links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.error,
         description="Target not supported: nonexisting-target",
         check_name="packit-stg/production-build-nonexisting-target",
         url=get_srpm_build_info_url(1),
+        links_to_external_services=None,
     ).and_return()
 
     flexmock(GitProject).should_receive("get_pr").and_return(
@@ -305,6 +311,7 @@ def test_koji_build_failed(github_pr_event):
         description="Building SRPM ...",
         check_name="packit-stg/production-build-bright-future",
         url="",
+        links_to_external_services=None,
     ).and_return()
 
     srpm_build_url = get_srpm_build_info_url(2)
@@ -313,6 +320,7 @@ def test_koji_build_failed(github_pr_event):
         description="Submit of the build failed: some error",
         check_name="packit-stg/production-build-bright-future",
         url=srpm_build_url,
+        links_to_external_services=None,
     ).and_return()
 
     flexmock(GitProject).should_receive("get_pr").and_return(
@@ -351,12 +359,14 @@ def test_koji_build_failed_srpm(github_pr_event):
         description="Building SRPM ...",
         check_name="packit-stg/production-build-bright-future",
         url="",
+        links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.failure,
         description="SRPM build failed, check the logs for details.",
         check_name="packit-stg/production-build-bright-future",
         url=srpm_build_url,
+        links_to_external_services=None,
     ).and_return()
 
     flexmock(GitProject).should_receive("get_pr").and_return(

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -23,8 +23,11 @@ from packit_service.worker.reporting import (
     BaseCommitStatus,
     StatusReporterGithubStatuses,
     StatusReporterGitlab,
+    StatusReporterGithubChecks,
 )
-from packit_service.constants import MSG_MORE_DETAILS, MSG_RERUN_NOT_SUPPORTED
+from packit_service.constants import MSG_RERUN_NOT_SUPPORTED
+
+create_table_content = StatusReporterGithubChecks._create_table
 
 
 @pytest.mark.parametrize(
@@ -150,7 +153,10 @@ def test_set_status_gitlab(
             flexmock(),
             BaseCommitStatus.success,
             "We made it!",
-            MSG_MORE_DETAILS.format(url="https://api.packit.dev/build/111/logs"),
+            create_table_content(
+                url="https://api.packit.dev/build/111/logs",
+                links_to_external_services=None,
+            ),
             "packit/pr-rpm-build",
             "https://api.packit.dev/build/111/logs",
             GithubCheckRunStatus.completed,
@@ -164,7 +170,10 @@ def test_set_status_gitlab(
             flexmock(),
             BaseCommitStatus.running,
             "In progress",
-            MSG_MORE_DETAILS.format(url="https://api.packit.dev/build/111/logs"),
+            create_table_content(
+                url="https://api.packit.dev/build/111/logs",
+                links_to_external_services=None,
+            ),
             "packit/pr-rpm-build",
             "https://api.packit.dev/build/111/logs",
             GithubCheckRunStatus.in_progress,
@@ -178,7 +187,10 @@ def test_set_status_gitlab(
             flexmock(),
             BaseCommitStatus.failure,
             "We made it!",
-            MSG_MORE_DETAILS.format(url="https://api.packit.dev/build/112/logs")
+            create_table_content(
+                url="https://api.packit.dev/build/112/logs",
+                links_to_external_services=None,
+            )
             + MSG_RERUN_NOT_SUPPORTED,
             "packit/branch-rpm-build",
             "https://api.packit.dev/build/112/logs",
@@ -382,7 +394,10 @@ def test_report_status_by_comment(
             flexmock(source_project=flexmock()),
             BaseCommitStatus.success,
             "We made it!",
-            MSG_MORE_DETAILS.format(url="https://api.packit.dev/build/111/logs"),
+            create_table_content(
+                url="https://api.packit.dev/build/111/logs",
+                links_to_external_services=None,
+            ),
             "packit/pr-rpm-build",
             "https://api.packit.dev/build/111/logs",
             GithubCheckRunStatus.completed,
@@ -441,3 +456,16 @@ def test_status_instead_check(
     ).once()
 
     reporter.set_status(state, title, check_name, url)
+
+
+def test_create_table():
+    assert create_table_content(
+        "dashboard-url",
+        {"Testing Farm": "tf-url", "COPR build": "copr-build-url"},
+    ) == (
+        "| Name/Job | URL |\n"
+        "| --- | --- |\n"
+        "| Dashboard | dashboard-url |\n"
+        "| Testing Farm | tf-url |\n"
+        "| COPR build | copr-build-url |\n"
+    )

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -107,6 +107,7 @@ def test_testing_farm_response(
     flexmock(StatusReporter).should_receive("report").with_args(
         state=status_status,
         description=status_message,
+        links_to_external_services={"Testing Farm": "some url"},
         url="https://dashboard.localhost/results/testing-farm/123",
         check_names="packit-stg/testing-farm-fedora-rawhide-x86_64",
     )


### PR DESCRIPTION
<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #1178 

---

<!-- release notes for changelog/blog follow -->
Now you can find URL pointing directly to testing farm results on GitHub Checks page.
