### PR TITLE
Nightly database backups to S3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,9 @@ repos:
       - id: check-yaml
       - id: detect-private-key
         exclude: tests/conftest.py
+      - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       POSTGRESQL_DATABASE: packit
       CELERY_RETRY_LIMIT: 0
       PUSHGATEWAY_ADDRESS: ""
+      AWS_ACCESS_KEY_ID: ""
+      AWS_SECRET_ACCESS_KEY: ""
     volumes:
       - ./packit_service:/usr/local/lib/python3.9/site-packages/packit_service:ro,z
       # worker should not require packit-service.yaml

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -37,6 +37,8 @@
           # oc rsync /tmp/sandcastle -> sandcastle pod
           - rsync
           - fedpkg-stage
+          - postgresql # pg_dump
+          - python3-boto3 # AWS (S3)
         state: present
     - import_tasks: tasks/install-packit-deps.yaml
     - import_tasks: tasks/install-ogr-deps.yaml

--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -22,9 +22,9 @@ beat_schedule = {
         "schedule": 600.0,
         "options": {"queue": "long-running"},
     },
-    "database-discard-old-stuff": {
-        "task": "packit_service.worker.tasks.periodic_database_cleanup",
-        "schedule": crontab(minute=0, hour=1),  # daily at 1AM
+    "database-maintenance": {
+        "task": "packit_service.worker.tasks.database_maintenance",
+        "schedule": crontab(minute=0, hour=1),  # nightly at 1AM
         "options": {"queue": "long-running"},
     },
 }

--- a/packit_service/worker/database.py
+++ b/packit_service/worker/database.py
@@ -1,16 +1,28 @@
-from datetime import timedelta, datetime
-from logging import getLogger
-from os import getenv
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
 
+from datetime import timedelta, datetime
+from gzip import open as gzip_open
+from logging import getLogger, DEBUG, INFO
+from os import getenv
+from pathlib import Path
+from shutil import copyfileobj
+
+from boto3 import client as boto3_client
+from botocore.exceptions import ClientError
+
+from packit.utils.commands import run_command
 from packit_service.constants import SRPMBUILDS_OUTDATED_AFTER_DAYS
-from packit_service.models import SRPMBuildModel
+from packit_service.models import get_pg_url, SRPMBuildModel
 
 logger = getLogger(__name__)
+
+DB_NAME = getenv("POSTGRESQL_DATABASE")
 
 
 def discard_old_srpm_build_logs():
     """Called periodically (see celery_config.py) to discard logs of old SRPM builds."""
-    logger.debug("About to discard old SRPM build logs & artifact urls.")
+    logger.info("About to discard old SRPM build logs & artifact urls.")
     outdated_after_days = getenv(
         "SRPMBUILDS_OUTDATED_AFTER_DAYS", SRPMBUILDS_OUTDATED_AFTER_DAYS
     )
@@ -23,3 +35,100 @@ def discard_old_srpm_build_logs():
         )
         build.set_logs(None)
         build.set_url(None)
+
+
+def gzip_file(file: Path) -> Path:
+    """Gzip compress given file into {file}.gz
+
+    Args:
+        file: File to be compressed.
+    Returns:
+        Compressed file.
+    Raises:
+        OSError: If the 'file' can't be opened.
+    """
+    compressed_file = Path(f"{file}.gz")
+    try:
+        with file.open(mode="rb") as f_in:
+            with gzip_open(compressed_file, mode="wb") as f_out:
+                logger.info(f"Compressing {file} into {compressed_file}")
+                copyfileobj(f_in, f_out)
+    except OSError as e:
+        logger.error(e)
+        raise
+    return compressed_file
+
+
+def upload_to_s3(
+    file: Path, bucket: str = f"arr-packit-{getenv('DEPLOYMENT', 'dev')}"
+) -> None:
+    """Upload a file to an S3 bucket.
+
+    Args:
+        file: File to upload.
+        bucket: Bucket to upload to.
+    """
+
+    s3_client = boto3_client("s3")
+    try:
+        logger.info(f"Uploading {file} to S3 ({bucket})")
+        s3_client.upload_file(str(file), bucket, file.name)
+    except ClientError as e:
+        logger.error(e)
+        raise
+
+
+def is_aws_configured() -> bool:
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#environment-variables
+    return bool(getenv("AWS_ACCESS_KEY_ID") and getenv("AWS_SECRET_ACCESS_KEY"))
+
+
+def dump_to(file: Path):
+    """Dump 'packit' database into a file.
+
+    To restore db from this file, run:
+    psql -d packit < database_packit.sql
+
+    Args:
+        file: File where to put the dump.
+    Raises:
+        PackitCommandFailedError: When pg_dump fails.
+    """
+    # We have to specify libpq connection string to be able to pass the
+    # password to the pg_dump. Luckily get_pg_url() does almost what we need.
+    pg_connection = get_pg_url().replace("+psycopg2", "")
+    cmd = ["pg_dump", f"--file={file}", f"--dbname={pg_connection}"]
+    packit_logger = getLogger("packit")
+    was_debug = packit_logger.level == DEBUG
+
+    logger.info(f"Running pg_dump to create '{DB_NAME}' database backup")
+    try:
+        if was_debug:
+            # Temporarily increase log level to avoid password leaking into logs
+            packit_logger.setLevel(INFO)
+        run_command(cmd=cmd)
+    finally:
+        if was_debug:
+            packit_logger.setLevel(DEBUG)
+
+
+def backup():
+    """Dump the 'packit' database into a file, compress and upload to S3."""
+    if not is_aws_configured():
+        logger.info("Not backing up database since AWS is not configured.")
+        # probably dev/test deployment
+        return
+
+    project = getenv("PROJECT", "packit")
+    file = Path(f"/tmp/{project}_database_{DB_NAME}.sql")
+    compressed_file = None
+    try:
+        logger.info("About to backup database")
+        dump_to(file)
+        compressed_file = gzip_file(file)
+        upload_to_s3(compressed_file)
+        logger.info("Backup complete")
+    finally:
+        file.unlink(missing_ok=True)
+        if compressed_file:
+            compressed_file.unlink()

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -19,7 +19,7 @@ from packit_service.worker.build.babysit import (
     check_pending_copr_builds,
     check_pending_testing_farm_runs,
 )
-from packit_service.worker.database import discard_old_srpm_build_logs
+from packit_service.worker.database import discard_old_srpm_build_logs, backup
 from packit_service.worker.handlers import (
     BugzillaHandler,
     CoprBuildEndHandler,
@@ -46,6 +46,7 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 logging.getLogger("github").setLevel(logging.WARNING)
 logging.getLogger("kubernetes").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)
+logging.getLogger("s3transfer").setLevel(logging.WARNING)
 # info is just enough
 logging.getLogger("ogr").setLevel(logging.INFO)
 # easier debugging
@@ -258,5 +259,6 @@ def babysit_pending_tft_runs() -> None:
 
 
 @celery_app.task
-def periodic_database_cleanup() -> None:
+def database_maintenance() -> None:
     discard_old_srpm_build_logs()
+    backup()


### PR DESCRIPTION
Re-uses the periodic job we already have for database cleanup.

Worker needs to have `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` env vars.

Database is `pg_dump`ed into plain-text SQL script file, compressed, and uploaded to S3 `arr-packit-$DEPLOYMENT` bucket.

The S3 bucket has versioning enabled, which means that uploading another file with the same name results in a new version of
the same object/key. You can always download any older version.
There's also a lifecycle rule to (permanently) delete old versions after a specified number of days.

To restore the database from the file, run: `psql -d packit < database_packit.sql`
(the `-d packit` is important, otherwise, you'd populate another database and then would, like me, wonder why it 'does nothing')

Note: tests are expected to fail due to new dependencies, but they of course pass locally

---

N/A (not interesting to users)
