### PR TITLE
Avoid using ogr's deprecated methods/properties

### DIFF
--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -238,7 +238,7 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
         comments = self.project.get_pr(self.copr_event.pr_id).get_comments(reverse=True)
         for comment in comments:
             if comment.author.startswith("packit-as-a-service"):
-                return "Congratulations!" in comment.comment
+                return "Congratulations!" in comment.body
         # if there is no comment from p-s
         return False
 

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -63,7 +63,7 @@ def mock_comment(request):
     comment = flexmock()
     flexmock(issue).should_receive("get_comment").and_return(comment)
     flexmock(comment).should_receive("add_reaction").with_args("+1").once()
-    flexmock(project_class).should_receive("issue_close").and_return(None)
+    flexmock(issue).should_receive("close").and_return(issue)
     gr = release_class(
         tag_name="0.5.1",
         url="packit-service/packit",

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -59,7 +59,7 @@ def test_get_logs(client):
     pr_mock = flexmock()
     pr_mock.job_trigger_model_type = JobTriggerModelType.pull_request
     pr_mock.pr_id = 234
-    pr_mock.project = project_mock
+    pr_mock.target_project = project_mock
 
     srpm_build_mock = flexmock()
     srpm_build_mock.id = 11


### PR DESCRIPTION
Just some minor cleanup related to cleanup in ogr, nothing significant (the changes in test don't really have an effect but I feel it's better to be as close to ogr as possible since we are mocking it).

Related to https://github.com/packit/ogr/pull/652

---

N/A
