### PR TITLE
Fix typo for getting comment object for GitLab

### DIFF
--- a/packit_service/worker/events/gitlab.py
+++ b/packit_service/worker/events/gitlab.py
@@ -156,7 +156,7 @@ class MergeRequestCommentGitlabEvent(
     @property
     def comment_object(self) -> Optional[Comment]:
         if not self._comment_object:
-            self._comment_object = self.project.get_pr(self.object_id).get_comment(
+            self._comment_object = self.project.get_pr(self.object_iid).get_comment(
                 self.comment_id
             )
         return self._comment_object


### PR DESCRIPTION
Fix typo that looks up GitLab MR by its internal ID from database rather
than IID which is used.

Fixes PACKIT-SERVICE-3TB

Signed-off-by: Matej Focko <mfocko@redhat.com>

---

<!-- release notes for changelog/blog follow -->
