### PR TITLE
Improve EventData.db_trigger

### DIFF
--- a/packit_service/service/db_triggers.py
+++ b/packit_service/service/db_triggers.py
@@ -16,72 +16,130 @@ from packit_service.models import (
 )
 
 
-class AddReleaseDbTrigger:
+class _AddDbTrigger:
+    # This is a private common supertype for Add*DbTrigger classes. Use it only as a superclass in
+    # this file as a superclass of Add*DbTrigger classes.
+    pass
+
+
+class AddReleaseDbTrigger(_AddDbTrigger):
     tag_name: str
     repo_namespace: str
     repo_name: str
     project_url: str
+    commit_sha: Optional[str]
 
-    @property
-    def commit_sha(self):
-        """
-        To please the mypy.
-        """
-        raise NotImplementedError()
+    @staticmethod
+    def get_or_create(
+        tag_name: str,
+        repo_namespace: str,
+        repo_name: str,
+        project_url: str,
+        commit_sha: Optional[str],
+    ) -> Optional[AbstractTriggerDbType]:
+        return ProjectReleaseModel.get_or_create(
+            tag_name=tag_name,
+            namespace=repo_namespace,
+            repo_name=repo_name,
+            project_url=project_url,
+            commit_hash=commit_sha,
+        )
 
     @property
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
-        return ProjectReleaseModel.get_or_create(
+        return self.get_or_create(
             tag_name=self.tag_name,
-            namespace=self.repo_namespace,
+            repo_namespace=self.repo_namespace,
             repo_name=self.repo_name,
             project_url=self.project_url,
-            commit_hash=self.commit_sha,
+            commit_sha=self.commit_sha,
         )
 
 
-class AddPullRequestDbTrigger:
+class AddPullRequestDbTrigger(_AddDbTrigger):
     pr_id: int
     project: GitProject
     project_url: str
 
+    @staticmethod
+    def get_or_create(
+        pr_id: int,
+        repo_namespace: str,
+        repo_name: str,
+        project_url: str,
+    ) -> Optional[AbstractTriggerDbType]:
+        return PullRequestModel.get_or_create(
+            pr_id=pr_id,
+            namespace=repo_namespace,
+            repo_name=repo_name,
+            project_url=project_url,
+        )
+
     @property
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
-        return PullRequestModel.get_or_create(
+        return self.get_or_create(
             pr_id=self.pr_id,
-            namespace=self.project.namespace,
+            repo_namespace=self.project.namespace,
             repo_name=self.project.repo,
             project_url=self.project_url,
         )
 
 
-class AddIssueDbTrigger:
+class AddIssueDbTrigger(_AddDbTrigger):
     issue_id: int
     repo_namespace: str
     repo_name: str
     project_url: str
 
+    @staticmethod
+    def get_or_create(
+        issue_id: int,
+        repo_namespace: str,
+        repo_name: str,
+        project_url: str,
+    ) -> Optional[AbstractTriggerDbType]:
+        return IssueModel.get_or_create(
+            issue_id=issue_id,
+            namespace=repo_namespace,
+            repo_name=repo_name,
+            project_url=project_url,
+        )
+
     @property
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
-        return IssueModel.get_or_create(
+        return self.get_or_create(
             issue_id=self.issue_id,
-            namespace=self.repo_namespace,
+            repo_namespace=self.repo_namespace,
             repo_name=self.repo_name,
             project_url=self.project_url,
         )
 
 
-class AddBranchPushDbTrigger:
+class AddBranchPushDbTrigger(_AddDbTrigger):
     git_ref: str
     repo_namespace: str
     repo_name: str
     project_url: str
 
+    @staticmethod
+    def get_or_create(
+        git_ref: str,
+        repo_namespace: str,
+        repo_name: str,
+        project_url: str,
+    ) -> Optional[AbstractTriggerDbType]:
+        return GitBranchModel.get_or_create(
+            branch_name=git_ref,
+            namespace=repo_namespace,
+            repo_name=repo_name,
+            project_url=project_url,
+        )
+
     @property
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
-        return GitBranchModel.get_or_create(
-            branch_name=self.git_ref,
-            namespace=self.repo_namespace,
+        return self.get_or_create(
+            git_ref=self.git_ref,
+            repo_namespace=self.repo_namespace,
             repo_name=self.repo_name,
             project_url=self.project_url,
         )

--- a/packit_service/worker/events/__init__.py
+++ b/packit_service/worker/events/__init__.py
@@ -42,6 +42,7 @@ from packit_service.worker.events.pagure import (
     PullRequestCommentPagureEvent,
     PushPagureEvent,
     AbstractPagureEvent,
+    PullRequestFlagPagureEvent,
 )
 from packit_service.worker.events.testing_farm import TestingFarmResultsEvent
 
@@ -77,4 +78,5 @@ __all__ = [
     AbstractPRCommentEvent.__name__,
     AbstractIssueCommentEvent.__name__,
     AbstractForgeIndependentEvent.__name__,
+    PullRequestFlagPagureEvent.__name__,
 ]

--- a/packit_service/worker/events/github.py
+++ b/packit_service/worker/events/github.py
@@ -1,16 +1,10 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
-
 from typing import Dict, Optional, Union, List, Set
 
 from ogr.abstract import GitProject, Comment
 
-from packit_service.models import (
-    AllowlistStatus,
-    GitBranchModel,
-    ProjectReleaseModel,
-    PullRequestModel,
-)
+from packit_service.models import AllowlistStatus
 from packit_service.service.db_triggers import (
     AddPullRequestDbTrigger,
     AddBranchPushDbTrigger,
@@ -210,7 +204,6 @@ class CheckRerunEvent(AbstractGithubEvent):
         project_url: str,
         repo_namespace: str,
         repo_name: str,
-        db_trigger: Union[PullRequestModel, GitBranchModel, ProjectReleaseModel],
         commit_sha: str,
         actor: str,
         pr_id: Optional[int] = None,
@@ -223,7 +216,6 @@ class CheckRerunEvent(AbstractGithubEvent):
         self.repo_name = repo_name
         self.commit_sha = commit_sha
         self.actor = actor
-        self._db_trigger = db_trigger
         self.job_identifier = job_identifier
 
     @property
@@ -248,9 +240,7 @@ class CheckRerunEvent(AbstractGithubEvent):
         return None
 
 
-class CheckRerunCommitEvent(CheckRerunEvent):
-    _db_trigger: GitBranchModel
-
+class CheckRerunCommitEvent(AddBranchPushDbTrigger, CheckRerunEvent):
     def __init__(
         self,
         project_url: str,
@@ -260,7 +250,6 @@ class CheckRerunCommitEvent(CheckRerunEvent):
         git_ref: str,
         check_name_job: str,
         check_name_target: str,
-        db_trigger,
         actor: str,
         job_identifier: Optional[str] = None,
     ):
@@ -270,7 +259,6 @@ class CheckRerunCommitEvent(CheckRerunEvent):
             project_url=project_url,
             repo_namespace=repo_namespace,
             repo_name=repo_name,
-            db_trigger=db_trigger,
             commit_sha=commit_sha,
             actor=actor,
             job_identifier=job_identifier,
@@ -279,9 +267,7 @@ class CheckRerunCommitEvent(CheckRerunEvent):
         self.git_ref = git_ref
 
 
-class CheckRerunPullRequestEvent(CheckRerunEvent):
-    _db_trigger: PullRequestModel
-
+class CheckRerunPullRequestEvent(AddPullRequestDbTrigger, CheckRerunEvent):
     def __init__(
         self,
         pr_id: int,
@@ -291,7 +277,6 @@ class CheckRerunPullRequestEvent(CheckRerunEvent):
         commit_sha: str,
         check_name_job: str,
         check_name_target: str,
-        db_trigger,
         actor: str,
         job_identifier: Optional[str] = None,
     ):
@@ -301,7 +286,6 @@ class CheckRerunPullRequestEvent(CheckRerunEvent):
             project_url=project_url,
             repo_namespace=repo_namespace,
             repo_name=repo_name,
-            db_trigger=db_trigger,
             commit_sha=commit_sha,
             pr_id=pr_id,
             actor=actor,
@@ -311,9 +295,7 @@ class CheckRerunPullRequestEvent(CheckRerunEvent):
         self.git_ref = None
 
 
-class CheckRerunReleaseEvent(CheckRerunEvent):
-    _db_trigger: ProjectReleaseModel
-
+class CheckRerunReleaseEvent(AddReleaseDbTrigger, CheckRerunEvent):
     def __init__(
         self,
         repo_namespace: str,
@@ -323,7 +305,6 @@ class CheckRerunReleaseEvent(CheckRerunEvent):
         commit_sha: str,
         check_name_job: str,
         check_name_target: str,
-        db_trigger,
         actor: str,
         job_identifier: Optional[str] = None,
     ):
@@ -333,7 +314,6 @@ class CheckRerunReleaseEvent(CheckRerunEvent):
             project_url=project_url,
             repo_namespace=repo_namespace,
             repo_name=repo_name,
-            db_trigger=db_trigger,
             commit_sha=commit_sha,
             actor=actor,
             job_identifier=job_identifier,

--- a/packit_service/worker/events/pagure.py
+++ b/packit_service/worker/events/pagure.py
@@ -143,7 +143,7 @@ class PullRequestPagureEvent(AddPullRequestDbTrigger, AbstractPagureEvent):
         return fork
 
 
-class PullRequestFlagPagureEvent(AbstractPagureEvent):
+class PullRequestFlagPagureEvent(AddPullRequestDbTrigger, AbstractPagureEvent):
     def __init__(
         self,
         username: str,

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -746,7 +746,6 @@ class Parser:
                 pr_id=db_trigger.pr_id,
                 check_name_job=check_name_job,
                 check_name_target=check_name_target,
-                db_trigger=db_trigger,
                 actor=actor,
                 job_identifier=check_name_identifier,
             )
@@ -760,7 +759,6 @@ class Parser:
                 tag_name=db_trigger.tag_name,
                 check_name_job=check_name_job,
                 check_name_target=check_name_target,
-                db_trigger=db_trigger,
                 actor=actor,
                 job_identifier=check_name_identifier,
             )
@@ -774,7 +772,6 @@ class Parser:
                 git_ref=db_trigger.name,
                 check_name_job=check_name_job,
                 check_name_target=check_name_target,
-                db_trigger=db_trigger,
                 actor=actor,
                 job_identifier=check_name_identifier,
             )

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -17,6 +17,7 @@ from packit_service.models import (
     JobTriggerModel,
     ProjectReleaseModel,
     PullRequestModel,
+    JobTriggerModelType,
 )
 from packit_service.service.db_triggers import (
     AddBranchPushDbTrigger,
@@ -95,7 +96,11 @@ def mock_pr_functionality(request):
     )
     flexmock(Github, get_repo=lambda full_name_or_id: None)
 
-    trigger = JobTriggerModel(type=JobConfigTriggerType.pull_request, id=123)
+    trigger = flexmock(
+        job_config_trigger_type=JobConfigTriggerType.pull_request,
+        job_trigger_model_type=JobTriggerModelType.pull_request,
+        id=123,
+    )
     flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
     flexmock(PullRequestModel).should_receive("get_by_id").with_args(123).and_return(
         trigger
@@ -137,7 +142,11 @@ def mock_push_functionality(request):
     )
     flexmock(Github, get_repo=lambda full_name_or_id: None)
 
-    trigger = JobTriggerModel(type=JobConfigTriggerType.commit, id=123)
+    trigger = flexmock(
+        job_config_trigger_type=JobConfigTriggerType.commit,
+        job_trigger_model_type=JobTriggerModelType.branch_push,
+        id=123,
+    )
     flexmock(AddBranchPushDbTrigger).should_receive("db_trigger").and_return(trigger)
     flexmock(GitBranchModel).should_receive("get_by_id").with_args(123).and_return(
         trigger
@@ -177,7 +186,11 @@ def mock_release_functionality(request):
     )
     flexmock(Github, get_repo=lambda full_name_or_id: None)
 
-    trigger = JobTriggerModel(type=JobConfigTriggerType.release, id=123)
+    trigger = flexmock(
+        job_config_trigger_type=JobConfigTriggerType.release,
+        job_trigger_model_type=JobTriggerModelType.release,
+        id=123,
+    )
     flexmock(AddReleaseDbTrigger).should_receive("db_trigger").and_return(trigger)
     flexmock(ProjectReleaseModel).should_receive("get_by_id").with_args(123).and_return(
         trigger

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -719,7 +719,7 @@ def test_trigger_build(copr_build, run_new_build):
     package_config.spec_source_id = 1
 
     event = {
-        "event_type": "CoprBuileEndEvent",
+        "event_type": "CoprBuildEndEvent",
         "commit_sha": valid_commit_sha,
         "targets_override": ["target-x86_64"],
     }


### PR DESCRIPTION
TODO:

- [x] tests

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Original thought how to improve this (TODO in previous solution) was about recreating original Event classes so then we can call `db_trigger` on them. I tried that but parameters of these classes are sometimes so different that the result was even more complex. But we can still recreate only their db trigger classes with necessary attributes and call `db_trigger` property on them.

pros:
- previous solution was hardcoded, this is not 
(but still, I can't figure out how to get rid of `needed_attributes_for_abstract_db_trigger` in `_recreate_original_db_trigger` - would be nice to get rid of this too 
    - what about assigning `EventData.__dict__` to `db_trigger_cls.__dict__` [here](https://github.com/packit/packit-service/pull/1304/files#diff-e8a39471e11af02ed27cca0023ecf56a5b2f5266579281b4bce81a370c1631ecR157)?)
- if we want to add new event, we can do this without touching EventData.db_trigger
- it is easier to read EventData.db_trigger property

cons:
- the solution is not as straightforward as previous solution (and maybe harder to debug so I added a few logs) 

My question is - do we want to do it this way? This is still in progress (without tests and maybe not correct) but I don't want to spend time on finishing it if we don't want it :grinning: 

---

<!-- release notes for changelog/blog follow -->
N/A