### PR TITLE
Pass target branch commit to testing farm env

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -105,6 +105,12 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
         return self.metadata.commit_sha
 
+    @property
+    def target_branch_sha(self) -> Optional[str]:
+        if not self.metadata.pr_id:
+            return None
+        return self.project.get_pr(int(self.metadata.pr_id)).target_branch_head_commit
+
     @staticmethod
     def _artifact(
         chroot: str, build_id: Optional[int], built_packages: Optional[List[Dict]]
@@ -176,6 +182,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             "PACKIT_BUILD_LOG_URL": build_log_url,
             "PACKIT_SRPM_URL": srpm_url,
             "PACKIT_COMMIT_SHA": self.metadata.commit_sha,
+            "PACKIT_TARGET_SHA": self.target_branch_sha,
         }
         predefined_environment = {
             k: v for k, v in predefined_environment.items() if v is not None

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -378,7 +378,8 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(
-            source_project=flexmock(get_web_url=lambda: "https://github.com/foo/bar")
+            source_project=flexmock(get_web_url=lambda: "https://github.com/foo/bar"),
+            target_branch_head_commit="deadbeef",
         )
         .should_receive("comment")
         .mock()
@@ -471,6 +472,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
                     "PACKIT_COMMIT_SHA": "0011223344",
                     "PACKIT_PACKAGE_NVR": "bar-0.1-1",
                     "PACKIT_BUILD_LOG_URL": "https://log-url",
+                    "PACKIT_TARGET_SHA": "deadbeef",
                 },
             }
         ],
@@ -570,7 +572,10 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
 def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(
-        flexmock(source_project=flexmock(get_web_url=lambda: "abc"))
+        flexmock(
+            source_project=flexmock(get_web_url=lambda: "abc"),
+            target_branch_head_commit="deadbeef",
+        )
         .should_receive("comment")
         .mock()
     )
@@ -693,7 +698,10 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
 def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(
-        flexmock(source_project=flexmock(get_web_url=lambda: "abc"))
+        flexmock(
+            source_project=flexmock(get_web_url=lambda: "abc"),
+            target_branch_head_commit="deadbeef",
+        )
         .should_receive("comment")
         .mock()
     )

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -757,6 +757,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
     pr = flexmock(
         head_commit="12345",
         source_project=flexmock(get_web_url=lambda: "https://github.com/foo/bar"),
+        target_branch_head_commit="6789a",
     )
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
@@ -842,6 +843,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
                     "PACKIT_DOWNSTREAM_URL": "https://src.fedoraproject.org/rpms/hello-world.git",
                     "PACKIT_PACKAGE_NAME": "hello-world",
                     "PACKIT_COMMIT_SHA": "12345",
+                    "PACKIT_TARGET_SHA": "6789a",
                 },
             }
         ],

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -468,7 +468,10 @@ def test_payload(
         command_handler_work_dir="/tmp",
     )
     package_config = flexmock(jobs=[])
-    pr = flexmock(source_project=flexmock(get_web_url=lambda: project_url))
+    pr = flexmock(
+        source_project=flexmock(get_web_url=lambda: project_url),
+        target_branch_head_commit="deadbeef",
+    )
     project = flexmock(
         repo=repo,
         namespace=namespace,
@@ -552,6 +555,7 @@ def test_payload(
                 "PACKIT_PACKAGE_NVR": f"{repo}-0.1-1",
                 "PACKIT_BUILD_LOG_URL": log_url,
                 "PACKIT_SRPM_URL": srpm_url,
+                "PACKIT_TARGET_SHA": "deadbeef",
             },
         }
     ]
@@ -608,7 +612,10 @@ def test_test_repo(fmf_url, fmf_ref, result_url, result_ref):
         command_handler_work_dir="/tmp",
     )
     package_config = flexmock(jobs=[])
-    pr = flexmock(source_project=flexmock(get_web_url=lambda: project_url))
+    pr = flexmock(
+        source_project=flexmock(get_web_url=lambda: project_url),
+        target_branch_head_commit="deadbeef",
+    )
     project = flexmock(
         repo=repo,
         namespace=namespace,


### PR DESCRIPTION
Related to #1224

Signed-off-by: Matej Focko <mfocko@redhat.com>

---

<!-- release notes for changelog/blog follow -->
Service now passes `PACKIT_TARGET_SHA` variable, which holds commit hash of the HEAD of the target branch where the changes are supposed to be merged, to the Testing Farm environment. This should help solving the issue of running tests from non-merged codebase on the Testing Farm side.