### PR TITLE
Change accessMode of test-data-pvc: RWX->RWO

### DIFF
--- a/files/test-in-openshift.yaml
+++ b/files/test-in-openshift.yaml
@@ -69,7 +69,7 @@ objects:
       name: test-data-pvc
     spec:
       accessModes:
-        - ReadWriteMany
+        - ReadWriteOnce
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
Error from Openshift Online:
`Failed to provision volume with StorageClass gp2-encrypted: invalid AccessModes [ReadWriteMany]: only AccessModes [ReadWriteOnce] are supported.`

I think I deleted the `test-data-pvc` last week when I was purging unused PVCs. Sorry for that.
But I think it should actually [be automatically removed after the tests](https://github.com/packit/packit-service/blob/main/files/check-inside-openshift.yaml#L109).
I'm wondering how this could have worked with RWX previously - AFAIR Online never supported RWX.
Was it somehow requested explicitly?
Do we actually need RWX or would it work with RWO?

Does it ring a bell to anyone? @lachmanfrantisek @TomasTomecek 

---

N/A
