### PR TITLE
TF runs: fill submitted_time if missing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     hooks:
       - id: check-rebase
         args:
-          - git://github.com/packit-service/packit-service.git
+          - https://github.com/packit/packit-service.git
         stages: [manual, push]
   - repo: https://github.com/packit/requre
     rev: 0.8.1

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1391,9 +1391,14 @@ class TFTTestRunModel(ProjectAndTriggersConnector, Base):
 
     runs = relationship("RunModel", back_populates="test_run")
 
-    def set_status(self, status: TestingFarmResult):
+    def set_status(self, status: TestingFarmResult, created: Optional[DateTime] = None):
+        """
+        set status of the TF run and optionally set the created datetime as well
+        """
         with get_sa_session() as session:
             self.status = status
+            if created and not self.submitted_time:
+                self.submitted_time = created
             session.add(self)
 
     def set_web_url(self, web_url: str):

--- a/packit_service/worker/events/testing_farm.py
+++ b/packit_service/worker/events/testing_farm.py
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
-
+from datetime import datetime
 from typing import Optional, Dict
 
 from ogr.abstract import GitProject
@@ -27,6 +27,7 @@ class TestingFarmResultsEvent(AbstractForgeIndependentEvent):
         copr_chroot: str,
         commit_sha: str,
         project_url: str,
+        created: datetime,
     ):
         super().__init__(project_url=project_url)
         self.pipeline_id = pipeline_id
@@ -37,6 +38,7 @@ class TestingFarmResultsEvent(AbstractForgeIndependentEvent):
         self.copr_build_id = copr_build_id
         self.copr_chroot = copr_chroot
         self.commit_sha: str = commit_sha
+        self.created: datetime = created
 
         # Lazy properties
         self._pr_id: Optional[int] = None

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -225,6 +225,7 @@ class TestingFarmResultsHandler(JobHandler):
         self.copr_chroot = event.get("copr_chroot")
         self.summary = event.get("summary")
         self._db_trigger: Optional[AbstractTriggerDbType] = None
+        self.created = event.get("created")
 
     @property
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
@@ -247,7 +248,7 @@ class TestingFarmResultsHandler(JobHandler):
             )
 
         if test_run_model:
-            test_run_model.set_status(self.result)
+            test_run_model.set_status(self.result, created=self.created)
 
         if self.result == TestingFarmResult.running:
             status = BaseCommitStatus.running

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -3,6 +3,7 @@
 
 import datetime
 
+import pytest
 import requests
 from copr.v3 import Client
 from flexmock import flexmock
@@ -211,12 +212,20 @@ def test_check_pending_testing_farm_runs_no_runs():
     check_pending_testing_farm_runs()
 
 
-def test_check_pending_testing_farm_runs():
+@pytest.mark.parametrize(
+    "created",
+    (
+        # I don't think it matters that this is evaluated before running the test
+        datetime.datetime.utcnow(),
+        None,
+    ),
+)
+def test_check_pending_testing_farm_runs(created):
     pipeline_id = 1
     run = (
         flexmock(
             pipeline_id=pipeline_id,
-            submitted_time=datetime.datetime.utcnow(),
+            submitted_time=created,
             commit_sha="123456",
             target="fedora-rawhide-x86_64",
             data={},
@@ -250,6 +259,7 @@ def test_check_pending_testing_farm_runs():
             json=lambda: {
                 "id": pipeline_id,
                 "state": TestingFarmResult.passed,
+                "created": "2021-11-01 17:22:36.061250",
             },
             ok=lambda: True,
         )

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -91,6 +91,7 @@ def test_testing_farm_response(
     config.should_receive("get_project").with_args(
         url="https://github.com/packit/ogr"
     ).and_return()
+    created_dt = datetime.utcnow()
     event_dict = TFResultsEvent(
         pipeline_id="id",
         result=tests_result,
@@ -101,6 +102,7 @@ def test_testing_farm_response(
         copr_chroot="fedora-rawhide-x86_64",
         commit_sha=flexmock(),
         project_url="https://github.com/packit/ogr",
+        created=created_dt,
     ).get_dict()
     test_farm_handler = TFResultsHandler(
         package_config=flexmock(), job_config=flexmock(), event=event_dict
@@ -124,7 +126,7 @@ def test_testing_farm_response(
         ),
     )
     tft_test_run_model.should_receive("set_status").with_args(
-        tests_result
+        tests_result, created=created_dt
     ).and_return().once()
     tft_test_run_model.should_receive("set_web_url").with_args(
         "some url"


### PR DESCRIPTION
...and don't traceback on the fact that submitted_time is not filled
since we use it to compute timedelta

If submitted_time is not filled in, we obtain it from TF's result,
"created" field and populate it in the TF Result handler.

Fixes
https://sentry.io/organizations/red-hat-0p/issues/2762340421/?environment=prod&project=1767823

---

N/A, internal change