### PR TITLE
Markdown content in reports

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -464,6 +464,7 @@ class BaseBuildJobHelper:
         description: str,
         url: str = "",
         check_names: Union[str, list, None] = None,
+        markdown_content: str = None,
     ) -> None:
         """
         The status reporting should be done through this method
@@ -492,34 +493,60 @@ class BaseBuildJobHelper:
             state=state,
             url=url,
             check_names=check_names,
+            markdown_content=markdown_content,
         )
 
     def report_status_to_all(
-        self, description: str, state: BaseCommitStatus, url: str = ""
+        self,
+        description: str,
+        state: BaseCommitStatus,
+        url: str = "",
+        markdown_content: str = None,
     ) -> None:
-        self.report_status_to_build(description, state, url)
-        self.report_status_to_tests(description, state, url)
+        self.report_status_to_build(
+            description=description,
+            state=state,
+            url=url,
+            markdown_content=markdown_content,
+        )
+        self.report_status_to_tests(
+            description=description,
+            state=state,
+            url=url,
+            markdown_content=markdown_content,
+        )
 
-    def report_status_to_build(self, description, state, url: str = "") -> None:
+    def report_status_to_build(
+        self, description, state, url: str = "", markdown_content: str = None
+    ) -> None:
         if self.job_build:
             self._report(
                 description=description,
                 state=state,
                 url=url,
                 check_names=self.build_check_names,
+                markdown_content=markdown_content,
             )
 
-    def report_status_to_tests(self, description, state, url: str = "") -> None:
+    def report_status_to_tests(
+        self, description, state, url: str = "", markdown_content: str = None
+    ) -> None:
         if self.job_tests:
             self._report(
                 description=description,
                 state=state,
                 url=url,
                 check_names=self.test_check_names,
+                markdown_content=markdown_content,
             )
 
     def report_status_to_build_for_chroot(
-        self, description, state, url: str = "", chroot: str = ""
+        self,
+        description,
+        state,
+        url: str = "",
+        chroot: str = "",
+        markdown_content: str = None,
     ) -> None:
         if self.job_build and chroot in self.build_targets:
             cs = self.get_build_check(chroot)
@@ -528,10 +555,16 @@ class BaseBuildJobHelper:
                 state=state,
                 url=url,
                 check_names=cs,
+                markdown_content=markdown_content,
             )
 
     def report_status_to_test_for_chroot(
-        self, description, state, url: str = "", chroot: str = ""
+        self,
+        description,
+        state,
+        url: str = "",
+        chroot: str = "",
+        markdown_content: str = None,
     ) -> None:
         if self.job_tests and chroot in self.tests_targets:
             self._report(
@@ -539,13 +572,31 @@ class BaseBuildJobHelper:
                 state=state,
                 url=url,
                 check_names=self.get_test_check(chroot),
+                markdown_content=markdown_content,
             )
 
     def report_status_to_all_for_chroot(
-        self, description, state, url: str = "", chroot: str = ""
+        self,
+        description,
+        state,
+        url: str = "",
+        chroot: str = "",
+        markdown_content: str = None,
     ):
-        self.report_status_to_build_for_chroot(description, state, url, chroot)
-        self.report_status_to_test_for_chroot(description, state, url, chroot)
+        self.report_status_to_build_for_chroot(
+            description=description,
+            state=state,
+            url=url,
+            chroot=chroot,
+            markdown_content=markdown_content,
+        )
+        self.report_status_to_test_for_chroot(
+            description=description,
+            state=state,
+            url=url,
+            chroot=chroot,
+            markdown_content=markdown_content,
+        )
 
     def run_build(
         self, target: Optional[str] = None

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -104,6 +104,8 @@ class TestingFarmHandler(JobHandler):
             self.testing_farm_job_helper.report_status_to_tests(
                 description=f"{actor} can't run tests internally",
                 state=BaseCommitStatus.neutral,
+                markdown_content="*As a project maintainer, you can trigger the test job manually "
+                "via `/packit test` comment.*",
             )
             return False
         return True

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -239,6 +239,7 @@ def test_check_rerun_pr_copr_build_handler(
         check_name="rpm-build:fedora-rawhide-x86_64",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").twice().and_return()
@@ -297,6 +298,7 @@ def test_check_rerun_pr_testing_farm_handler(
         check_name="testing-farm:fedora-rawhide-x86_64",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").twice().and_return()
@@ -350,6 +352,7 @@ def test_check_rerun_pr_koji_build_handler(
         check_name="production-build:f34",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").twice().and_return()
@@ -404,6 +407,7 @@ def test_check_rerun_push_copr_build_handler(
         check_name="rpm-build:fedora-rawhide-x86_64",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").twice().and_return()
@@ -462,6 +466,7 @@ def test_check_rerun_push_testing_farm_handler(
         check_name="testing-farm:fedora-rawhide-x86_64",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").twice().and_return()
@@ -515,6 +520,7 @@ def test_check_rerun_push_koji_build_handler(
         check_name="production-build:f34",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").twice().and_return()
@@ -569,6 +575,7 @@ def test_check_rerun_release_copr_build_handler(
         check_name="rpm-build:fedora-rawhide-x86_64",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").twice().and_return()
@@ -623,6 +630,7 @@ def test_check_rerun_release_koji_build_handler(
         check_name="production-build:f34",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").twice().and_return()

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -168,6 +168,7 @@ def test_precheck_koji_build_non_scratch(github_pr_event):
         check_name="production-build:bright-future",
         url=KOJI_PRODUCTION_BUILDS_ISSUE,
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return().once()
     flexmock(GithubProject).should_receive("can_merge_pr").and_return(True)
     koji_build_handler = KojiBuildHandler(

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -215,6 +215,7 @@ def test_copr_build_end(
         description="RPMs were built successfully.",
         url=url,
         check_names=CoprBuildJobHelper.get_build_check(copr_build_end["chroot"]),
+        markdown_content=None,
     ).once()
 
     # no test job defined => testing farm should be skipped
@@ -282,6 +283,7 @@ def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build_branch_pu
         description="RPMs were built successfully.",
         url=url,
         check_names=CoprBuildJobHelper.get_build_check(copr_build_end["chroot"]),
+        markdown_content=None,
     ).once()
 
     # skip testing farm
@@ -338,6 +340,7 @@ def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build_rel
         description="RPMs were built successfully.",
         url=url,
         check_names=CoprBuildJobHelper.get_build_check(copr_build_end["chroot"]),
+        markdown_content=None,
     ).once()
 
     # skip testing farm
@@ -426,6 +429,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         description="RPMs were built successfully.",
         url=url,
         check_names=EXPECTED_BUILD_CHECK_NAME,
+        markdown_content=None,
     ).once()
 
     flexmock(StatusReporter).should_receive("report").with_args(
@@ -433,6 +437,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         description="RPMs were built successfully.",
         url=url,
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
+        markdown_content=None,
     ).once()
 
     payload = {
@@ -499,6 +504,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         description="Build succeeded. Submitting the tests ...",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
         url="",
+        markdown_content=None,
     ).once()
 
     flexmock(GithubProject).should_receive("get_web_url").and_return(
@@ -521,6 +527,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         description="Tests have been submitted ...",
         url="https://dashboard.localhost/results/testing-farm/5",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").twice()
 
@@ -612,6 +619,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         description="RPMs were built successfully.",
         url=url,
         check_names=EXPECTED_BUILD_CHECK_NAME,
+        markdown_content=None,
     ).once()
 
     flexmock(StatusReporter).should_receive("report").with_args(
@@ -619,6 +627,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         description="RPMs were built successfully.",
         url=url,
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
+        markdown_content=None,
     ).once()
 
     flexmock(TestingFarmJobHelper).should_receive("is_fmf_configured").and_return(True)
@@ -638,12 +647,14 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         description="Build succeeded. Submitting the tests ...",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
         url="",
+        markdown_content=None,
     ).once()
     flexmock(StatusReporter).should_receive("report").with_args(
         state=BaseCommitStatus.failure,
         description="some error",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
         url="",
+        markdown_content=None,
     ).once()
 
     flexmock(Signature).should_receive("apply_async").twice()
@@ -731,6 +742,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         description="RPMs were built successfully.",
         url=url,
         check_names=EXPECTED_BUILD_CHECK_NAME,
+        markdown_content=None,
     ).once()
 
     flexmock(StatusReporter).should_receive("report").with_args(
@@ -738,6 +750,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         description="RPMs were built successfully.",
         url=url,
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
+        markdown_content=None,
     ).once()
 
     flexmock(TestingFarmJobHelper).should_receive("is_fmf_configured").and_return(True)
@@ -759,12 +772,14 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         description="Build succeeded. Submitting the tests ...",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
         url="",
+        markdown_content=None,
     ).once()
     flexmock(StatusReporter).should_receive("report").with_args(
         state=BaseCommitStatus.failure,
         description="Failed to submit tests: some text error",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
         url="",
+        markdown_content=None,
     ).once()
 
     flexmock(Signature).should_receive("apply_async").twice()
@@ -827,6 +842,7 @@ def test_copr_build_start(copr_build_start, pc_build_pr, copr_build_pr):
         description="RPM build is in progress...",
         url=url,
         check_names=EXPECTED_BUILD_CHECK_NAME,
+        markdown_content=None,
     ).once()
 
     flexmock(Signature).should_receive("apply_async").once()
@@ -874,6 +890,7 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build_pr
         description="RPM build is in progress...",
         url=url,
         check_names=EXPECTED_BUILD_CHECK_NAME,
+        markdown_content=None,
     ).never()
 
     flexmock(StatusReporter).should_receive("report").with_args(
@@ -881,6 +898,7 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build_pr
         description="RPM build is in progress...",
         url=url,
         check_names=TestingFarmJobHelper.get_test_check(copr_build_start["chroot"]),
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").once().and_return()
@@ -927,6 +945,7 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_bui
         description="RPMs were built successfully.",
         url=url,
         check_names=CoprBuildJobHelper.get_build_check(copr_build_end["chroot"]),
+        markdown_content=None,
     ).once()
 
     # skip testing farm
@@ -975,6 +994,7 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
         description="RPM build is in progress...",
         url=url,
         check_names="production-build:rawhide",
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").once().and_return()
@@ -1034,6 +1054,7 @@ def test_koji_build_end(koji_build_scratch_end, pc_koji_build_pr, koji_build_pr)
         description="RPMs were built successfully.",
         url=url,
         check_names="production-build:rawhide",
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").once().and_return()

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -1062,6 +1062,8 @@ def test_pr_test_command_handler_not_allowed_external_contributor_on_internal_TF
     flexmock(CoprBuildJobHelper).should_receive("report_status_to_tests").with_args(
         description="phracek can't run tests internally",
         state=BaseCommitStatus.neutral,
+        markdown_content="*As a project maintainer, "
+        "you can trigger the test job manually via `/packit test` comment.*",
     ).once()
 
     processing_results = SteveJobs().process_message(pr_embedded_command_comment_event)

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -875,6 +875,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
         description="Submitting the tests ...",
         check_names="testing-farm:fedora-rawhide-x86_64",
         url="",
+        markdown_content=None,
     ).once()
 
     flexmock(GithubProject).should_receive("get_web_url").and_return(
@@ -899,6 +900,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
         state=BaseCommitStatus.running,
         url="https://dashboard.localhost/results/testing-farm/5",
         check_names="testing-farm:fedora-rawhide-x86_64",
+        markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
 

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -559,6 +559,7 @@ def test_check_and_report(
                 state=BaseCommitStatus.neutral,
                 url=FAQ_URL,
                 check_names=[EXPECTED_TESTING_FARM_CHECK_NAME],
+                markdown_content=None,
             ).once()
         flexmock(packit_service.worker.build.copr_build).should_receive(
             "get_valid_build_targets"

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -171,6 +171,7 @@ def test_copr_build_check_names(github_pr_event):
         check_name="rpm-build:bright-future-x86_64",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
@@ -178,6 +179,7 @@ def test_copr_build_check_names(github_pr_event):
         check_name="rpm-build:bright-future-x86_64",
         url="https://test.url",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
 
     flexmock(GithubProject).should_receive("get_pr").and_return(
@@ -275,6 +277,7 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
             check_name=f"rpm-build:{target}",
             url="",
             links_to_external_services=None,
+            markdown_content=None,
         ).and_return()
 
     for not_supported_target in ("bright-future-x86_64", "fedora-32-x86_64"):
@@ -284,6 +287,7 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
             check_name=f"rpm-build:{not_supported_target}",
             url="https://test.url",
             links_to_external_services=None,
+            markdown_content=None,
         ).and_return()
 
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
@@ -292,6 +296,7 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
         check_name="rpm-build:even-brighter-one-aarch64",
         url="https://test.url",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
 
     flexmock(GithubProject).should_receive("get_pr").and_return(
@@ -417,6 +422,7 @@ def test_copr_build_check_names_multiple_jobs(github_pr_event):
         check_name="rpm-build:fedora-32-x86_64",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return().once()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
@@ -424,6 +430,7 @@ def test_copr_build_check_names_multiple_jobs(github_pr_event):
         check_name="rpm-build:fedora-32-x86_64",
         url="https://test.url",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return().once()
 
     flexmock(GithubProject).should_receive("get_pr").and_return(
@@ -509,6 +516,7 @@ def test_copr_build_check_names_custom_owner(github_pr_event):
         check_name="rpm-build:bright-future-x86_64",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
@@ -516,6 +524,7 @@ def test_copr_build_check_names_custom_owner(github_pr_event):
         check_name="rpm-build:bright-future-x86_64",
         url="https://test.url",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
 
     flexmock(GithubProject).should_receive("get_pr").and_return(
@@ -1203,6 +1212,7 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
         check_name="rpm-build:bright-future-x86_64",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
     flexmock(StatusReporterGitlab).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
@@ -1210,6 +1220,7 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
         check_name="rpm-build:bright-future-x86_64",
         url="https://test.url",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
 
     mr = flexmock(source_project=flexmock())

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -119,6 +119,7 @@ def test_koji_build_check_names(github_pr_event):
         check_name="production-build:bright-future",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
@@ -126,6 +127,7 @@ def test_koji_build_check_names(github_pr_event):
         check_name="production-build:bright-future",
         url=koji_build_url,
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
 
     flexmock(GitProject).should_receive("get_pr").and_return(
@@ -177,6 +179,7 @@ def test_koji_build_failed_kerberos(github_pr_event):
         check_name="production-build:bright-future",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.error,
@@ -184,6 +187,7 @@ def test_koji_build_failed_kerberos(github_pr_event):
         check_name="production-build:bright-future",
         url=get_srpm_build_info_url(1),
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
 
     flexmock(GitProject).should_receive("get_pr").and_return(
@@ -236,6 +240,7 @@ def test_koji_build_target_not_supported(github_pr_event):
         check_name="production-build:nonexisting-target",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.error,
@@ -243,6 +248,7 @@ def test_koji_build_target_not_supported(github_pr_event):
         check_name="production-build:nonexisting-target",
         url=get_srpm_build_info_url(1),
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
 
     flexmock(GitProject).should_receive("get_pr").and_return(
@@ -342,6 +348,7 @@ def test_koji_build_failed(github_pr_event):
         check_name="production-build:bright-future",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
 
     srpm_build_url = get_srpm_build_info_url(2)
@@ -351,6 +358,7 @@ def test_koji_build_failed(github_pr_event):
         check_name="production-build:bright-future",
         url=srpm_build_url,
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
 
     flexmock(GitProject).should_receive("get_pr").and_return(
@@ -395,6 +403,7 @@ def test_koji_build_failed_srpm(github_pr_event):
         check_name="production-build:bright-future",
         url="",
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.failure,
@@ -402,6 +411,7 @@ def test_koji_build_failed_srpm(github_pr_event):
         check_name="production-build:bright-future",
         url=srpm_build_url,
         links_to_external_services=None,
+        markdown_content=None,
     ).and_return()
 
     flexmock(GitProject).should_receive("get_pr").and_return(


### PR DESCRIPTION
Add optional `markdown_content` argument to report classes.

* Only GitHub check runs support this.
* It's ignored in other implementations.

---

N/A
