### PR TITLE
Fix Postgres URL

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -52,7 +52,7 @@ session_instance = None
 def get_pg_url() -> str:
     """create postgresql connection string"""
     return (
-        f"postgres+psycopg2://{os.getenv('POSTGRESQL_USER')}"
+        f"postgresql+psycopg2://{os.getenv('POSTGRESQL_USER')}"
         f":{os.getenv('POSTGRESQL_PASSWORD')}@{os.getenv('POSTGRESQL_HOST', 'postgres')}"
         f":{os.getenv('POSTGRESQL_PORT', '5432')}/{os.getenv('POSTGRESQL_DATABASE')}"
     )


### PR DESCRIPTION
I tried to bootstrap the testing environment for packit service on F35
in the toolbox and it seems that using `postgres` as dialect no longer
works.

Never mind, it was removed in https://github.com/sqlalchemy/sqlalchemy/commit/a9b068ae564e5e775e312373088545b75aeaa1b0, and deprecated before 1.1 release…
And this change is included in the version bump to 1.4(something something) in F35

Signed-off-by: Matej Focko <mfocko@redhat.com>

---

<!-- release notes for changelog/blog follow -->

N/A