### PR TITLE
'0' is a key, not 0-th element of a list

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -447,7 +447,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
                 msg = req.json()["errors"]
                 # specific case, unsupported arch
                 if nested_get(req.json(), "errors", "environments", "0", "arch"):
-                    msg = req.json()["errors"]["environments"][0]["arch"]
+                    msg = req.json()["errors"]["environments"]["0"]["arch"]
             else:
                 msg = f"Failed to submit tests: {req.reason}"
             logger.error(msg)


### PR DESCRIPTION
`req.json()["errors"]` contained
```
{
  environments: {
     0: {
          arch: "must be one of: 'x86_64', 's390x', 'ppc64le', 'aarch64'"
         }
   }
}
```

Fixes https://sentry.io/organizations/red-hat-0p/issues/2845847115

---

N/A
