### PR TITLE
Pass environment variables to Testing Farm

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,8 +114,17 @@ def copr_build_model(
         runs=runs,
         set_status=lambda x: None,
         set_built_packages=lambda x: None,
-        built_packages=None,
+        built_packages=[
+            {
+                "name": repo_name,
+                "version": "0.1",
+                "release": "1",
+                "arch": "noarch",
+                "epoch": 0,
+            }
+        ],
         task_accepted_time=datetime.now(),
+        build_logs_url="https://log-url",
     )
 
     flexmock(JobTriggerModel).should_receive("get_or_create").with_args(

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -458,8 +458,15 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
                     {
                         "id": "1:fedora-rawhide-x86_64",
                         "type": "fedora-copr-build",
+                        "packages": ["bar-0:0.1-1.noarch"],
                     },
                 ],
+                "variables": {
+                    "PACKIT_FULL_REPO_NAME": "foo/bar",
+                    "PACKIT_COMMIT_SHA": "0011223344",
+                    "PACKIT_PACKAGE_NVR": "bar-0.1-1",
+                    "PACKIT_BUILD_LOG_URL": "https://log-url",
+                },
             }
         ],
         "notification": {

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -835,6 +835,14 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
                         "trigger": "commit",
                     }
                 },
+                "variables": {
+                    "PACKIT_FULL_REPO_NAME": "packit-service/hello-world",
+                    "PACKIT_UPSTREAM_NAME": "hello-world",
+                    "PACKIT_DOWNSTREAM_NAME": "hello-world",
+                    "PACKIT_DOWNSTREAM_URL": "https://src.fedoraproject.org/rpms/hello-world.git",
+                    "PACKIT_PACKAGE_NAME": "hello-world",
+                    "PACKIT_COMMIT_SHA": "12345",
+                },
             }
         ],
         "notification": {


### PR DESCRIPTION
Fixes https://github.com/packit/packit-service/issues/1217

Related to

Merge after https://github.com/packit/packit/pull/1411 (though this solution should be backward compatible)

---
Environment variables from config are now passed to Testing Farm along with some more pre-defined variables (e.g. name of the project, URL, etc).
