### PR TITLE
Improve pipeline grouping

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -34,6 +34,8 @@ from sqlalchemy import (
     create_engine,
     desc,
     func,
+    null,
+    case,
 )
 from sqlalchemy.dialects.postgresql import array as psql_array
 from sqlalchemy.ext.declarative import declarative_base
@@ -766,7 +768,12 @@ class RunModel(Base):
         with get_sa_session() as session:
             return (
                 cls.__query_merged_runs(session)
-                .group_by(RunModel.srpm_build_id)
+                .group_by(
+                    RunModel.srpm_build_id,
+                    case(
+                        [(RunModel.srpm_build_id.isnot(null()), 0)], else_=RunModel.id
+                    ),
+                )
                 .order_by(desc("merged_id"))[first:last]
             )
 
@@ -776,7 +783,12 @@ class RunModel(Base):
             return (
                 cls.__query_merged_runs(session)
                 .filter(RunModel.id >= first_id, RunModel.id <= first_id + 100)
-                .group_by(RunModel.srpm_build_id)
+                .group_by(
+                    RunModel.srpm_build_id,
+                    case(
+                        [(RunModel.srpm_build_id.isnot(null()), 0)], else_=RunModel.id
+                    ),
+                )
                 .first()
             )
 

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -1675,10 +1675,14 @@ def few_runs(pr_model, different_pr_model):
 
 
 @pytest.fixture()
-def run_without_build(pr_model):
+def runs_without_build(pr_model, branch_model):
     run_model_for_pr_only_test = RunModel.create(
         type=pr_model.job_trigger_model_type, trigger_id=pr_model.id
     )
+    run_model_for_branch_only_test = RunModel.create(
+        type=branch_model.job_trigger_model_type, trigger_id=branch_model.id
+    )
+
     TFTTestRunModel.create(
         pipeline_id=SampleValues.pipeline_id,
         commit_sha=SampleValues.commit_sha,
@@ -1686,8 +1690,16 @@ def run_without_build(pr_model):
         target=SampleValues.target,
         status=TestingFarmResult.new,
         run_model=run_model_for_pr_only_test,
+    ),
+    TFTTestRunModel.create(
+        pipeline_id=SampleValues.pipeline_id,
+        commit_sha=SampleValues.commit_sha,
+        web_url=SampleValues.testing_farm_url,
+        target=SampleValues.target,
+        status=TestingFarmResult.new,
+        run_model=run_model_for_branch_only_test,
     )
-    yield run_model_for_pr_only_test
+    yield [run_model_for_pr_only_test, run_model_for_branch_only_test]
 
 
 @pytest.fixture()

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -764,3 +764,12 @@ def test_merged_runs(clean_before_and_after, few_runs):
             assert copr_build.get_srpm_build().id == srpm_build_id
 
         assert len(merged_run.test_run_id) == 2 * i
+
+
+def test_merged_chroots_on_tests_without_build(
+    clean_before_and_after, runs_without_build
+):
+    result = RunModel.get_merged_chroots(0, 10)
+    assert len(result) == 2
+    for item in result:
+        assert len(item.test_run_id[0]) == 1

--- a/tests_requre/service/test_api.py
+++ b/tests_requre/service/test_api.py
@@ -3,7 +3,7 @@
 
 from flask import url_for
 
-from packit_service.models import TestingFarmResult, RunModel, optional_timestamp
+from packit_service.models import TestingFarmResult, RunModel
 from packit_service.service.api.runs import process_runs
 from tests_requre.conftest import SampleValues
 
@@ -428,12 +428,11 @@ def test_meta(client, clean_before_and_after, a_copr_build_for_pr):
     assert response.headers["Access-Control-Allow-Origin"] == "*"
 
 
-def test_process_run_without_build(clean_before_and_after, run_without_build):
-    merged_run = RunModel.get_merged_run(run_without_build.id)
-    result = process_runs([merged_run])[0]
-    assert not result["srpm"]
-    assert result["time_submitted"] == optional_timestamp(
-        run_without_build.test_run.submitted_time
-    )
-    assert len(result["test_run"]) == 1
-    assert result["trigger"]
+def test_process_runs_without_build(clean_before_and_after, runs_without_build):
+    merged_runs = RunModel.get_merged_chroots(0, 10)
+    result = process_runs(merged_runs)
+    for item in result:
+        assert not item["srpm"]
+        assert item["time_submitted"]
+        assert len(item["test_run"]) == 1
+        assert item["trigger"]


### PR DESCRIPTION
If we group only by the SRPM build ID, all tests without build (without the SRPM build ID) are grouped together, which is incorrect. We discussed that until the DB schema is not improved, it is okay to display the tests without build as separate pipelines.

Related to #1276 


---

N/A
