### PR TITLE
Use query.slice() to slice the query on server

### DIFF
--- a/packit_service/service/api/projects.py
+++ b/packit_service/service/api/projects.py
@@ -29,10 +29,7 @@ class ProjectsList(Resource):
         result = []
         first, last = indices()
 
-        projects_list = GitProjectModel.get_projects(first, last)
-        if not projects_list:
-            return response_maker([])
-        for project in projects_list:
+        for project in GitProjectModel.get_projects(first, last):
             project_info = {
                 "namespace": project.namespace,
                 "repo_name": project.repo_name,
@@ -43,6 +40,9 @@ class ProjectsList(Resource):
                 "issues_handled": len(project.issues),
             }
             result.append(project_info)
+
+        if not result:
+            return response_maker([])
 
         resp = response_maker(
             result,
@@ -90,10 +90,7 @@ class ProjectsForge(Resource):
         result = []
         first, last = indices()
 
-        projects_list = GitProjectModel.get_forge(first, last, forge)
-        if not projects_list:
-            return response_maker([])
-        for project in projects_list:
+        for project in GitProjectModel.get_forge(first, last, forge):
             project_info = {
                 "namespace": project.namespace,
                 "repo_name": project.repo_name,
@@ -104,6 +101,9 @@ class ProjectsForge(Resource):
                 "issues_handled": len(project.issues),
             }
             result.append(project_info)
+
+        if not result:
+            return response_maker([])
 
         resp = response_maker(
             result,
@@ -154,12 +154,9 @@ class ProjectsPRs(Resource):
         result = []
         first, last = indices()
 
-        pr_list = GitProjectModel.get_project_prs(
+        for pr in GitProjectModel.get_project_prs(
             first, last, forge, namespace, repo_name
-        )
-        if not pr_list:
-            return response_maker([])
-        for pr in pr_list:
+        ):
             pr_info = {
                 "pr_id": pr.pr_id,
                 "builds": [],
@@ -212,6 +209,9 @@ class ProjectsPRs(Resource):
             pr_info["tests"] = test_runs
 
             result.append(pr_info)
+
+        if not result:
+            return response_maker([])
 
         resp = response_maker(
             result,

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -268,8 +268,8 @@ def test_errors_while_doing_db(clean_before_and_after):
 def test_get_srpm_builds_in_give_range(
     clean_before_and_after, srpm_build_model_with_new_run_for_pr
 ):
-    builds_list = SRPMBuildModel.get(0, 10)
-    assert len(list(builds_list)) == 1
+    builds_list = list(SRPMBuildModel.get(0, 10))
+    assert len(builds_list) == 1
     assert builds_list[0].success is True
 
 
@@ -522,7 +522,7 @@ def test_tmt_test_get_by_pipeline_id_pr(
 def test_tmt_test_get_range(clean_before_and_after, multiple_new_test_runs):
     assert multiple_new_test_runs
     results = TFTTestRunModel.get_range(0, 10)
-    assert len(results) == 4
+    assert len(list(results)) == 4
 
 
 def test_tmt_test_get_by_pipeline_id_branch_push(
@@ -604,14 +604,14 @@ def test_get_project(clean_before_and_after, a_copr_build_for_pr):
 
 
 def test_get_forge(clean_before_and_after, multiple_forge_projects):
-    projects = GitProjectModel.get_forge(0, 10, "github.com")
+    projects = list(GitProjectModel.get_forge(0, 10, "github.com"))
     assert projects
     assert len(projects) == 2
 
-    projects = GitProjectModel.get_forge(0, 10, "gitlab.com")
+    projects = list(GitProjectModel.get_forge(0, 10, "gitlab.com"))
     assert len(projects) == 1
 
-    projects = GitProjectModel.get_forge(0, 10, "git.stg.centos.org")
+    projects = list(GitProjectModel.get_forge(0, 10, "git.stg.centos.org"))
     assert len(projects) == 1
 
 
@@ -622,18 +622,24 @@ def test_get_namespace(clean_before_and_after, multiple_copr_builds):
 
 
 def test_get_project_prs(clean_before_and_after, a_copr_build_for_pr):
-    prs_a = GitProjectModel.get_project_prs(
-        0, 10, "github.com", "the-namespace", "the-repo-name"
+    prs_a = list(
+        GitProjectModel.get_project_prs(
+            0, 10, "github.com", "the-namespace", "the-repo-name"
+        )
     )
-    assert prs_a is not None
+    assert prs_a
     assert len(prs_a) == 1
     assert prs_a[0].id is not None  # cant explicitly check because its random like
-    prs_b = GitProjectModel.get_project_prs(
-        0, 10, "gitlab.com", "the-namespace", "the-repo-name"
+    prs_b = list(
+        GitProjectModel.get_project_prs(
+            0, 10, "gitlab.com", "the-namespace", "the-repo-name"
+        )
     )
     assert prs_b == []
-    prs_c = GitProjectModel.get_project_prs(
-        0, 10, "github", "the-namespace", "the-repo-name"
+    prs_c = list(
+        GitProjectModel.get_project_prs(
+            0, 10, "github", "the-namespace", "the-repo-name"
+        )
     )
     assert prs_c == []
 
@@ -769,7 +775,7 @@ def test_merged_runs(clean_before_and_after, few_runs):
 def test_merged_chroots_on_tests_without_build(
     clean_before_and_after, runs_without_build
 ):
-    result = RunModel.get_merged_chroots(0, 10)
+    result = list(RunModel.get_merged_chroots(0, 10))
     assert len(result) == 2
     for item in result:
         assert len(item.test_run_id[0]) == 1


### PR DESCRIPTION
instead of in a client, as done previously.

https://docs.sqlalchemy.org/en/14/orm/query.html?highlight=order_by#sqlalchemy.orm.Query.slice

I built & pushed `stg` image, so you can check it in https://dashboard.stg.packit.dev
I was hoping to see much better speed improvement, but it's quite insignificant.
It's still a good thing to do this on the server instead of in a client, though.

---

N/A