### PR TITLE
Fix checking the status of Testing Farm pipelines

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1454,11 +1454,14 @@ class TFTTestRunModel(ProjectAndTriggersConnector, Base):
 
     @classmethod
     def get_all_by_status(
-        cls, status: TestingFarmResult
+        cls, *status: TestingFarmResult
     ) -> Optional[Iterable["TFTTestRunModel"]]:
-        """Returns all runs which currently have the given status"""
+        """Returns all runs which currently have their status set to one
+        of the requested statuses."""
         with get_sa_session() as session:
-            return session.query(TFTTestRunModel).filter_by(status=status)
+            return session.query(TFTTestRunModel).filter(
+                TFTTestRunModel.status.in_(status)
+            )
 
     @classmethod
     def get_by_id(cls, id: int) -> Optional["TFTTestRunModel"]:

--- a/packit_service/worker/build/babysit.py
+++ b/packit_service/worker/build/babysit.py
@@ -58,13 +58,8 @@ def check_pending_testing_farm_runs() -> None:
             )
             run.set_status(TestingFarmResult.error)
             continue
-        details = response.json()
-        status = TestingFarmResult(details.get("state"))
-        logger.info(f"The status is {status}")
-        if status == TestingFarmResult.running:
-            logger.info(f"Pipeline {run.pipeline_id} is still running")
-            continue
 
+        details = response.json()
         (
             project_url,
             ref,
@@ -76,6 +71,13 @@ def check_pending_testing_farm_runs() -> None:
             log_url,
             created,
         ) = Parser.parse_data_from_testing_farm(run, details)
+
+        logger.info(
+            f"Result for the testing farm pipeline {run.pipeline_id} is {result}."
+        )
+        if result == TestingFarmResult.running:
+            logger.info("Skip updating a running pipeline.")
+            continue
 
         event = TestingFarmResultsEvent(
             pipeline_id=details["id"],


### PR DESCRIPTION
Packit Service implementation mixes the pipeline state and result values
into a single enum, called TestingFarmResult. This lead to a
misunderstanding when determining the state of pipelines in the
baby-sitting task.

Fix this by first parsing the response received from Testing Farm, and
then looking at the value of 'result' to tell the state.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>