### PR TITLE
Fail when event is triggered by `\packit` command without packit config file in repo

### DIFF
--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -294,6 +294,7 @@ class AbstractForgeIndependentEvent(Event):
         super().__init__(created_at)
         self.project_url = project_url
         self._pr_id = pr_id
+        self.fail_when_config_file_missing = False
 
         # Lazy properties
         self._project: Optional[GitProject] = None
@@ -359,7 +360,7 @@ class AbstractForgeIndependentEvent(Event):
             project=self.project,
             reference=self.commit_sha,
             pr_id=self.pr_id,
-            fail_when_missing=False,
+            fail_when_missing=self.fail_when_config_file_missing,
             spec_file_path=spec_path,
         )
 

--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from logging import getLogger
 from typing import Dict, Optional, Union, Set, List
 
-from ogr.abstract import GitProject
+from ogr.abstract import GitProject, Comment
 from ogr.services.pagure import PagureProject
 from packit.config import PackageConfig
 
@@ -376,3 +376,22 @@ class AbstractForgeIndependentEvent(Event):
         result.pop("_base_project")
         result.pop("_package_config")
         return result
+
+
+class AbstractCommentEvent(AbstractForgeIndependentEvent):
+    def __init__(
+        self,
+        project_url: str,
+        comment: str,
+        pr_id: Optional[int] = None,
+        comment_object: Optional[Comment] = None,
+    ) -> None:
+        super().__init__(project_url=project_url, pr_id=pr_id)
+        self.comment = comment
+
+        # Lazy properties
+        self._comment_object = comment_object
+
+    @property
+    def comment_object(self) -> Optional[Comment]:
+        raise NotImplementedError()

--- a/packit_service/worker/events/pagure.py
+++ b/packit_service/worker/events/pagure.py
@@ -11,13 +11,16 @@ from packit_service.worker.events.enums import (
     PullRequestAction,
     PullRequestCommentAction,
 )
-from packit_service.worker.events.event import AbstractForgeIndependentEvent
+from packit_service.worker.events.event import (
+    AbstractForgeIndependentEvent,
+    AbstractCommentEvent,
+)
 
 logger = getLogger(__name__)
 
 
 class AbstractPagureEvent(AbstractForgeIndependentEvent):
-    def __init__(self, project_url: str, pr_id: Optional[int] = None):
+    def __init__(self, project_url: str, pr_id: Optional[int] = None, **kwargs):
         super().__init__(pr_id=pr_id)
         self.project_url: str = project_url
         self.git_ref: Optional[str] = None  # git ref that can be 'git checkout'-ed
@@ -43,7 +46,9 @@ class PushPagureEvent(AbstractPagureEvent):
         self.identifier = git_ref
 
 
-class PullRequestCommentPagureEvent(AddPullRequestDbTrigger, AbstractPagureEvent):
+class PullRequestCommentPagureEvent(
+    AddPullRequestDbTrigger, AbstractCommentEvent, AbstractPagureEvent
+):
     def __init__(
         self,
         action: PullRequestCommentAction,
@@ -58,7 +63,7 @@ class PullRequestCommentPagureEvent(AddPullRequestDbTrigger, AbstractPagureEvent
         comment: str,
         commit_sha: str = "",
     ):
-        super().__init__(project_url=project_url, pr_id=pr_id)
+        super().__init__(project_url=project_url, pr_id=pr_id, comment=comment)
         self.action = action
         self.base_repo_namespace = base_repo_namespace
         self.base_repo_name = base_repo_name


### PR DESCRIPTION
If event is triggered by `\packit` command and there is no packit config file in repository, let user know that we require it.

TODO:

- [x] tests
- [ ] don't check every comment twice
- [x] mypy complains a lot - solve it
- [x] AbstractCommentEvent?

<!-- notes for reviewers -->

Also this implementation has a few issues...
- I don't like that I am checking every comment twice for handlers triggered by comment. I can think of two solutions but both of them are quite messy for me... any ideas?
    - when I call `get_handlers_triggered_by_comment` for first time, just store those job handlers to class attribute to remember them and I can use them later.
    - remember those handlers as function arguments
- I don't want to check if event is somewhat \*Comment\* type of event every time because it is like 10-lines if statement. But if it is separated in function, mypy don't know (and obviously can't know) that I am operating only with \*Comment\* type of event outside this function. 
What about implementing `AbstractCommentEvent` class? So I can check whether event is  \*Comment\* type much cleaner than checking it for every subtype of comment.
Now we want to check this in the code like 3 times but this can be really handy in the future because if we want to provide more feedback to users via comments and operate more with comments, we may want some easier way to check whether event is \*Comment\* type. 
And also I can store in this class `handlers_triggered_by_comment` so this will solve my problem with checking every comment twice.

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #765 

---

<!-- release notes for changelog/blog follow -->
N/A