### PR TITLE
Add epel-6 to epel_mapping

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -207,16 +207,15 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         """Get distro and arch from chroot."""
         distro, arch = chroot.rsplit("-", 1)
 
+        epel_mapping = {
+            "epel-6": "centos-6",
+            "epel-7": "centos-7",
+        }
+
         if self.job_config.metadata.use_internal_tf:
-            epel_mapping = {
-                "epel-7": "centos-7",
-                "epel-8": "centos-8",
-            }
+            epel_mapping["epel-8"] = "centos-8"
         else:
-            epel_mapping = {
-                "epel-7": "centos-7",
-                "epel-8": "centos-stream-8",
-            }
+            epel_mapping["epel-8"] = "centos-stream-8"
 
         distro = epel_mapping.get(distro, distro)
         return distro, arch

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -148,6 +148,7 @@ def test_testing_farm_response(
         ("fedora-33-x86_64", "fedora-33", "x86_64", False),
         ("fedora-rawhide-aarch64", "fedora-rawhide", "aarch64", False),
         ("centos-stream-x86_64", "centos-stream", "x86_64", False),
+        ("epel-6-x86_64", "centos-6", "x86_64", False),
         ("epel-7-x86_64", "centos-7", "x86_64", False),
         ("epel-8-x86_64", "centos-stream-8", "x86_64", False),
         ("fedora-33-x86_64", "fedora-33", "x86_64", True),


### PR DESCRIPTION
Fixes #1243

---

Running tests via Testing Farm now supports `centos-6` target.
