### PR TITLE
External contributors can't use internal services

### DIFF
--- a/packit_service/worker/allowlist.py
+++ b/packit_service/worker/allowlist.py
@@ -256,7 +256,7 @@ class Allowlist:
         service_config: ServiceConfig,
         job_configs: Iterable[JobConfig],
     ) -> bool:
-        actor_name = event.user_login
+        actor_name = event.actor
         if not actor_name:
             raise KeyError(f"Failed to get login of the actor from {type(event)}")
 
@@ -311,7 +311,7 @@ class Allowlist:
         service_config: ServiceConfig,
         job_configs: Iterable[JobConfig],
     ) -> bool:
-        actor_name = event.user_login
+        actor_name = event.actor
         if not actor_name:
             raise KeyError(f"Failed to get login of the actor from {type(event)}")
         project_url = self._strip_protocol_and_add_git(event.project_url)
@@ -377,7 +377,10 @@ class Allowlist:
         }
 
         # Administrators
-        user_login = getattr(event, "user_login", None)
+        user_login = getattr(  # some old events with user_login can still be there
+            event, "user_login", None
+        ) or getattr(event, "actor", None)
+
         if user_login and user_login in service_config.admins:
             logger.info(f"{user_login} is admin, you shall pass.")
             return True

--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -33,7 +33,7 @@ class EventData:
     def __init__(
         self,
         event_type: str,
-        user_login: str,
+        actor: str,
         trigger_id: int,
         project_url: str,
         tag_name: Optional[str],
@@ -47,7 +47,7 @@ class EventData:
         targets_override: Optional[List[str]],
     ):
         self.event_type = event_type
-        self.user_login = user_login
+        self.actor = actor
         self.trigger_id = trigger_id
         self.project_url = project_url
         self.tag_name = tag_name
@@ -67,7 +67,8 @@ class EventData:
     @classmethod
     def from_event_dict(cls, event: dict):
         event_type = event.get("event_type")
-        user_login = event.get("user_login")
+        # We used `user_login` in the past.
+        actor = event.get("user_login") or event.get("actor")
         trigger_id = event.get("trigger_id")
         project_url = event.get("project_url")
         tag_name = event.get("tag_name")
@@ -86,7 +87,7 @@ class EventData:
 
         return EventData(
             event_type=event_type,
-            user_login=user_login,
+            actor=actor,
             trigger_id=trigger_id,
             project_url=project_url,
             tag_name=tag_name,
@@ -189,6 +190,7 @@ class EventData:
 
 class Event:
     task_accepted_time: Optional[datetime] = None
+    actor: Optional[str]
 
     def __init__(self, created_at: Union[int, float, str] = None):
         self.created_at: datetime
@@ -290,11 +292,13 @@ class AbstractForgeIndependentEvent(Event):
         created_at: Union[int, float, str] = None,
         project_url=None,
         pr_id: Optional[int] = None,
+        actor: Optional[str] = None,
     ):
         super().__init__(created_at)
         self.project_url = project_url
         self._pr_id = pr_id
         self.fail_when_config_file_missing = False
+        self.actor = actor
 
         # Lazy properties
         self._project: Optional[GitProject] = None

--- a/packit_service/worker/events/github.py
+++ b/packit_service/worker/events/github.py
@@ -93,7 +93,7 @@ class PullRequestGithubEvent(AddPullRequestDbTrigger, AbstractGithubEvent):
         target_repo_name: str,
         project_url: str,
         commit_sha: str,
-        user_login: str,
+        actor: str,
     ):
         super().__init__(project_url=project_url, pr_id=pr_id)
         self.action = action
@@ -103,7 +103,7 @@ class PullRequestGithubEvent(AddPullRequestDbTrigger, AbstractGithubEvent):
         self.target_repo_namespace = target_repo_namespace
         self.target_repo_name = target_repo_name
         self.commit_sha = commit_sha
-        self.user_login = user_login
+        self.actor = actor
         self.identifier = str(pr_id)
         self.git_ref = None  # pr_id will be used for checkout
 
@@ -129,7 +129,7 @@ class PullRequestCommentGithubEvent(
         target_repo_namespace: str,
         target_repo_name: str,
         project_url: str,
-        user_login: str,
+        actor: str,
         comment: str,
         comment_id: int,
         commit_sha: Optional[str] = None,
@@ -147,7 +147,7 @@ class PullRequestCommentGithubEvent(
         self.base_ref = base_ref
         self.target_repo_namespace = target_repo_namespace
         self.target_repo_name = target_repo_name
-        self.user_login = user_login
+        self.actor = actor
         self.comment = comment
         self.comment_id = comment_id
         self.identifier = str(pr_id)
@@ -192,7 +192,7 @@ class IssueCommentEvent(AddIssueDbTrigger, AbstractCommentEvent, AbstractGithubE
         repo_name: str,
         target_repo: str,
         project_url: str,
-        user_login: str,
+        actor: str,
         comment: str,
         comment_id: int,
         tag_name: str = "",
@@ -211,7 +211,7 @@ class IssueCommentEvent(AddIssueDbTrigger, AbstractCommentEvent, AbstractGithubE
         self.base_ref = base_ref
         self._tag_name = tag_name
         self.target_repo = target_repo
-        self.user_login = user_login
+        self.actor = actor
         self.comment = comment
         self.comment_id = comment_id
         self.identifier = str(issue_id)
@@ -258,6 +258,7 @@ class CheckRerunEvent(AbstractGithubEvent):
         repo_name: str,
         db_trigger: Union[PullRequestModel, GitBranchModel, ProjectReleaseModel],
         commit_sha: str,
+        actor: str,
         pr_id: Optional[int] = None,
     ):
         super().__init__(project_url=project_url, pr_id=pr_id)
@@ -266,6 +267,7 @@ class CheckRerunEvent(AbstractGithubEvent):
         self.repo_namespace = repo_namespace
         self.repo_name = repo_name
         self.commit_sha = commit_sha
+        self.actor = actor
         self._db_trigger = db_trigger
 
     @property
@@ -297,6 +299,7 @@ class CheckRerunCommitEvent(CheckRerunEvent):
         check_name_job: str,
         check_name_target: str,
         db_trigger,
+        actor: str,
     ):
         super().__init__(
             check_name_job=check_name_job,
@@ -306,6 +309,7 @@ class CheckRerunCommitEvent(CheckRerunEvent):
             repo_name=repo_name,
             db_trigger=db_trigger,
             commit_sha=commit_sha,
+            actor=actor,
         )
         self.identifier = git_ref
         self.git_ref = git_ref
@@ -324,6 +328,7 @@ class CheckRerunPullRequestEvent(CheckRerunEvent):
         check_name_job: str,
         check_name_target: str,
         db_trigger,
+        actor: str,
     ):
         super().__init__(
             check_name_job=check_name_job,
@@ -334,6 +339,7 @@ class CheckRerunPullRequestEvent(CheckRerunEvent):
             db_trigger=db_trigger,
             commit_sha=commit_sha,
             pr_id=pr_id,
+            actor=actor,
         )
         self.identifier = str(pr_id)
         self.git_ref = None
@@ -352,6 +358,7 @@ class CheckRerunReleaseEvent(CheckRerunEvent):
         check_name_job: str,
         check_name_target: str,
         db_trigger,
+        actor: str,
     ):
         super().__init__(
             check_name_job=check_name_job,
@@ -361,6 +368,7 @@ class CheckRerunReleaseEvent(CheckRerunEvent):
             repo_name=repo_name,
             db_trigger=db_trigger,
             commit_sha=commit_sha,
+            actor=actor,
         )
         self.tag_name = tag_name
         self.git_ref = tag_name
@@ -383,6 +391,7 @@ class InstallationEvent(Event):
     ):
         super().__init__(created_at)
         self.installation_id = installation_id
+        self.actor = account_login
         # account == namespace (user/organization) into which the app has been installed
         self.account_login = account_login
         self.account_id = account_id

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -342,6 +342,15 @@ class JobHandler(Handler):
             [s for c in cls.__subclasses__() for s in c.get_all_subclasses()]
         )
 
+    def check_if_actor_can_run_job_and_report(self, actor: str) -> bool:
+        """
+        Here, handlers can specify additional check of permissions for a given user
+        by overriding this method.
+
+        In case of False, we expect the method provides a feedback to the user.
+        """
+        return True
+
     def run_job(self):
         """
         If pre-check succeeds, run the job for the specific handler.

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -122,10 +122,8 @@ class KojiBuildHandler(JobHandler):
                 return False
 
         if self.data.event_type == PullRequestGithubEvent.__name__:
-            user_can_merge_pr = self.project.can_merge_pr(self.data.user_login)
-            if not (
-                user_can_merge_pr or self.data.user_login in self.service_config.admins
-            ):
+            user_can_merge_pr = self.project.can_merge_pr(self.data.actor)
+            if not (user_can_merge_pr or self.data.actor in self.service_config.admins):
                 self.koji_build_helper.report_status_to_all(
                     description=PERMISSIONS_ERROR_WRITE_OR_ADMIN,
                     state=BaseCommitStatus.neutral,

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -96,7 +96,8 @@ class TestingFarmHandler(JobHandler):
 
     def pre_check(self) -> bool:
         return not (
-            self.testing_farm_job_helper.skip_build and self.copr_build_comment_event()
+            self.testing_farm_job_helper.skip_build
+            and self.is_copr_build_comment_event()
         )
 
     @property
@@ -136,18 +137,18 @@ class TestingFarmHandler(JobHandler):
                 PullRequestGithubEvent.__name__,
                 MergeRequestGitlabEvent.__name__,
             )
-            or self.copr_build_comment_event()
+            or self.is_copr_build_comment_event()
         )
 
-    def comment_event(self) -> bool:
+    def is_comment_event(self) -> bool:
         return self.data.event_type in (
             PullRequestCommentGithubEvent.__name__,
             MergeRequestCommentGitlabEvent.__name__,
             PullRequestCommentPagureEvent.__name__,
         )
 
-    def copr_build_comment_event(self) -> bool:
-        return self.comment_event() and get_packit_commands_from_comment(
+    def is_copr_build_comment_event(self) -> bool:
+        return self.is_comment_event() and get_packit_commands_from_comment(
             self.data.event_dict.get("comment")
         )[0] in ("build", "copr-build")
 

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -19,14 +19,10 @@ from packit_service.worker.events.event import AbstractCommentEvent
 from packit_service.worker.events import (
     Event,
     EventData,
-    MergeRequestCommentGitlabEvent,
-    PullRequestCommentGithubEvent,
     PullRequestCommentPagureEvent,
     MergeRequestGitlabEvent,
     InstallationEvent,
     CheckRerunEvent,
-    PullRequestGithubEvent,
-    PullRequestPagureEvent,
 )
 from packit_service.worker.allowlist import Allowlist
 from packit_service.worker.build import CoprBuildJobHelper, KojiBuildJobHelper
@@ -303,18 +299,8 @@ class SteveJobs:
                 if not handler.pre_check():
                     continue
 
-                if isinstance(
-                    event,
-                    (
-                        PullRequestGithubEvent,
-                        PullRequestCommentGithubEvent,
-                        MergeRequestGitlabEvent,
-                        MergeRequestCommentGitlabEvent,
-                        PullRequestCommentPagureEvent,
-                        PullRequestPagureEvent,
-                    ),
-                ) and not handler.check_if_actor_can_run_job_and_report(
-                    actor=event.user_login
+                if event.actor and not handler.check_if_actor_can_run_job_and_report(
+                    actor=event.actor
                 ):
                     # For external contributors, we need to be more careful when running jobs.
                     # This is a handler-specific permission check

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -19,10 +19,14 @@ from packit_service.worker.events.event import AbstractCommentEvent
 from packit_service.worker.events import (
     Event,
     EventData,
+    MergeRequestCommentGitlabEvent,
+    PullRequestCommentGithubEvent,
     PullRequestCommentPagureEvent,
     MergeRequestGitlabEvent,
     InstallationEvent,
     CheckRerunEvent,
+    PullRequestGithubEvent,
+    PullRequestPagureEvent,
 )
 from packit_service.worker.allowlist import Allowlist
 from packit_service.worker.build import CoprBuildJobHelper, KojiBuildJobHelper
@@ -297,6 +301,25 @@ class SteveJobs:
                     event=event.get_dict(),
                 )
                 if not handler.pre_check():
+                    continue
+
+                if isinstance(
+                    event,
+                    (
+                        PullRequestGithubEvent,
+                        PullRequestCommentGithubEvent,
+                        MergeRequestGitlabEvent,
+                        MergeRequestCommentGitlabEvent,
+                        PullRequestCommentPagureEvent,
+                        PullRequestPagureEvent,
+                    ),
+                ) and not handler.check_if_actor_can_run_job_and_report(
+                    actor=event.user_login
+                ):
+                    # For external contributors, we need to be more careful when running jobs.
+                    # This is a handler-specific permission check
+                    # for a user who trigger the action on a PR.
+                    # e.g. We don't allow using internal TF for external contributors.
                     continue
 
                 if isinstance(

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -267,7 +267,7 @@ class Parser:
             target_repo_name=target_repo_name,
             project_url=https_url,
             commit_sha=commit_sha,
-            user_login=user_login,
+            actor=user_login,
         )
 
     @staticmethod
@@ -627,7 +627,7 @@ class Parser:
             target_repo_namespace=target_repo_namespace,
             target_repo_name=target_repo_name,
             project_url=https_url,
-            user_login=user_login,
+            actor=user_login,
             comment=comment,
             comment_id=comment_id,
         )
@@ -687,6 +687,7 @@ class Parser:
 
         repo_namespace = nested_get(event, "repository", "owner", "login")
         repo_name = nested_get(event, "repository", "name")
+        actor = nested_get(event, "sender", "login")
 
         if not (repo_namespace and repo_name):
             logger.warning("No full name of the repository.")
@@ -720,6 +721,7 @@ class Parser:
                 check_name_job=check_name_job,
                 check_name_target=check_name_target,
                 db_trigger=db_trigger,
+                actor=actor,
             )
 
         elif isinstance(db_trigger, ProjectReleaseModel):
@@ -732,6 +734,7 @@ class Parser:
                 check_name_job=check_name_job,
                 check_name_target=check_name_target,
                 db_trigger=db_trigger,
+                actor=actor,
             )
 
         elif isinstance(db_trigger, GitBranchModel):
@@ -744,6 +747,7 @@ class Parser:
                 check_name_job=check_name_job,
                 check_name_target=check_name_target,
                 db_trigger=db_trigger,
+                actor=actor,
             )
 
         return event

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -1005,6 +1005,67 @@ def test_pr_test_command_handler_missing_build(pr_embedded_command_comment_event
     )
 
 
+def test_pr_test_command_handler_not_allowed_external_contributor_on_internal_TF(
+    pr_embedded_command_comment_event,
+):
+    jobs = [
+        {
+            "trigger": "pull_request",
+            "job": "tests",
+            "metadata": {"targets": "fedora-rawhide-x86_64", "use_internal_tf": True},
+        }
+    ]
+    packit_yaml = (
+        "{'specfile_path': 'the-specfile.spec', 'synced_files': [], 'jobs': "
+        + str(jobs)
+        + "}"
+    )
+    pr = flexmock(head_commit="12345")
+    flexmock(GithubProject).should_receive("get_pr").and_return(pr)
+    comment = flexmock()
+    flexmock(pr).should_receive("get_comment").and_return(comment)
+    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    gh_project = flexmock(
+        GithubProject,
+        full_repo_name="packit-service/hello-world",
+        get_file_content=lambda path, ref: packit_yaml,
+        get_files=lambda ref, filter_regex: ["the-specfile.spec"],
+        get_web_url=lambda: "https://github.com/the-namespace/the-repo",
+    )
+    gh_project.should_receive("can_merge_pr").with_args("phracek").and_return(False)
+    flexmock(Github, get_repo=lambda full_name_or_id: None)
+
+    config = ServiceConfig()
+    config.command_handler_work_dir = SANDCASTLE_WORK_DIR
+    flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
+    trigger = flexmock(
+        job_config_trigger_type=JobConfigTriggerType.pull_request, id=123
+    )
+    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
+    flexmock(LocalProject, refresh_the_arguments=lambda: None)
+    flexmock(Allowlist, check_and_report=True)
+    flexmock(PullRequestModel).should_receive("get_or_create").with_args(
+        pr_id=9,
+        namespace="packit-service",
+        repo_name="hello-world",
+        project_url="https://github.com/packit-service/hello-world",
+    ).and_return(
+        flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
+    ).once()
+    pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
+    flexmock(GithubProject, get_files="foo.spec")
+    flexmock(GithubProject).should_receive("is_private").and_return(False).once()
+    flexmock(Signature).should_receive("apply_async").times(0)
+    flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").times(0)
+    flexmock(CoprBuildJobHelper).should_receive("report_status_to_tests").with_args(
+        description="phracek can't run tests internally",
+        state=BaseCommitStatus.neutral,
+    ).once()
+
+    processing_results = SteveJobs().process_message(pr_embedded_command_comment_event)
+    assert not processing_results
+
+
 @pytest.mark.parametrize(
     "comments",
     [

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -245,7 +245,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
                 target_repo_namespace="foo",
                 target_repo_name="bar",
                 project_url="https://github.com/foo/bar",
-                user_login="bar",
+                actor="bar",
                 comment="",
                 comment_id=0,
             ),
@@ -260,7 +260,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
                 repo_name="bar",
                 target_repo="",
                 project_url="https://github.com/foo/bar",
-                user_login="baz",
+                actor="baz",
                 comment="",
                 comment_id=0,
             ),
@@ -277,7 +277,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
                 target_repo_namespace="fero",
                 target_repo_name="dwm.git",
                 project_url="https://github.com/fero/dwm",
-                user_login="lojzo",
+                actor="lojzo",
                 comment="",
                 comment_id=0,
             ),
@@ -292,7 +292,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
                 repo_name="glibc",
                 target_repo="",
                 project_url="https://gitlab.com/packit-service/src/glibc",
-                user_login="lojzo",
+                actor="lojzo",
                 comment="",
                 comment_id=0,
             ),
@@ -312,7 +312,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
                 target_repo_namespace="banned_namespace_again",
                 target_repo_name="some_repo",
                 project_url="https://github.com/banned_namespace_again/some_repo",
-                user_login="admin",
+                actor="admin",
                 comment="",
                 comment_id=0,
             ),
@@ -325,7 +325,7 @@ def test_signed_fpca(allowlist, account_name, person_object, raises, signed_fpca
 def test_check_and_report_calls_method(allowlist, event, mocked_model, approved):
     gp = GitProject("", GitService(), "")
 
-    flexmock(gp).should_receive("can_merge_pr").with_args(event.user_login).and_return(
+    flexmock(gp).should_receive("can_merge_pr").with_args(event.actor).and_return(
         approved
     )
     mocked_pr_or_issue = flexmock(author=None)
@@ -376,7 +376,7 @@ def events(request) -> Iterable[Tuple[AbstractGithubEvent, bool, Iterable[str]]]
                 "target_repo_name": repository,
                 "project_url": f"https://{forge}/{namespace}/{repository}",
                 "commit_sha": "",
-                "user_login": "login",
+                "actor": "login",
                 "base_ref": "",
             },
         ),
@@ -391,7 +391,7 @@ def events(request) -> Iterable[Tuple[AbstractGithubEvent, bool, Iterable[str]]]
                 "target_repo_namespace": namespace,
                 "target_repo_name": repository,
                 "project_url": f"https://{forge}/{namespace}/{repository}",
-                "user_login": "login",
+                "actor": "login",
                 "comment": "",
                 "comment_id": 1,
             },
@@ -405,7 +405,7 @@ def events(request) -> Iterable[Tuple[AbstractGithubEvent, bool, Iterable[str]]]
                 "repo_name": repository,
                 "target_repo": "",
                 "project_url": f"https://{forge}/{namespace}/{repository}",
-                "user_login": "login",
+                "actor": "login",
                 "comment": "",
                 "comment_id": 1,
             },
@@ -421,7 +421,7 @@ def events(request) -> Iterable[Tuple[AbstractGithubEvent, bool, Iterable[str]]]
                 "target_repo_namespace": namespace,
                 "target_repo_name": repository,
                 "project_url": f"https://{forge}/{namespace}/{repository}",
-                "user_login": "admin",
+                "actor": "admin",
                 "comment": "",
                 "comment_id": 1,
             },

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -343,7 +343,7 @@ class TestEvents:
         assert (
             event_object.project_url == "https://github.com/packit-service/hello-world"
         )
-        assert event_object.user_login == "phracek"
+        assert event_object.actor == "phracek"
         assert event_object.comment == "/packit copr-build"
 
         assert isinstance(event_object.project, GithubProject)
@@ -420,7 +420,7 @@ class TestEvents:
         assert (
             event_object.project_url == "https://github.com/packit-service/hello-world"
         )
-        assert event_object.user_login == "phracek"
+        assert event_object.actor == "phracek"
         assert event_object.comment == ""
 
         assert isinstance(event_object.project, GithubProject)
@@ -462,7 +462,7 @@ class TestEvents:
         )
         assert event_object.base_ref == "master"
         assert event_object.project_url == "https://github.com/packit-service/packit"
-        assert event_object.user_login == "phracek"
+        assert event_object.actor == "phracek"
         assert event_object.comment == "/packit propose-downstream"
 
         assert isinstance(event_object.project, GithubProject)
@@ -1014,6 +1014,7 @@ class TestEvents:
         ).once()
         assert event_object.package_config
         assert event_object.targets_override == {"fedora-rawhide-x86_64"}
+        assert event_object.actor == "lbarcziova"
 
     def test_parse_check_rerun_pull_request(self, check_rerun):
         trigger = flexmock(JobTriggerModel, trigger_id=1234)
@@ -1038,6 +1039,7 @@ class TestEvents:
         )
         assert event_object.check_name_job == "testing-farm"
         assert event_object.check_name_target == "fedora-rawhide-x86_64"
+        assert event_object.actor == "lbarcziova"
 
         flexmock(PackageConfigGetter).should_receive(
             "get_package_config_from_repo"
@@ -1075,6 +1077,7 @@ class TestEvents:
         assert event_object.check_name_job == "testing-farm"
         assert event_object.check_name_target == "fedora-rawhide-x86_64"
         assert event_object.targets_override == {"fedora-rawhide-x86_64"}
+        assert event_object.actor == "lbarcziova"
 
 
 class TestCentOSEventParser:
@@ -1361,7 +1364,7 @@ def test_event_data_parse_pr(github_pr_event):
     PullRequestGithubEvent.db_trigger = None
     data = EventData.from_event_dict(github_pr_event.get_dict())
     assert data.event_type == "PullRequestGithubEvent"
-    assert data.user_login == "lbarcziova"
+    assert data.actor == "lbarcziova"
     assert not data.git_ref
     assert data.commit_sha == "528b803be6f93e19ca4130bf4976f2800a3004c4"
     assert data.identifier == "342"


### PR DESCRIPTION
* Add user-specific pre-check for handlers to check permissions.
  * This allows us to restrict access for external contributors when using internal services.
* Restrict external contributor running a Test job when `user_internal_tf` is configured.
* All events that provide `actor` attribute are checked now.
---

External contributors can't trigger internal tests initially. Project maintainers need to trigger the action via `/packit test` comment to run the job.