### PR TITLE
Discard old SRPM build logs and artifact URLs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   postgres:
     container_name: postgres
-    image: quay.io/centos7/postgresql-12-centos7
+    image: quay.io/centos7/postgresql-13-centos7
     environment:
       POSTGRESQL_USER: packit
       POSTGRESQL_PASSWORD: secret-password
@@ -150,6 +150,7 @@ services:
     ports:
       - 8082:8080
     user: "123123"
+
   beat:
     container_name: beat
     build:

--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -1,5 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+from celery.schedules import crontab
 
 import packit_service.constants
 
@@ -18,5 +19,9 @@ beat_schedule = {
     "update-pending-tft-runs": {
         "task": "packit_service.worker.tasks.babysit_pending_tft_runs",
         "schedule": 600.0,
+    },
+    "database-discard-old-stuff": {
+        "task": "packit_service.worker.tasks.periodic_database_cleanup",
+        "schedule": crontab(minute=0, hour=1),  # daily at 1AM
     },
 }

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -53,6 +53,10 @@ DEFAULT_RETRY_BACKOFF = 3
 # timeout/internal error. Nothing should hopefully run for 7 days.
 DEFAULT_JOB_TIMEOUT = 7 * 24 * 3600
 
+# SRPM builds older than this number of days are considered
+# outdated and their logs can be discarded.
+SRPMBUILDS_OUTDATED_AFTER_DAYS = 90
+
 ALLOWLIST_CONSTANTS = {
     "approved_automatically": "approved_automatically",
     "waiting": "waiting",

--- a/packit_service/worker/database.py
+++ b/packit_service/worker/database.py
@@ -1,0 +1,25 @@
+from datetime import timedelta, datetime
+from logging import getLogger
+from os import getenv
+
+from packit_service.constants import SRPMBUILDS_OUTDATED_AFTER_DAYS
+from packit_service.models import SRPMBuildModel
+
+logger = getLogger(__name__)
+
+
+def discard_old_srpm_build_logs():
+    """Called periodically (see celery_config.py) to discard logs of old SRPM builds."""
+    logger.debug("About to discard old SRPM build logs & artifact urls.")
+    outdated_after_days = getenv(
+        "SRPMBUILDS_OUTDATED_AFTER_DAYS", SRPMBUILDS_OUTDATED_AFTER_DAYS
+    )
+    ago = timedelta(days=int(outdated_after_days))
+    for build in SRPMBuildModel.get_older_than(ago):
+        age = datetime.utcnow() - build.build_submitted_time
+        logger.debug(
+            f"SRPM build {build.id}, age '{age}' is older than '{ago}'. "
+            "Discarding log and artifact url."
+        )
+        build.set_logs(None)
+        build.set_url(None)

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -6,6 +6,7 @@ from os import getenv
 from typing import List, Optional
 
 from celery import Task
+
 from packit_service.celerizer import celery_app
 from packit_service.constants import (
     DEFAULT_RETRY_LIMIT,
@@ -18,7 +19,7 @@ from packit_service.worker.build.babysit import (
     check_pending_copr_builds,
     check_pending_testing_farm_runs,
 )
-from packit_service.worker.handlers.abstract import TaskName
+from packit_service.worker.database import discard_old_srpm_build_logs
 from packit_service.worker.handlers import (
     BugzillaHandler,
     CoprBuildEndHandler,
@@ -32,6 +33,7 @@ from packit_service.worker.handlers import (
     TestingFarmHandler,
     TestingFarmResultsHandler,
 )
+from packit_service.worker.handlers.abstract import TaskName
 from packit_service.worker.handlers.distgit import DownstreamKojiBuildHandler
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.result import TaskResults
@@ -253,3 +255,8 @@ def babysit_pending_copr_builds() -> None:
 @celery_app.task
 def babysit_pending_tft_runs() -> None:
     check_pending_testing_farm_runs()
+
+
+@celery_app.task
+def periodic_database_cleanup() -> None:
+    discard_old_srpm_build_logs()

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from flexmock import flexmock
+
+from packit_service.models import SRPMBuildModel
+from packit_service.worker.database import discard_old_srpm_build_logs
+
+
+def test_cleanup_old_srpm_build_logs():
+    srpm_build = flexmock(id=1, build_submitted_time=datetime.utcnow())
+    flexmock(srpm_build).should_receive("set_logs").with_args(None).once()
+    flexmock(srpm_build).should_receive("set_url").with_args(None).once()
+    flexmock(SRPMBuildModel).should_receive("get_older_than").and_return(
+        [srpm_build]
+    ).once()
+    discard_old_srpm_build_logs()


### PR DESCRIPTION
We're doing this because the SRPM build logs take the most space in the database and we don't need the old logs.

Periodically (daily at 1AM) check SRPM builds in database and discard logs and urls to artifacts (uploaded .src.rpm files) at copr
of the builds which are older than `SRPMBUILDS_OUTDATED_AFTER_DAYS`.
The `SRPMBUILDS_OUTDATED_AFTER_DAYS` can be set also as env. var.

The artifact urls could be removed even sooner because copr deletes the artifacts after 2 weeks.
We could also do it similar way copr does, i.e. leave the latest (for each PR) srpm (build log, URL) indefinitely and discard older builds. But we might soon be building srpms in copr so it's probably not worth the effort at the moment.

---

Packit service now discards old (currently, this means 3 months) SRPM builds logs.
