### PR TITLE
Send periodic tasks to long-running queue

### DIFF
--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -15,13 +15,16 @@ beat_schedule = {
     "update-pending-copr-builds": {
         "task": "packit_service.worker.tasks.babysit_pending_copr_builds",
         "schedule": 3600.0,
+        "options": {"queue": "long-running"},
     },
     "update-pending-tft-runs": {
         "task": "packit_service.worker.tasks.babysit_pending_tft_runs",
         "schedule": 600.0,
+        "options": {"queue": "long-running"},
     },
     "database-discard-old-stuff": {
         "task": "packit_service.worker.tasks.periodic_database_cleanup",
         "schedule": crontab(minute=0, hour=1),  # daily at 1AM
+        "options": {"queue": "long-running"},
     },
 }


### PR DESCRIPTION
They might take some time (if there are lots of tasks to babysit or lots of data to discard) and might take a lot of resources.

I'm not sure where's the line between a short running and a long running task, but I feel these should be classified as long running.

https://stackoverflow.com/questions/16962449/how-to-send-periodic-tasks-to-specific-queue-in-celery

---

N/A
