### PR TITLE
Test epel-9 on CentOS-Stream-9

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -277,12 +277,18 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             return distros[0], arch
 
         if self.job_config.metadata.use_internal_tf:
-            epel_mapping = {"epel-6": "rhel-6", "epel-7": "rhel-7", "epel-8": "rhel-8"}
+            epel_mapping = {
+                "epel-6": "rhel-6",
+                "epel-7": "rhel-7",
+                "epel-8": "rhel-8",
+                "epel-9": "centos-stream-9",
+            }
         else:
             epel_mapping = {
                 "epel-6": "centos-6",
                 "epel-7": "centos-7",
                 "epel-8": "centos-stream-8",
+                "epel-9": "centos-stream-9",
             }
 
         distro = epel_mapping.get(distro, distro)


### PR DESCRIPTION
there's `CentOS-Stream-9` in https://api.dev.testing-farm.io/v0.1/composes

See [Sentry issue](https://sentry.io/organizations/red-hat-0p/issues/2636836262/?project=1767823)

@thrix is `CentOS-Stream-9` compose available also in the internal Testing Farm, or what compose should we use there (for testing epel-9 packages)?

---

EPEL 9 builds are now by default tested on CentOS Stream 9 in Testing Farm
