### PR TITLE
+1 on comment commands

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -99,6 +99,11 @@ def get_handlers_for_event(
     ):
         handlers_triggered_by_comment = get_handlers_for_comment(event.comment)
 
+        if handlers_triggered_by_comment and not isinstance(
+            event, PullRequestCommentPagureEvent
+        ):
+            event.comment_object.add_reaction("+1")
+
     if isinstance(
         event,
         CheckRerunEvent,

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -401,8 +401,13 @@ class Parser:
 
         issue_id = nested_get(event, "issue", "number")
         action = event.get("action")
+        if action != "created" or not issue_id:
+            return None
+
         comment = nested_get(event, "comment", "body")
-        if action != "created" or not issue_id or not comment:
+        comment_id = nested_get(event, "comment", "id")
+        if not (comment and comment_id):
+            logger.warning("No comment or comment id from the event.")
             return None
 
         logger.info(f"Github issue#{issue_id} comment: {comment!r} {action!r} event.")
@@ -429,6 +434,7 @@ class Parser:
             https_url,
             user_login,
             comment,
+            comment_id,
         )
 
     @staticmethod
@@ -446,8 +452,9 @@ class Parser:
             logger.warning("No issue id from the event.")
             return None
         comment = nested_get(event, "object_attributes", "note")
-        if not comment:
-            logger.warning("No note from the event.")
+        comment_id = nested_get(event, "object_attributes", "id")
+        if not (comment and comment_id):
+            logger.warning("No note or note id from the event.")
             return None
 
         state = nested_get(event, "issue", "state")
@@ -489,6 +496,7 @@ class Parser:
             project_url=project_url,
             username=username,
             comment=comment,
+            comment_id=comment_id,
         )
 
     @staticmethod
@@ -520,8 +528,10 @@ class Parser:
             logger.warning("No object id from the event.")
 
         comment = nested_get(event, "object_attributes", "note")
+        comment_id = nested_get(event, "object_attributes", "id")
         logger.info(
-            f"Gitlab MR id#{object_id} iid#{object_iid} comment: {comment!r} {action!r} event."
+            f"Gitlab MR id#{object_id} iid#{object_iid} comment: {comment!r} id#{comment_id} "
+            f"{action!r} event."
         )
 
         source_project_url = nested_get(event, "merge_request", "source", "web_url")
@@ -570,6 +580,7 @@ class Parser:
             username=username,
             comment=comment,
             commit_sha=commit_sha,
+            comment_id=comment_id,
         )
 
     @staticmethod
@@ -586,7 +597,10 @@ class Parser:
             return None
 
         comment = nested_get(event, "comment", "body")
-        logger.info(f"Github PR#{pr_id} comment: {comment!r} {action!r} event.")
+        comment_id = nested_get(event, "comment", "id")
+        logger.info(
+            f"Github PR#{pr_id} comment: {comment!r} id#{comment_id} {action!r} event."
+        )
 
         base_repo_namespace = nested_get(event, "issue", "user", "login")
         base_repo_name = nested_get(event, "repository", "name")
@@ -618,6 +632,7 @@ class Parser:
             project_url=https_url,
             user_login=user_login,
             comment=comment,
+            comment_id=comment_id,
         )
 
     @staticmethod

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -57,6 +57,11 @@ def mock_comment(request):
         .and_return(True)
     )
     flexmock(project_class).should_receive("issue_comment").and_return(None)
+    issue = flexmock()
+    flexmock(project_class).should_receive("get_issue").and_return(issue)
+    comment = flexmock()
+    flexmock(issue).should_receive("get_comment").and_return(comment)
+    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
     flexmock(project_class).should_receive("issue_close").and_return(None)
     gr = release_class(
         tag_name="0.5.1",

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -247,6 +247,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
                 project_url="https://github.com/foo/bar",
                 user_login="bar",
                 comment="",
+                comment_id=0,
             ),
             ("github.com/foo/bar.git", "github.com/foo", "github.com"),
             False,
@@ -261,6 +262,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
                 project_url="https://github.com/foo/bar",
                 user_login="baz",
                 comment="",
+                comment_id=0,
             ),
             ("github.com/foo/bar.git", "github.com/foo", "github.com"),
             False,
@@ -277,6 +279,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
                 project_url="https://github.com/fero/dwm",
                 user_login="lojzo",
                 comment="",
+                comment_id=0,
             ),
             ("github.com/fero/dwm.git", "github.com/fero"),
             True,
@@ -291,6 +294,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
                 project_url="https://gitlab.com/packit-service/src/glibc",
                 user_login="lojzo",
                 comment="",
+                comment_id=0,
             ),
             (
                 "gitlab.com/packit-service/src/glibc.git",
@@ -310,6 +314,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
                 project_url="https://github.com/banned_namespace_again/some_repo",
                 user_login="admin",
                 comment="",
+                comment_id=0,
             ),
             [],
             True,
@@ -388,6 +393,7 @@ def events(request) -> Iterable[Tuple[AbstractGithubEvent, bool, Iterable[str]]]
                 "project_url": f"https://{forge}/{namespace}/{repository}",
                 "user_login": "login",
                 "comment": "",
+                "comment_id": 1,
             },
         ),
         "issue_comment": (
@@ -401,6 +407,7 @@ def events(request) -> Iterable[Tuple[AbstractGithubEvent, bool, Iterable[str]]]
                 "project_url": f"https://{forge}/{namespace}/{repository}",
                 "user_login": "login",
                 "comment": "",
+                "comment_id": 1,
             },
         ),
         "admin": (
@@ -416,6 +423,7 @@ def events(request) -> Iterable[Tuple[AbstractGithubEvent, bool, Iterable[str]]]
                 "project_url": f"https://{forge}/{namespace}/{repository}",
                 "user_login": "admin",
                 "comment": "",
+                "comment_id": 1,
             },
         ),
     }

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -896,6 +896,10 @@ def test_get_handlers_for_comment_event(event_cls, comment, db_trigger, jobs, re
             return db_trigger
 
     event = Event()
+    if comment:
+        comment_object = flexmock()
+        event._comment_object = comment_object
+        flexmock(comment_object).should_receive("add_reaction").with_args("+1").once()
 
     event_handlers = set(
         get_handlers_for_event(


### PR DESCRIPTION
TODO:

- [x] add a test case which will work
- [x] modify tests to make them work :confounded:
- [x] implement `get_comment` method in ogr

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #1081 

---

<!-- release notes for changelog/blog follow -->
If you trigger packit tests with one of `/packit _` commands, our bot gives you a :+1: reaction to let you know that we are working on it. 
