### PR TITLE
Use read-only PR for mock testing

### DIFF
--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -10,7 +10,8 @@ from celery.canvas import Signature
 from flexmock import flexmock
 
 from ogr.abstract import GitTag
-from ogr.abstract import PullRequest, PRStatus
+from ogr.abstract import PRStatus
+from ogr.read_only import PullRequestReadOnly
 from ogr.services.github import GithubProject, GithubRelease
 from ogr.services.gitlab import GitlabProject, GitlabRelease
 from packit.api import PackitAPI
@@ -109,7 +110,7 @@ def test_issue_comment_propose_downstream_handler(
     project_class, comment_event = mock_comment
 
     flexmock(PackitAPI).should_receive("sync_release").and_return(
-        PullRequest(
+        PullRequestReadOnly(
             title="foo",
             description="bar",
             target_branch="baz",


### PR DESCRIPTION
As @mfocko described in https://github.com/packit/ogr/pull/652#discussion_r740103503 , the constructor for `PullRequest` was supposed to be changed (I will hopefully get around to refactoring it soon). Anyway, for the use-case of testing with flexmock, it seems that the read-only PR object should be the way to go so modifying in advance.


Fixes

Related to https://github.com/packit/ogr/pull/652

Merge before/after

---

N/A
