### PR TITLE
Make the MR targets handled in GitLab configurable

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -67,6 +67,24 @@ class ProjectToSync(NamedTuple):
         )
 
 
+class MRTarget(NamedTuple):
+    """
+    A pair of repo and branch regexes.
+    """
+
+    repo: str
+    branch: str
+
+    def __repr__(self):
+        return f"MRTarget(repo={self.repo}, branch={self.branch})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, MRTarget):
+            raise NotImplementedError()
+
+        return self.repo == other.repo and self.branch == self.branch
+
+
 class ServiceConfig(Config):
     def __init__(
         self,
@@ -84,6 +102,7 @@ class ServiceConfig(Config):
         bugz_branches: List[str] = None,
         enabled_private_namespaces: Union[Set[str], List[str]] = None,
         gitlab_token_secret: str = "",
+        gitlab_mr_targets_handled: List[MRTarget] = None,
         projects_to_sync: List[ProjectToSync] = None,
         enabled_projects_for_internal_tf: Union[Set[str], List[str]] = None,
         dashboard_url: str = "",
@@ -124,6 +143,8 @@ class ServiceConfig(Config):
 
         # Gitlab token secret to decode JWT tokens
         self.gitlab_token_secret: str = gitlab_token_secret
+
+        self.gitlab_mr_targets_handled: List[MRTarget] = gitlab_mr_targets_handled
 
         # Explicit list of private namespaces we work with
         # e.g.:
@@ -167,8 +188,9 @@ class ServiceConfig(Config):
             f"bugzilla_url='{self.bugzilla_url}', "
             f"bugzilla_api_key='{hide(self.bugzilla_api_key)}', "
             f"gitlab_token_secret='{hide(self.gitlab_token_secret)}',"
-            f"enabled_private_namespaces='{self.enabled_private_namespaces}',"
-            f"enabled_projects_for_internal_tf='{self.enabled_projects_for_internal_tf}',"
+            f"gitlab_mr_targets_handled='{self.gitlab_mr_targets_handled}', "
+            f"enabled_private_namespaces='{self.enabled_private_namespaces}', "
+            f"enabled_projects_for_internal_tf='{self.enabled_projects_for_internal_tf}', "
             f"server_name='{self.server_name}', "
             f"dashboard_url='{self.dashboard_url}', "
             f"koji_logs_url='{self.koji_logs_url}', "

--- a/packit_service/schema.py
+++ b/packit_service/schema.py
@@ -6,7 +6,7 @@ import typing
 from marshmallow import ValidationError, fields, post_load, Schema
 
 from packit.schema import UserConfigSchema
-from packit_service.config import Deployment, ServiceConfig, ProjectToSync
+from packit_service.config import Deployment, ServiceConfig, ProjectToSync, MRTarget
 
 
 class DeploymentField(fields.Field):
@@ -43,6 +43,22 @@ class ProjectToSyncSchema(Schema):
         return ProjectToSync(**data)
 
 
+class MRTargetSchema(Schema):
+    """
+    Schema for MR targets to handle.
+
+    repo: Regex string to be matched against the slug of a repo.
+    branch: Regex string to be matched against the branch name.
+    """
+
+    repo = fields.String(missing=None)
+    branch = fields.String(missing=None)
+
+    @post_load
+    def make_instance(self, data, **_):
+        return MRTarget(**data)
+
+
 class ServiceConfigSchema(UserConfigSchema):
     deployment = DeploymentField(required=True)
     webhook_secret = fields.String()
@@ -58,6 +74,7 @@ class ServiceConfigSchema(UserConfigSchema):
     admins = fields.List(fields.String())
     server_name = fields.String()
     gitlab_token_secret = fields.String()
+    gitlab_mr_targets_handled = fields.List(fields.Nested(MRTargetSchema), missing=None)
     enabled_private_namespaces = fields.List(fields.String())
     enabled_projects_for_internal_tf = fields.List(fields.String())
     projects_to_sync = fields.List(fields.Nested(ProjectToSyncSchema), missing=None)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,7 +11,12 @@ from ogr.abstract import GitProject, GitService
 from packit.config import PackageConfig
 from packit.exceptions import PackitConfigException
 from packit.sync import SyncFilesItem
-from packit_service.config import ServiceConfig, Deployment, PackageConfigGetter
+from packit_service.config import (
+    ServiceConfig,
+    Deployment,
+    PackageConfigGetter,
+    MRTarget,
+)
 from packit_service.constants import TESTING_FARM_API_URL
 
 
@@ -47,6 +52,11 @@ def service_config_valid():
         "admins": ["Dasher", "Dancer", "Vixen", "Comet", "Blitzen"],
         "server_name": "hub.packit.org",
         "gitlab_token_secret": "jwt_secret",
+        "gitlab_mr_targets_handled": [
+            {"repo": "redhat/centos-stream/src/.+", "branch": "c9s"},
+            {"repo": "packit-service/src/.+"},
+            {"branch": "rawhide"},
+        ],
         "enabled_private_namespaces": [
             "gitlab.com/private/namespace",
             "github.com/other-private-namespace",
@@ -73,6 +83,13 @@ def test_parse_valid(service_config_valid):
     assert config.admins == {"Dasher", "Dancer", "Vixen", "Comet", "Blitzen"}
     assert config.server_name == "hub.packit.org"
     assert config.gitlab_token_secret == "jwt_secret"
+    assert len(config.gitlab_mr_targets_handled) == 3
+    assert (
+        MRTarget("redhat/centos-stream/src/.+", "c9s")
+        in config.gitlab_mr_targets_handled
+    )
+    assert MRTarget("packit-service/src/.+", None) in config.gitlab_mr_targets_handled
+    assert MRTarget(None, "rawhide") in config.gitlab_mr_targets_handled
     assert config.enabled_private_namespaces == {
         "gitlab.com/private/namespace",
         "github.com/other-private-namespace",


### PR DESCRIPTION
'gitlab_mr_targets_handled' is an optional configuration field for Packit
Service, which if defined, is a list of objects with a 'repo' and
'branch' fields. Both of these should be regex strings.

The regex strings of 'repo' are matched against the full slug of the
target repo of the MR ('redhat/centos-stream/src/make', for example).

The regex strings of 'branch' are matched against the name of the target
branch of the MR.

If any of 'repo' or 'branch' is missing, it's considered to match all
repositories or branches.

If 'gitlab_mr_targets_handled' is not specified, all target repositories
and branches are considered to be handled.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

---

N/A