### PR TITLE
Create a function for safer datetime subtraction

### DIFF
--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Set, Tuple
 
 from copr.v3 import CoprRequestException
@@ -25,7 +25,7 @@ from packit_service.service.urls import (
     get_srpm_build_info_url,
 )
 from packit_service.worker.build.build_helper import BaseBuildJobHelper
-from packit_service.worker.monitoring import Pushgateway
+from packit_service.worker.monitoring import Pushgateway, measure_time
 from packit_service.worker.result import TaskResults
 from packit_service.worker.reporting import BaseCommitStatus
 
@@ -177,7 +177,9 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         Measure the time it took to set the failed status in case of event (e.g. failed SRPM)
         that prevents Copr build to be submitted.
         """
-        time = (datetime.now() - self.metadata.task_accepted_time).total_seconds()
+        time = measure_time(
+            end=datetime.now(timezone.utc), begin=self.metadata.task_accepted_time
+        )
         for _ in range(number_of_builds):
             self.pushgateway.copr_build_not_submitted_time.labels(
                 reason=reason

--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -200,7 +200,7 @@ class Event:
                 created_at = created_at.replace("Z", "+00:00")
                 self.created_at = datetime.fromisoformat(created_at)
         else:
-            self.created_at = datetime.now()
+            self.created_at = datetime.now(timezone.utc)
 
     @staticmethod
     def ts2str(event: dict):

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from celery import signature
@@ -54,6 +54,7 @@ from packit_service.worker.handlers.abstract import (
     add_topic,
     FedmsgHandler,
 )
+from packit_service.worker.monitoring import measure_time
 from packit_service.worker.reporting import BaseCommitStatus
 from packit_service.worker.result import TaskResults
 
@@ -290,9 +291,9 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
 
         # if the build is needed only for test, it doesn't have the task_accepted_time
         if self.build.task_accepted_time:
-            copr_build_time = (
-                datetime.now() - self.build.task_accepted_time
-            ).total_seconds()
+            copr_build_time = measure_time(
+                end=datetime.now(timezone.utc), begin=self.build.task_accepted_time
+            )
             self.pushgateway.copr_build_finished_time.observe(copr_build_time)
 
         end_time = (

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -5,7 +5,7 @@
 This file defines classes for job handlers specific for Testing farm
 """
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from celery import signature
@@ -39,6 +39,7 @@ from packit_service.worker.handlers.abstract import (
     run_for_comment,
     run_for_check_rerun,
 )
+from packit_service.worker.monitoring import measure_time
 from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 from packit_service.worker.result import TaskResults
 from packit_service.worker.testing_farm import TestingFarmJobHelper
@@ -265,9 +266,9 @@ class TestingFarmResultsHandler(JobHandler):
             self.pushgateway.test_runs_started.inc()
         else:
             self.pushgateway.test_runs_finished.inc()
-            test_run_time = (
-                datetime.now() - test_run_model.submitted_time
-            ).total_seconds()
+            test_run_time = measure_time(
+                end=datetime.now(timezone.utc), begin=test_run_model.submitted_time
+            )
             self.pushgateway.test_run_finished_time.observe(test_run_time)
 
         if test_run_model:

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -5,7 +5,7 @@
 We love you, Steve Jobs.
 """
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from typing import List, Set, Type, Union
 
@@ -48,7 +48,7 @@ from packit_service.worker.handlers.abstract import (
     MAP_CHECK_PREFIX_TO_HANDLER,
 )
 
-from packit_service.worker.monitoring import Pushgateway
+from packit_service.worker.monitoring import Pushgateway, measure_time
 from packit_service.worker.parser import CentosEventParser, Parser
 from packit_service.worker.reporting import BaseCommitStatus
 from packit_service.worker.result import TaskResults
@@ -229,8 +229,8 @@ def get_config_for_handler_kls(
 def push_initial_metrics(event: Event, handler: JobHandler, build_targets_len: int):
     pushgateway = Pushgateway()
 
-    task_accepted_time = datetime.now()
-    response_time = (task_accepted_time - event.created_at).total_seconds()
+    task_accepted_time = datetime.now(timezone.utc)
+    response_time = measure_time(end=task_accepted_time, begin=event.created_at)
     pushgateway.initial_status_time.observe(response_time)
     if response_time > 15:
         pushgateway.no_status_after_15_s.inc()

--- a/packit_service/worker/monitoring.py
+++ b/packit_service/worker/monitoring.py
@@ -3,10 +3,27 @@
 
 import logging
 import os
+from datetime import datetime, timezone
 
 from prometheus_client import CollectorRegistry, Counter, push_to_gateway, Histogram
 
 logger = logging.getLogger(__name__)
+
+
+def measure_time(begin: datetime, end: datetime) -> float:
+    """
+    Make the datetime objects timezone aware (utc) if needed
+    and measure time between them in seconds.
+
+    Returns:
+        float seconds between begin and end
+    """
+    if begin.tzinfo is None or begin.tzinfo.utcoffset(begin) is None:
+        begin = begin.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None or end.tzinfo.utcoffset(end) is None:
+        end = end.replace(tzinfo=timezone.utc)
+
+    return (end - begin).total_seconds()
 
 
 class Pushgateway:

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Type
 
@@ -133,7 +133,7 @@ def build_helper(
             commit_sha=event.commit_sha,
             identifier=event.identifier,
             tag_name=None,
-            task_accepted_time=datetime.now(),
+            task_accepted_time=datetime.now(timezone.utc),
         ),
         db_trigger=db_trigger,
         targets_override=targets_override,


### PR DESCRIPTION

- function that checks timezone awareness and add UTC if needed
- datetime.now() -> datetime.now(timezone.utc)
- datetimes in DB are stored without timezone awareness, currently, the new function should handle this, but maybe it would be nice to improve this as some Friday work.

Related to #1249 


---

<!-- release notes for changelog/blog follow -->
N/A