### PR TITLE
Map oraclelinux-8 distro to Oracle-Linux-8.5 compose

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -324,7 +324,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             if compose == "Oracle-Linux-7":
                 return "Oracle-Linux-7.9"
             if compose == "Oracle-Linux-8":
-                return "Oracle-Linux-8.4"
+                return "Oracle-Linux-8.5"
         else:
             response = self.send_testing_farm_request(endpoint="composes")
             if response.status_code == 200:

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -200,7 +200,7 @@ def test_chroot2distro_arch(chroot, distro, arch, use_internal_tf):
         ("rhel-7", "RHEL-7-LatestReleased", True),
         ("rhel-8", "RHEL-8.5.0-Nightly", True),
         ("oraclelinux-7", "Oracle-Linux-7.9", True),
-        ("oraclelinux-8", "Oracle-Linux-8.4", True),
+        ("oraclelinux-8", "Oracle-Linux-8.5", True),
     ],
 )
 def test_distro2compose(distro, compose, use_internal_tf):


### PR DESCRIPTION
[Oralce-Linux8.5 is now in artemis and openstack](https://gitlab.cee.redhat.com/baseos-qe/citool-config/-/commit/a544f243cedffb0db7a688cd03c3ee09b544ecc1)

---

N/A