### PR TITLE
/sandcastle → /tmp/sandcastle

### DIFF
--- a/files/docker/Dockerfile.tests
+++ b/files/docker/Dockerfile.tests
@@ -13,7 +13,7 @@ ENV USER=packit \
     HOME=/home/packit
 
 RUN set -ex; \
-    mkdir -m 0777 /sandcastle && \
+    mkdir -m 0777 /tmp/sandcastle && \
     mkdir -m 0776 -p ${HOME} && \
     mkdir -p ${HOME}/.config
 

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -36,7 +36,7 @@
           - make
           # provides dnf builddep, required for packit dep installation from spec file
           - dnf-plugins-core
-          # oc rsync /sandcastle -> sandcastle pod
+          # oc rsync /tmp/sandcastle -> sandcastle pod
           - rsync
           - fedpkg-stage
         state: present

--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -6,11 +6,11 @@
     packit_service_path: /src
   tasks:
     - import_tasks: tasks/common.yaml
-    - name: Create /sandcastle
+    - name: Create /tmp/sandcastle
       # working dir for the upstream git which is mapped to the sandbox pod
       file:
         state: directory
-        path: /sandcastle
+        path: /tmp/sandcastle
         mode: 0777
     - name: Copy gitconfig
       copy:

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -11,7 +11,7 @@ FAQ_URL_HOW_TO_RETRIGGER = (
 )
 KOJI_PRODUCTION_BUILDS_ISSUE = "https://pagure.io/releng/issue/9801"
 
-SANDCASTLE_WORK_DIR = "/sandcastle"
+SANDCASTLE_WORK_DIR = "/tmp/sandcastle"
 SANDCASTLE_IMAGE = "quay.io/packit/sandcastle"
 SANDCASTLE_DEFAULT_PROJECT = "myproject"
 SANDCASTLE_PVC = "SANDCASTLE_PVC"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -41,7 +41,7 @@ def service_config_valid():
         "bugz_namespaces": ["^magic/namespace"],
         "bugz_branches": ["^onlythis$"],
         "command_handler": "sandcastle",
-        "command_handler_work_dir": "/sandcastle",
+        "command_handler_work_dir": "/tmp/sandcastle",
         "command_handler_image_reference": "quay.io/packit/sandcastle",
         "command_handler_k8s_namespace": "packit-test-sandbox",
         "admins": ["Dasher", "Dancer", "Vixen", "Comet", "Blitzen"],
@@ -69,7 +69,7 @@ def test_parse_valid(service_config_valid):
     assert config.bugzilla_api_key == "ratamahatta"
     assert config.bugz_namespaces == {"^magic/namespace"}
     assert config.bugz_branches == {"^onlythis$"}
-    assert config.command_handler_work_dir == "/sandcastle"
+    assert config.command_handler_work_dir == "/tmp/sandcastle"
     assert config.admins == {"Dasher", "Dancer", "Vixen", "Comet", "Blitzen"}
     assert config.server_name == "hub.packit.org"
     assert config.gitlab_token_secret == "jwt_secret"


### PR DESCRIPTION
https://issues.redhat.com/browse/PACKIT-1705

AWS EBS PVs seem to have data in them even though `ls` prints empty
directories.

This commit tries to utilize /tmp/sandcastle as the working dir and
utilize filesystem provided to the pod and not requires additional PV.