### PR TITLE
Remove name of the app/service from check names

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -311,8 +311,7 @@ class BaseBuildJobHelper:
         """
         List of full names of the commit statuses.
 
-        e.g. ["packit/copr-build-fedora-rawhide-x86_64"]
-        or ["packit-stg/production-build-f31", "packit-stg/production-build-f32"]
+        e.g. ["testing-farm:fedora-rawhide-x86_64"]
         """
         if not self._test_check_names:
             self._test_check_names = [
@@ -325,8 +324,8 @@ class BaseBuildJobHelper:
         """
         List of full names of the commit statuses.
 
-        e.g. ["packit/copr-build-fedora-rawhide-x86_64"]
-        or ["packit-stg/production-build-f31", "packit-stg/production-build-f32"]
+        e.g. ["copr-build:fedora-rawhide-x86_64"]
+        or ["production-build:f31", "production-build:f32"]
         """
         if not self._build_check_names:
             self._build_check_names = [
@@ -347,21 +346,13 @@ class BaseBuildJobHelper:
 
     @classmethod
     def get_build_check(cls, chroot: str = None) -> str:
-        config = ServiceConfig.get_service_config()
-        deployment_str = (
-            "packit" if config.deployment == Deployment.prod else "packit-stg"
-        )
-        chroot_str = f"-{chroot}" if chroot else ""
-        return f"{deployment_str}/{cls.status_name_build}{chroot_str}"
+        chroot_str = f":{chroot}" if chroot else ""
+        return f"{cls.status_name_build}{chroot_str}"
 
     @classmethod
     def get_test_check(cls, chroot: str = None) -> str:
-        config = ServiceConfig.get_service_config()
-        deployment_str = (
-            "packit" if config.deployment == Deployment.prod else "packit-stg"
-        )
-        chroot_str = f"-{chroot}" if chroot else ""
-        return f"{deployment_str}/{cls.status_name_test}{chroot_str}"
+        chroot_str = f":{chroot}" if chroot else ""
+        return f"{cls.status_name_test}{chroot_str}"
 
     def create_srpm_if_needed(self) -> Optional[TaskResults]:
         """

--- a/tests/data/webhooks/github/checkrun_rerequested.json
+++ b/tests/data/webhooks/github/checkrun_rerequested.json
@@ -2,7 +2,7 @@
   "action": "rerequested",
   "check_run": {
     "id": 3659360488,
-    "name": "packit-stg/testing-farm-fedora-rawhide-x86_64",
+    "name": "testing-farm:fedora-rawhide-x86_64",
     "node_id": "CR_kwDOCwFO9M7aHWjo",
     "head_sha": "0e5d8b51fd5dfa460605e1497d22a76d65c6d7fd",
     "external_id": "123456",

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -59,7 +59,7 @@ def check_rerun_event_copr_build():
     event = json.loads(
         (DATA_DIR / "webhooks" / "github" / "checkrun_rerequested.json").read_text()
     )
-    event["check_run"]["name"] = "packit-stg/rpm-build-fedora-rawhide-x86_64"
+    event["check_run"]["name"] = "rpm-build:fedora-rawhide-x86_64"
     return event
 
 
@@ -68,7 +68,7 @@ def check_rerun_event_koji_build():
     event = json.loads(
         (DATA_DIR / "webhooks" / "github" / "checkrun_rerequested.json").read_text()
     )
-    event["check_run"]["name"] = "packit-stg/production-build-f34"
+    event["check_run"]["name"] = "production-build:f34"
     return event
 
 
@@ -236,7 +236,7 @@ def test_check_rerun_pr_copr_build_handler(
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.pending,
         description=TASK_ACCEPTED,
-        check_name="packit-stg/rpm-build-fedora-rawhide-x86_64",
+        check_name="rpm-build:fedora-rawhide-x86_64",
         url="",
         links_to_external_services=None,
     ).once()
@@ -294,7 +294,7 @@ def test_check_rerun_pr_testing_farm_handler(
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.pending,
         description=TASK_ACCEPTED,
-        check_name="packit-stg/testing-farm-fedora-rawhide-x86_64",
+        check_name="testing-farm:fedora-rawhide-x86_64",
         url="",
         links_to_external_services=None,
     ).once()
@@ -347,7 +347,7 @@ def test_check_rerun_pr_koji_build_handler(
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.pending,
         description=TASK_ACCEPTED,
-        check_name="packit-stg/production-build-f34",
+        check_name="production-build:f34",
         url="",
         links_to_external_services=None,
     ).once()
@@ -401,7 +401,7 @@ def test_check_rerun_push_copr_build_handler(
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.pending,
         description=TASK_ACCEPTED,
-        check_name="packit-stg/rpm-build-fedora-rawhide-x86_64",
+        check_name="rpm-build:fedora-rawhide-x86_64",
         url="",
         links_to_external_services=None,
     ).once()
@@ -459,7 +459,7 @@ def test_check_rerun_push_testing_farm_handler(
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.pending,
         description=TASK_ACCEPTED,
-        check_name="packit-stg/testing-farm-fedora-rawhide-x86_64",
+        check_name="testing-farm:fedora-rawhide-x86_64",
         url="",
         links_to_external_services=None,
     ).once()
@@ -512,7 +512,7 @@ def test_check_rerun_push_koji_build_handler(
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.pending,
         description=TASK_ACCEPTED,
-        check_name="packit-stg/production-build-f34",
+        check_name="production-build:f34",
         url="",
         links_to_external_services=None,
     ).once()
@@ -566,7 +566,7 @@ def test_check_rerun_release_copr_build_handler(
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.pending,
         description=TASK_ACCEPTED,
-        check_name="packit-stg/rpm-build-fedora-rawhide-x86_64",
+        check_name="rpm-build:fedora-rawhide-x86_64",
         url="",
         links_to_external_services=None,
     ).once()
@@ -620,7 +620,7 @@ def test_check_rerun_release_koji_build_handler(
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.pending,
         description=TASK_ACCEPTED,
-        check_name="packit-stg/production-build-f34",
+        check_name="production-build:f34",
         url="",
         links_to_external_services=None,
     ).once()

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -165,7 +165,7 @@ def test_precheck_koji_build_non_scratch(github_pr_event):
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.neutral,
         description="Non-scratch builds not possible from upstream.",
-        check_name="packit-stg/production-build-bright-future",
+        check_name="production-build:bright-future",
         url=KOJI_PRODUCTION_BUILDS_ISSUE,
         links_to_external_services=None,
     ).and_return().once()

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -58,7 +58,6 @@ def mock_comment(request):
         .with_args(author)
         .and_return(True)
     )
-    flexmock(project_class).should_receive("issue_comment").and_return(None)
     issue = flexmock()
     flexmock(project_class).should_receive("get_issue").and_return(issue)
     comment = flexmock()

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -46,8 +46,8 @@ from tests.conftest import copr_build_model
 from tests.spellbook import DATA_DIR, first_dict_value, get_parameters_from_results
 
 CHROOT = "fedora-rawhide-x86_64"
-EXPECTED_BUILD_CHECK_NAME = f"packit-stg/rpm-build-{CHROOT}"
-EXPECTED_TESTING_FARM_CHECK_NAME = f"packit-stg/testing-farm-{CHROOT}"
+EXPECTED_BUILD_CHECK_NAME = f"rpm-build:{CHROOT}"
+EXPECTED_TESTING_FARM_CHECK_NAME = f"testing-farm:{CHROOT}"
 
 pytestmark = pytest.mark.usefixtures("mock_get_valid_build_targets")
 
@@ -967,7 +967,7 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
         state=BaseCommitStatus.running,
         description="RPM build is in progress...",
         url=url,
-        check_names="packit-stg/production-build-rawhide",
+        check_names="production-build:rawhide",
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").once().and_return()
@@ -1026,7 +1026,7 @@ def test_koji_build_end(koji_build_scratch_end, pc_koji_build_pr, koji_build_pr)
         state=BaseCommitStatus.success,
         description="RPMs were built successfully.",
         url=url,
-        check_names="packit-stg/production-build-rawhide",
+        check_names="production-build:rawhide",
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").once().and_return()

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -865,7 +865,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
     flexmock(StatusReporter).should_receive("report").with_args(
         state=BaseCommitStatus.running,
         description="Submitting the tests ...",
-        check_names="packit-stg/testing-farm-fedora-rawhide-x86_64",
+        check_names="testing-farm:fedora-rawhide-x86_64",
         url="",
     ).once()
 
@@ -890,7 +890,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
         description="Tests have been submitted ...",
         state=BaseCommitStatus.running,
         url="https://dashboard.localhost/results/testing-farm/5",
-        check_names="packit-stg/testing-farm-fedora-rawhide-x86_64",
+        check_names="testing-farm:fedora-rawhide-x86_64",
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
 

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -41,7 +41,7 @@ from packit_service.worker.events.enums import (
 from packit_service.worker.allowlist import Allowlist
 from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 
-EXPECTED_TESTING_FARM_CHECK_NAME = "packit-stg/testing-farm-fedora-rawhide-x86_64"
+EXPECTED_TESTING_FARM_CHECK_NAME = "testing-farm:fedora-rawhide-x86_64"
 
 
 @pytest.fixture()

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -168,14 +168,14 @@ def test_copr_build_check_names(github_pr_event):
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
-        check_name="packit-stg/rpm-build-bright-future-x86_64",
+        check_name="rpm-build:bright-future-x86_64",
         url="",
         links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Starting RPM build...",
-        check_name="packit-stg/rpm-build-bright-future-x86_64",
+        check_name="rpm-build:bright-future-x86_64",
         url="https://test.url",
         links_to_external_services=None,
     ).and_return()
@@ -272,7 +272,7 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
         flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
             state=BaseCommitStatus.running,
             description="Building SRPM ...",
-            check_name=f"packit-stg/rpm-build-{target}",
+            check_name=f"rpm-build:{target}",
             url="",
             links_to_external_services=None,
         ).and_return()
@@ -281,7 +281,7 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
         flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
             state=BaseCommitStatus.error,
             description=f"Not supported target: {not_supported_target}",
-            check_name=f"packit-stg/rpm-build-{not_supported_target}",
+            check_name=f"rpm-build:{not_supported_target}",
             url="https://test.url",
             links_to_external_services=None,
         ).and_return()
@@ -289,7 +289,7 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Starting RPM build...",
-        check_name="packit-stg/rpm-build-even-brighter-one-aarch64",
+        check_name="rpm-build:even-brighter-one-aarch64",
         url="https://test.url",
         links_to_external_services=None,
     ).and_return()
@@ -414,14 +414,14 @@ def test_copr_build_check_names_multiple_jobs(github_pr_event):
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
-        check_name="packit-stg/rpm-build-fedora-32-x86_64",
+        check_name="rpm-build:fedora-32-x86_64",
         url="",
         links_to_external_services=None,
     ).and_return().once()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Starting RPM build...",
-        check_name="packit-stg/rpm-build-fedora-32-x86_64",
+        check_name="rpm-build:fedora-32-x86_64",
         url="https://test.url",
         links_to_external_services=None,
     ).and_return().once()
@@ -506,14 +506,14 @@ def test_copr_build_check_names_custom_owner(github_pr_event):
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
-        check_name="packit-stg/rpm-build-bright-future-x86_64",
+        check_name="rpm-build:bright-future-x86_64",
         url="",
         links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Starting RPM build...",
-        check_name="packit-stg/rpm-build-bright-future-x86_64",
+        check_name="rpm-build:bright-future-x86_64",
         url="https://test.url",
         links_to_external_services=None,
     ).and_return()
@@ -936,7 +936,7 @@ def test_copr_build_fails_in_packit(github_pr_event):
     flexmock(packit_service.worker.build.copr_build).should_receive(
         "get_valid_build_targets"
     ).and_return({"fedora-31-x86_64", "fedora-rawhide-x86_64"})
-    templ = "packit-stg/rpm-build-fedora-{ver}-x86_64"
+    templ = "rpm-build:fedora-{ver}-x86_64"
     flexmock(copr_build).should_receive("get_srpm_build_info_url").and_return(
         "https://test.url"
     )
@@ -998,7 +998,7 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
     flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
         type=JobTriggerModelType.pull_request, trigger_id=123
     ).and_return(flexmock(id=2, type=JobTriggerModelType.pull_request))
-    templ = "packit-stg/rpm-build-fedora-{ver}-x86_64"
+    templ = "rpm-build:fedora-{ver}-x86_64"
     flexmock(copr_build).should_receive("get_srpm_build_info_url").and_return(
         "https://test.url"
     )
@@ -1200,14 +1200,14 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
     flexmock(StatusReporterGitlab).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
-        check_name="packit-stg/rpm-build-bright-future-x86_64",
+        check_name="rpm-build:bright-future-x86_64",
         url="",
         links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporterGitlab).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Starting RPM build...",
-        check_name="packit-stg/rpm-build-bright-future-x86_64",
+        check_name="rpm-build:bright-future-x86_64",
         url="https://test.url",
         links_to_external_services=None,
     ).and_return()
@@ -1513,7 +1513,7 @@ def test_copr_build_fails_in_packit_gitlab(gitlab_mr_event):
         type=JobTriggerModelType.pull_request, trigger_id=123
     ).and_return(flexmock(id=2, type=JobTriggerModelType.pull_request))
     flexmock(CoprBuildJobHelper).should_receive("is_reporting_allowed").and_return(True)
-    templ = "packit-stg/rpm-build-fedora-{ver}-x86_64"
+    templ = "rpm-build:fedora-{ver}-x86_64"
     flexmock(copr_build).should_receive("get_srpm_build_info_url").and_return(
         "https://test.url"
     )

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -116,14 +116,14 @@ def test_koji_build_check_names(github_pr_event):
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
-        check_name="packit-stg/production-build-bright-future",
+        check_name="production-build:bright-future",
         url="",
         links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building RPM ...",
-        check_name="packit-stg/production-build-bright-future",
+        check_name="production-build:bright-future",
         url=koji_build_url,
         links_to_external_services=None,
     ).and_return()
@@ -174,14 +174,14 @@ def test_koji_build_failed_kerberos(github_pr_event):
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
-        check_name="packit-stg/production-build-bright-future",
+        check_name="production-build:bright-future",
         url="",
         links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.error,
         description="Kerberos authentication error: the bad authentication error",
-        check_name="packit-stg/production-build-bright-future",
+        check_name="production-build:bright-future",
         url=get_srpm_build_info_url(1),
         links_to_external_services=None,
     ).and_return()
@@ -233,14 +233,14 @@ def test_koji_build_target_not_supported(github_pr_event):
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
-        check_name="packit-stg/production-build-nonexisting-target",
+        check_name="production-build:nonexisting-target",
         url="",
         links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.error,
         description="Target not supported: nonexisting-target",
-        check_name="packit-stg/production-build-nonexisting-target",
+        check_name="production-build:nonexisting-target",
         url=get_srpm_build_info_url(1),
         links_to_external_services=None,
     ).and_return()
@@ -339,7 +339,7 @@ def test_koji_build_failed(github_pr_event):
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
-        check_name="packit-stg/production-build-bright-future",
+        check_name="production-build:bright-future",
         url="",
         links_to_external_services=None,
     ).and_return()
@@ -348,7 +348,7 @@ def test_koji_build_failed(github_pr_event):
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.error,
         description="Submit of the build failed: some error",
-        check_name="packit-stg/production-build-bright-future",
+        check_name="production-build:bright-future",
         url=srpm_build_url,
         links_to_external_services=None,
     ).and_return()
@@ -392,14 +392,14 @@ def test_koji_build_failed_srpm(github_pr_event):
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
-        check_name="packit-stg/production-build-bright-future",
+        check_name="production-build:bright-future",
         url="",
         links_to_external_services=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.failure,
         description="SRPM build failed, check the logs for details.",
-        check_name="packit-stg/production-build-bright-future",
+        check_name="production-build:bright-future",
         url=srpm_build_url,
         links_to_external_services=None,
     ).and_return()

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -112,7 +112,7 @@ def test_testing_farm_response(
         description=status_message,
         links_to_external_services={"Testing Farm": "some url"},
         url="https://dashboard.localhost/results/testing-farm/123",
-        check_names="packit-stg/testing-farm-fedora-rawhide-x86_64",
+        check_names="testing-farm:fedora-rawhide-x86_64",
     )
 
     urls.DASHBOARD_URL = "https://dashboard.localhost"

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -1711,7 +1711,7 @@ def check_rerun_event_dict_commit():
         "action": "rerequested",
         "check_run": {
             "id": 3659360488,
-            "name": "packit-stg/testing-farm-fedora-rawhide-x86_64",
+            "name": "testing-farm:fedora-rawhide-x86_64",
             "node_id": "CR_kwDOCwFO9M7aHWjo",
             "head_sha": "0e5d8b51fd5dfa460605e1497d22a76d65c6d7fd",
             "external_id": "123456",


### PR DESCRIPTION
The check run names are already quite long and I need to add even more info (test distro) to them.
I checked some checks of various apps and most of them don't contain the name of the app, so I think it's not needed.
We have a different icon for the staging app and in the Checks tab the checks are in sections with the app names.

Also, the job and target are newly separated with ':' instead of '-', because there already are more '-' in most target names and it's more readable this way.

---

The check run names are now shorter and easier to read.
