### PR TITLE
Use aarch64-specific composes in TF

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -109,7 +109,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
         """
         distro, arch = self.chroot2distro_arch(chroot)
-        compose = self.distro2compose(distro)
+        compose = self.distro2compose(distro, arch)
         fmf = {"url": self.fmf_url}
         if self.fmf_ref:
             fmf["ref"] = self.fmf_ref
@@ -163,7 +163,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         """
         copr_build = CoprBuildModel.get_by_build_id(build_id)
         distro, arch = self.chroot2distro_arch(chroot)
-        compose = self.distro2compose(distro)
+        compose = self.distro2compose(distro, arch)
         return {
             "api_key": self.service_config.testing_farm_secret,
             "test": {
@@ -220,7 +220,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         distro = epel_mapping.get(distro, distro)
         return distro, arch
 
-    def distro2compose(self, distro: str) -> str:
+    def distro2compose(self, distro: str, arch: str) -> str:
         """
         Create a compose string from distro, e.g. fedora-33 -> Fedora-33
         https://api.dev.testing-farm.io/v0.1/composes
@@ -238,6 +238,10 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         )
         if compose == "CentOS-Stream":
             compose = "CentOS-Stream-8"
+
+        if arch == "aarch64":
+            # TF has separate composes for aarch64 architecture
+            compose += "-aarch64"
 
         if self.job_config.metadata.use_internal_tf:
             # Internal TF does not have own endpoint for composes

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -472,7 +472,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
 
     flexmock(TestingFarmJobHelper).should_receive("is_fmf_configured").and_return(True)
     flexmock(TestingFarmJobHelper).should_receive("distro2compose").with_args(
-        "fedora-rawhide"
+        "fedora-rawhide", "x86_64"
     ).and_return("Fedora-Rawhide")
 
     pipeline_id = "5e8079d8-f181-41cf-af96-28e99774eb68"

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -225,7 +225,41 @@ def test_distro2compose(distro, compose, use_internal_tf):
         0 if use_internal_tf else 1
     )
 
-    assert job_helper.distro2compose(distro) == compose
+    assert job_helper.distro2compose(distro, arch="x86_64") == compose
+
+
+@pytest.mark.parametrize(
+    "distro,arch,compose,use_internal_tf",
+    [
+        ("fedora-33", "x86_64", "Fedora-33", False),
+        ("fedora-33", "aarch64", "Fedora-33-aarch64", False),
+    ],
+)
+def test_distro2compose_for_aarch64(distro, arch, compose, use_internal_tf):
+    job_helper = TFJobHelper(
+        service_config=flexmock(
+            testing_farm_api_url="xyz",
+        ),
+        package_config=flexmock(jobs=[]),
+        project=flexmock(),
+        metadata=flexmock(),
+        db_trigger=flexmock(),
+        job_config=JobConfig(
+            type=JobType.tests,
+            trigger=JobConfigTriggerType.pull_request,
+            metadata=JobMetadataConfig(use_internal_tf=use_internal_tf),
+        ),
+    )
+    job_helper = flexmock(job_helper)
+
+    response = flexmock(
+        status_code=200, json=lambda: {"composes": [{"name": "Fedora-33"}]}
+    )
+    job_helper.should_receive("send_testing_farm_request").and_return(response).times(
+        0 if use_internal_tf else 1
+    )
+
+    assert job_helper.distro2compose(distro, arch=arch) == compose
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes: packit/packit#1352
Signed-off-by: Frantisek Lachman <flachman@redhat.com>
Ping: @thrix 

---

It is possible to use `aarch64` architecture in the Testing Farm.
