### PR TITLE
congrats comment: drop the disclaimer

### DIFF
--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -329,11 +329,6 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
         ):
             msg = (
                 f"Congratulations! One of the builds has completed. :champagne:\n\n"
-                ":warning: Please note that our current plans include removal of these "
-                "comments in the near future (at least 2 weeks after including this "
-                "disclaimer), if you have serious concerns regarding their removal "
-                "or would like to continue receiving them please reach out to us. "
-                ":warning:\n\n"
                 "You can install the built RPMs by following these steps:\n\n"
                 "* `sudo yum install -y dnf-plugins-core` on RHEL 8\n"
                 "* `sudo dnf install -y dnf-plugins-core` on Fedora\n"


### PR DESCRIPTION
I haven't seen the comment for a long time, until recently: https://github.com/sgallagher/sscg/pull/29#issuecomment-953059137

We have made the change long time ago, so the warning is no longer
relevant.

---
The "Congratulations!" comment no longer has a disclaimer about our intentions to stop posting it by default. We have already made that move earlier this year, so the disclaimer is no longer relevant.