### PR TITLE
Improvements to DB model names

### DIFF
--- a/alembic/versions/73a28911901f_improve_db_model_naming.py
+++ b/alembic/versions/73a28911901f_improve_db_model_naming.py
@@ -1,0 +1,82 @@
+"""Improve DB model naming
+
+Revision ID: 73a28911901f
+Revises: 0ad4d1c2a2d8
+Create Date: 2022-02-02 09:45:20.907000
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "73a28911901f"
+down_revision = "0ad4d1c2a2d8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table("build_triggers", "job_triggers")
+    op.execute("ALTER SEQUENCE build_triggers_id_seq RENAME TO job_triggers_id_seq")
+    op.execute("ALTER INDEX build_triggers_pkey RENAME TO job_triggers_pkey")
+    op.execute("ALTER TYPE jobtriggermodeltype RENAME TO jobtriggertype")
+
+    op.rename_table("runs", "pipelines")
+    op.execute("ALTER SEQUENCE runs_id_seq RENAME TO pipelines_id_seq")
+    op.execute("ALTER INDEX runs_pkey RENAME TO pipelines_pkey")
+
+    op.rename_table("copr_builds", "copr_build_targets")
+    op.execute("ALTER SEQUENCE copr_builds_id_seq RENAME TO copr_build_targets_id_seq")
+    op.execute("ALTER INDEX copr_builds_pkey RENAME TO copr_build_targets_pkey")
+    op.execute(
+        "ALTER INDEX ix_copr_builds_build_id RENAME TO ix_copr_build_targets_build_id"
+    )
+
+    op.rename_table("koji_builds", "koji_build_targets")
+    op.execute("ALTER SEQUENCE koji_builds_id_seq RENAME TO koji_build_targets_id_seq")
+    op.execute("ALTER INDEX koji_builds_pkey RENAME TO koji_build_targets_pkey")
+    op.execute(
+        "ALTER INDEX ix_koji_builds_build_id RENAME TO ix_koji_build_targets_build_id"
+    )
+
+    op.rename_table("tft_test_runs", "tft_test_run_targets")
+    op.execute(
+        "ALTER SEQUENCE tft_test_runs_id_seq RENAME TO tft_test_run_targets_id_seq"
+    )
+    op.execute("ALTER INDEX tft_test_runs_pkey RENAME TO tft_test_run_targets_pkey")
+    op.execute(
+        "ALTER INDEX ix_tft_test_runs_pipeline_id RENAME TO ix_tft_test_run_targets_pipeline_id"
+    )
+
+
+def downgrade():
+    op.rename_table("job_triggers", "build_triggers")
+    op.execute("ALTER SEQUENCE job_triggers_id_seq RENAME TO build_triggers_id_seq")
+    op.execute("ALTER INDEX job_triggers_pkey RENAME TO build_triggers_pkey")
+    op.execute("ALTER TYPE jobtriggertype RENAME TO jobtriggermodeltype")
+
+    op.rename_table("pipelines", "runs")
+    op.execute("ALTER SEQUENCE pipelines_id_seq RENAME TO runs_id_seq")
+    op.execute("ALTER INDEX pipelines_pkey RENAME TO runs_pkey")
+
+    op.rename_table("copr_build_targets", "copr_builds")
+    op.execute("ALTER SEQUENCE copr_build_targets_id_seq RENAME TO copr_builds_id_seq")
+    op.execute("ALTER INDEX copr_build_targets_pkey RENAME TO copr_builds_pkey")
+    op.execute(
+        "ALTER INDEX ix_copr_build_targets_build_id RENAME TO ix_copr_builds_build_id"
+    )
+
+    op.rename_table("koji_build_targets", "koji_builds")
+    op.execute("ALTER SEQUENCE koji_build_targets_id_seq RENAME TO koji_builds_id_seq")
+    op.execute("ALTER INDEX koji_build_targets_pkey RENAME TO koji_builds_pkey")
+    op.execute(
+        "ALTER INDEX ix_koji_build_targets_build_id RENAME TO ix_koji_builds_build_id"
+    )
+
+    op.rename_table("tft_test_run_targets", "tft_test_runs")
+    op.execute(
+        "ALTER SEQUENCE tft_test_run_targets_id_seq RENAME TO tft_test_runs_id_seq"
+    )
+    op.execute("ALTER INDEX tft_test_run_targets_pkey RENAME TO tft_test_runs_pkey")
+    op.execute(
+        "ALTER INDEX ix_tft_test_run_targets_pipeline_id RENAME TO ix_tft_test_runs_pipeline_id"
+    )

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -663,7 +663,7 @@ class JobTriggerModel(Base):
       (e.g. For each push to PR, there will be new PipelineModel, but same JobTriggerModel.)
     """
 
-    __tablename__ = "build_triggers"
+    __tablename__ = "job_triggers"
     id = Column(Integer, primary_key=True)  # our database PK
     type = Column(Enum(JobTriggerModelType))
     trigger_id = Column(Integer)
@@ -719,22 +719,22 @@ class PipelineModel(Base):
       (e.g. For each push to PR, there will be new PipelineModel, but same JobTriggerModel.)
     """
 
-    __tablename__ = "runs"
+    __tablename__ = "pipelines"
     id = Column(Integer, primary_key=True)  # our database PK
     # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
     # so it will run when the model is initiated, not when the table is made
     datetime = Column(DateTime, default=datetime.utcnow)
 
-    job_trigger_id = Column(Integer, ForeignKey("build_triggers.id"))
+    job_trigger_id = Column(Integer, ForeignKey("job_triggers.id"))
     job_trigger = relationship("JobTriggerModel", back_populates="runs")
 
     srpm_build_id = Column(Integer, ForeignKey("srpm_builds.id"))
     srpm_build = relationship("SRPMBuildModel", back_populates="runs")
-    copr_build_id = Column(Integer, ForeignKey("copr_builds.id"))
+    copr_build_id = Column(Integer, ForeignKey("copr_build_targets.id"))
     copr_build = relationship("CoprBuildTargetModel", back_populates="runs")
-    koji_build_id = Column(Integer, ForeignKey("koji_builds.id"))
+    koji_build_id = Column(Integer, ForeignKey("koji_build_targets.id"))
     koji_build = relationship("KojiBuildTargetModel", back_populates="runs")
-    test_run_id = Column(Integer, ForeignKey("tft_test_runs.id"))
+    test_run_id = Column(Integer, ForeignKey("tft_test_run_targets.id"))
     test_run = relationship("TFTTestRunTargetModel", back_populates="runs")
 
     @classmethod
@@ -814,7 +814,7 @@ class CoprBuildTargetModel(ProjectAndTriggersConnector, Base):
     Representation of Copr build for one target.
     """
 
-    __tablename__ = "copr_builds"
+    __tablename__ = "copr_build_targets"
     id = Column(Integer, primary_key=True)
     build_id = Column(String, index=True)  # copr build id
 
@@ -1051,7 +1051,7 @@ class CoprBuildTargetModel(ProjectAndTriggersConnector, Base):
 class KojiBuildTargetModel(ProjectAndTriggersConnector, Base):
     """we create an entry for every target"""
 
-    __tablename__ = "koji_builds"
+    __tablename__ = "koji_build_targets"
     id = Column(Integer, primary_key=True)
     build_id = Column(String, index=True)  # koji build id
 
@@ -1478,7 +1478,7 @@ class TestingFarmResult(str, enum.Enum):
 
 
 class TFTTestRunTargetModel(ProjectAndTriggersConnector, Base):
-    __tablename__ = "tft_test_runs"
+    __tablename__ = "tft_test_run_targets"
     id = Column(Integer, primary_key=True)
     pipeline_id = Column(String, index=True)
     commit_sha = Column(String)

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1653,7 +1653,7 @@ class ProjectAuthenticationIssueModel(Base):
         )
 
 
-class InstallationModel(Base):
+class GithubInstallationModel(Base):
     __tablename__ = "github_installations"
     id = Column(Integer, primary_key=True, autoincrement=True)
     # information about account (user/organization) into which the app has been installed
@@ -1678,23 +1678,25 @@ class InstallationModel(Base):
         )
 
     @classmethod
-    def get_by_id(cls, id: int) -> Optional["InstallationModel"]:
+    def get_by_id(cls, id: int) -> Optional["GithubInstallationModel"]:
         with get_sa_session() as session:
-            return session.query(InstallationModel).filter_by(id=id).first()
+            return session.query(GithubInstallationModel).filter_by(id=id).first()
 
     @classmethod
-    def get_by_account_login(cls, account_login: str) -> Optional["InstallationModel"]:
+    def get_by_account_login(
+        cls, account_login: str
+    ) -> Optional["GithubInstallationModel"]:
         with get_sa_session() as session:
             return (
-                session.query(InstallationModel)
+                session.query(GithubInstallationModel)
                 .filter_by(account_login=account_login)
                 .first()
             )
 
     @classmethod
-    def get_all(cls) -> Optional[Iterable["InstallationModel"]]:
+    def get_all(cls) -> Optional[Iterable["GithubInstallationModel"]]:
         with get_sa_session() as session:
-            return session.query(InstallationModel).all()
+            return session.query(GithubInstallationModel).all()
 
     @classmethod
     def create(cls, event):
@@ -1729,4 +1731,4 @@ class InstallationModel(Base):
         }
 
     def __repr__(self):
-        return f"InstallationModel(id={self.id}, account={self.account_login})"
+        return f"GithubInstallationModel(id={self.id}, account={self.account_login})"

--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -6,7 +6,7 @@ from logging import getLogger
 
 from flask_restx import Namespace, Resource
 
-from packit_service.models import CoprBuildModel, optional_timestamp
+from packit_service.models import CoprBuildTargetModel, optional_timestamp
 from packit_service.service.api.parsers import indices, pagination_arguments
 from packit_service.service.api.utils import get_project_info_from_build, response_maker
 
@@ -28,8 +28,8 @@ class CoprBuildsList(Resource):
         result = []
 
         first, last = indices()
-        for build in CoprBuildModel.get_merged_chroots(first, last):
-            build_info = CoprBuildModel.get_by_build_id(build.build_id, None)
+        for build in CoprBuildTargetModel.get_merged_chroots(first, last):
+            build_info = CoprBuildTargetModel.get_by_build_id(build.build_id, None)
             if build_info.status == "waiting_for_srpm":
                 continue
             project_info = build_info.get_project()
@@ -75,7 +75,7 @@ class CoprBuildItem(Resource):
     @ns.response(HTTPStatus.NOT_FOUND.value, "Copr build identifier not in db/hash")
     def get(self, id):
         """A specific copr build details for one chroot."""
-        build = CoprBuildModel.get_by_id(int(id))
+        build = CoprBuildTargetModel.get_by_id(int(id))
         if not build:
             return response_maker(
                 {"error": "No info about build stored in DB"},

--- a/packit_service/service/api/installations.py
+++ b/packit_service/service/api/installations.py
@@ -6,7 +6,7 @@ from logging import getLogger
 
 from flask_restx import Namespace, Resource
 
-from packit_service.models import InstallationModel
+from packit_service.models import GithubInstallationModel
 
 logger = getLogger("packit_service")
 
@@ -18,7 +18,9 @@ class InstallationsList(Resource):
     @ns.response(HTTPStatus.OK.value, "OK, installations list follows")
     def get(self):
         """List all Github App installations"""
-        return [installation.to_dict() for installation in InstallationModel.get_all()]
+        return [
+            installation.to_dict() for installation in GithubInstallationModel.get_all()
+        ]
 
 
 @ns.route("/<int:id>")
@@ -28,7 +30,7 @@ class InstallationItem(Resource):
     @ns.response(HTTPStatus.NO_CONTENT.value, "identifier not in allowlist")
     def get(self, id):
         """A specific installation details"""
-        installation = InstallationModel.get_by_id(id)
+        installation = GithubInstallationModel.get_by_id(id)
         return (
             installation.to_dict()
             if installation

--- a/packit_service/service/api/koji_builds.py
+++ b/packit_service/service/api/koji_builds.py
@@ -6,7 +6,7 @@ from logging import getLogger
 
 from flask_restx import Namespace, Resource
 
-from packit_service.models import KojiBuildModel, optional_timestamp
+from packit_service.models import KojiBuildTargetModel, optional_timestamp
 from packit_service.service.api.parsers import indices, pagination_arguments
 from packit_service.service.api.utils import get_project_info_from_build, response_maker
 
@@ -25,7 +25,7 @@ class KojiBuildsList(Resource):
         first, last = indices()
         result = []
 
-        for build in KojiBuildModel.get_range(first, last):
+        for build in KojiBuildTargetModel.get_range(first, last):
             build_dict = {
                 "packit_id": build.id,
                 "build_id": build.build_id,
@@ -65,7 +65,7 @@ class KojiBuildItem(Resource):
     )
     def get(self, id):
         """A specific koji build details."""
-        build = KojiBuildModel.get_by_id(int(id))
+        build = KojiBuildTargetModel.get_by_id(int(id))
 
         if not build:
             return response_maker(

--- a/packit_service/service/api/runs.py
+++ b/packit_service/service/api/runs.py
@@ -9,7 +9,7 @@ from flask_restx import Namespace, Resource
 from packit_service.models import (
     CoprBuildModel,
     KojiBuildModel,
-    RunModel,
+    PipelineModel,
     SRPMBuildModel,
     TFTTestRunModel,
     optional_timestamp,
@@ -27,11 +27,11 @@ ns = Namespace("runs", description="Pipelines")
 
 def process_runs(runs):
     """
-    Process `RunModel`s and construct a JSON that is returned from the endpoints
+    Process `PipelineModel`s and construct a JSON that is returned from the endpoints
     that return merged chroots.
 
     Args:
-        runs: Iterator over merged `RunModel`s.
+        runs: Iterator over merged `PipelineModel`s.
 
     Returns:
         List of JSON objects where each represents pipelines run on single SRPM.
@@ -95,7 +95,7 @@ class RunsList(Resource):
     def get(self):
         """List all runs."""
         first, last = indices()
-        result = process_runs(RunModel.get_merged_chroots(first, last))
+        result = process_runs(PipelineModel.get_merged_chroots(first, last))
         resp = response_maker(
             result,
             status=HTTPStatus.PARTIAL_CONTENT.value,
@@ -111,7 +111,7 @@ class MergedRun(Resource):
     @ns.response(HTTPStatus.NOT_FOUND.value, "Run ID not found in DB")
     def get(self, id):
         """Return details for merged run."""
-        if result := process_runs([RunModel.get_merged_run(id)]):
+        if result := process_runs([PipelineModel.get_merged_run(id)]):
             return response_maker(result[0])
 
         return response_maker(
@@ -126,7 +126,7 @@ class Run(Resource):
     @ns.response(HTTPStatus.NOT_FOUND.value, "Run ID not found in DB")
     def get(self, id):
         """Return details for given run."""
-        run = RunModel.get_run(id_=id)
+        run = PipelineModel.get_run(id_=id)
         if not run:
             return response_maker(
                 {"error": "No run has been found in DB"},

--- a/packit_service/service/api/runs.py
+++ b/packit_service/service/api/runs.py
@@ -7,11 +7,11 @@ from logging import getLogger
 from flask_restx import Namespace, Resource
 
 from packit_service.models import (
-    CoprBuildModel,
-    KojiBuildModel,
+    CoprBuildTargetModel,
+    KojiBuildTargetModel,
     PipelineModel,
     SRPMBuildModel,
-    TFTTestRunModel,
+    TFTTestRunTargetModel,
     optional_timestamp,
 )
 from packit_service.service.api.parsers import indices, pagination_arguments
@@ -59,9 +59,9 @@ def process_runs(runs):
             response_dict["trigger"] = get_project_info_from_build(srpm_build)
 
         for model_type, Model, packit_ids in (
-            ("copr", CoprBuildModel, pipeline.copr_build_id),
-            ("koji", KojiBuildModel, pipeline.koji_build_id),
-            ("test_run", TFTTestRunModel, pipeline.test_run_id),
+            ("copr", CoprBuildTargetModel, pipeline.copr_build_id),
+            ("koji", KojiBuildTargetModel, pipeline.koji_build_id),
+            ("test_run", TFTTestRunTargetModel, pipeline.test_run_id),
         ):
             for packit_id in set(filter(None, map(lambda ids: ids[0], packit_ids))):
                 row = Model.get_by_id(packit_id)
@@ -77,7 +77,7 @@ def process_runs(runs):
                 if "trigger" not in response_dict:
                     submitted_time = (
                         row.submitted_time
-                        if isinstance(row, TFTTestRunModel)
+                        if isinstance(row, TFTTestRunTargetModel)
                         else row.build_submitted_time
                     )
                     response_dict["time_submitted"] = optional_timestamp(submitted_time)

--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -11,7 +11,7 @@ from flask_restx import Namespace, Resource, fields
 from packit_service.celerizer import celery_app
 from packit_service.config import ServiceConfig
 from packit_service.constants import CELERY_DEFAULT_MAIN_TASK_NAME
-from packit_service.models import TFTTestRunModel, optional_timestamp
+from packit_service.models import TFTTestRunTargetModel, optional_timestamp
 from packit_service.service.api.errors import ValidationFailed
 from packit_service.service.api.parsers import indices, pagination_arguments
 from packit_service.service.api.utils import get_project_info_from_build, response_maker
@@ -108,7 +108,7 @@ class TestingFarmResults(Resource):
         first, last = indices()
         # results have nothing other than ref in common, so it doesnt make sense to
         # merge them like copr builds
-        for tf_result in TFTTestRunModel.get_range(first, last):
+        for tf_result in TFTTestRunTargetModel.get_range(first, last):
             result_dict = {
                 "packit_id": tf_result.id,
                 "pipeline_id": tf_result.pipeline_id,
@@ -142,7 +142,7 @@ class TestingFarmResult(Resource):
     @ns.response(HTTPStatus.NOT_FOUND.value, "No info about test run stored in DB")
     def get(self, id):
         """A specific test run details."""
-        test_run_model = TFTTestRunModel.get_by_id(int(id))
+        test_run_model = TFTTestRunTargetModel.get_by_id(int(id))
 
         if not test_run_model:
             return response_maker(

--- a/packit_service/service/api/utils.py
+++ b/packit_service/service/api/utils.py
@@ -8,10 +8,10 @@ from typing import Any, Dict, Union
 from flask import make_response
 
 from packit_service.models import (
-    CoprBuildModel,
-    KojiBuildModel,
+    CoprBuildTargetModel,
+    KojiBuildTargetModel,
     SRPMBuildModel,
-    TFTTestRunModel,
+    TFTTestRunTargetModel,
 )
 
 
@@ -24,7 +24,12 @@ def response_maker(result, status=HTTPStatus.OK.value):
 
 
 def get_project_info_from_build(
-    build: Union[SRPMBuildModel, CoprBuildModel, KojiBuildModel, TFTTestRunModel]
+    build: Union[
+        SRPMBuildModel,
+        CoprBuildTargetModel,
+        KojiBuildTargetModel,
+        TFTTestRunTargetModel,
+    ]
 ) -> Dict[str, Any]:
     project = build.get_project()
     if not project:

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -30,7 +30,7 @@ from sandcastle import SandcastleTimeoutReached
 from packit_service import sentry_integration
 from packit_service.config import Deployment, ServiceConfig
 from packit_service.constants import PG_BUILD_STATUS_SUCCESS, PG_BUILD_STATUS_FAILURE
-from packit_service.models import RunModel, SRPMBuildModel, JobTriggerModel
+from packit_service.models import PipelineModel, SRPMBuildModel, JobTriggerModel
 from packit_service.worker.events import EventData
 from packit_service.trigger_mapping import are_job_types_same
 from packit_service.worker.monitoring import Pushgateway
@@ -63,7 +63,7 @@ class BaseBuildJobHelper:
         self.db_trigger = db_trigger
         self.msg_retrigger: Optional[str] = ""
         self.metadata: EventData = metadata
-        self.run_model: Optional[RunModel] = None
+        self.run_model: Optional[PipelineModel] = None
         self.targets_override: Optional[Set[str]] = targets_override
         self.pushgateway = pushgateway
 

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -22,7 +22,11 @@ from packit_service.constants import (
     SRPM_BUILD_DEPS,
     PG_BUILD_STATUS_SUCCESS,
 )
-from packit_service.models import AbstractTriggerDbType, CoprBuildModel, SRPMBuildModel
+from packit_service.models import (
+    AbstractTriggerDbType,
+    CoprBuildTargetModel,
+    SRPMBuildModel,
+)
 from packit_service.utils import get_package_nvrs
 from packit_service.worker.events import EventData
 from packit_service.service.urls import (
@@ -398,7 +402,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 unprocessed_chroots.append(chroot)
                 continue
 
-            copr_build = CoprBuildModel.create(
+            copr_build = CoprBuildTargetModel.create(
                 build_id=str(build_id),
                 commit_sha=self.metadata.commit_sha,
                 project_name=self.job_project,

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -13,7 +13,7 @@ from packit.exceptions import PackitCommandFailedError
 from packit_service import sentry_integration
 from packit_service.config import ServiceConfig
 from packit_service.constants import MSG_RETRIGGER, PG_BUILD_STATUS_SUCCESS
-from packit_service.models import KojiBuildModel
+from packit_service.models import KojiBuildTargetModel
 from packit_service.worker.events import EventData
 from packit_service.service.urls import (
     get_koji_build_info_url,
@@ -142,7 +142,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
                 errors[target] = str(ex)
                 continue
 
-            koji_build = KojiBuildModel.create(
+            koji_build = KojiBuildTargetModel.create(
                 build_id=str(build_id),
                 commit_sha=self.metadata.commit_sha,
                 web_url=web_url,

--- a/packit_service/worker/events/copr.py
+++ b/packit_service/worker/events/copr.py
@@ -9,7 +9,7 @@ from ogr.services.pagure import PagureProject
 
 from packit_service.constants import COPR_SRPM_CHROOT
 from packit_service.models import (
-    CoprBuildModel,
+    CoprBuildTargetModel,
     JobTriggerModelType,
     AbstractTriggerDbType,
     SRPMBuildModel,
@@ -21,13 +21,13 @@ logger = getLogger(__name__)
 
 
 class AbstractCoprBuildEvent(AbstractForgeIndependentEvent):
-    build: Optional[Union[SRPMBuildModel, CoprBuildModel]]
+    build: Optional[Union[SRPMBuildModel, CoprBuildTargetModel]]
 
     def __init__(
         self,
         topic: str,
         build_id: int,
-        build: Union[CoprBuildModel, SRPMBuildModel],
+        build: Union[CoprBuildTargetModel, SRPMBuildModel],
         chroot: str,
         status: int,
         owner: str,
@@ -96,11 +96,11 @@ class AbstractCoprBuildEvent(AbstractForgeIndependentEvent):
         timestamp,
     ) -> Optional["AbstractCoprBuildEvent"]:
         """Return cls instance or None if build_id not in CoprBuildDB"""
-        build: Optional[Union[SRPMBuildModel, CoprBuildModel]]
+        build: Optional[Union[SRPMBuildModel, CoprBuildTargetModel]]
         if chroot == COPR_SRPM_CHROOT:
             build = SRPMBuildModel.get_by_copr_build_id(str(build_id))
         else:
-            build = CoprBuildModel.get_by_build_id(str(build_id), chroot)
+            build = CoprBuildTargetModel.get_by_build_id(str(build_id), chroot)
 
         if not build:
             logger.warning(

--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -16,12 +16,12 @@ from packit.config import JobConfigTriggerType, PackageConfig
 from packit_service.config import PackageConfigGetter, ServiceConfig
 from packit_service.models import (
     AbstractTriggerDbType,
-    CoprBuildModel,
+    CoprBuildTargetModel,
     GitBranchModel,
     IssueModel,
     ProjectReleaseModel,
     PullRequestModel,
-    TFTTestRunModel,
+    TFTTestRunTargetModel,
 )
 
 logger = getLogger(__name__)
@@ -444,7 +444,8 @@ class AbstractForgeIndependentEvent(Event):
     @staticmethod
     def _filter_failed_models_targets(
         models: Union[
-            Optional[Iterable[CoprBuildModel]], Optional[Iterable[TFTTestRunModel]]
+            Optional[Iterable[CoprBuildTargetModel]],
+            Optional[Iterable[TFTTestRunTargetModel]],
         ],
     ) -> Optional[Set[str]]:
         failed_models_targets = set()
@@ -459,17 +460,19 @@ class AbstractForgeIndependentEvent(Event):
             return None
 
         return self._filter_failed_models_targets(
-            models=TFTTestRunModel.get_all_by_commit_target(commit_sha=self.commit_sha)
+            models=TFTTestRunTargetModel.get_all_by_commit_target(
+                commit_sha=self.commit_sha
+            )
         )
 
     def get_all_build_failed_targets(self) -> Optional[Set[str]]:
-        # TODO: get rid of project.repo which is mandatory in `CoprBuildModel.get_all_by`
+        # TODO: get rid of project.repo which is mandatory in `CoprBuildTargetModel.get_all_by`
         # in this case relevant for us is only commit_sha
         if self.commit_sha is None or self.project.repo is None:
             return None
 
         return self._filter_failed_models_targets(
-            models=CoprBuildModel.get_all_by(
+            models=CoprBuildTargetModel.get_all_by(
                 project_name=self.project.repo, commit_sha=self.commit_sha
             )
         )

--- a/packit_service/worker/events/koji.py
+++ b/packit_service/worker/events/koji.py
@@ -16,7 +16,7 @@ from packit_service.models import (
     PullRequestModel,
     ProjectReleaseModel,
     GitBranchModel,
-    RunModel,
+    PipelineModel,
 )
 from packit_service.worker.events.event import (
     AbstractForgeIndependentEvent,
@@ -122,7 +122,7 @@ class KojiBuildEvent(AbstractKojiEvent):
                 web_url=self.web_url,
                 target="noarch",  # TODO: where to get this info from?
                 status=self.state.value,
-                run_model=RunModel.create(
+                run_model=PipelineModel.create(
                     type=JobTriggerModelType.branch_push,
                     trigger_id=GitBranchModel.get_or_create(
                         branch_name=self.branch_name,

--- a/packit_service/worker/events/koji.py
+++ b/packit_service/worker/events/koji.py
@@ -12,7 +12,7 @@ from packit_service.constants import KojiBuildState, KojiTaskState
 from packit_service.models import (
     AbstractTriggerDbType,
     JobTriggerModelType,
-    KojiBuildModel,
+    KojiBuildTargetModel,
     PullRequestModel,
     ProjectReleaseModel,
     GitBranchModel,
@@ -36,13 +36,15 @@ class AbstractKojiEvent(AbstractForgeIndependentEvent):
 
         # Lazy properties
         self._target: Optional[str] = None
-        self._build_model: Optional[KojiBuildModel] = None
+        self._build_model: Optional[KojiBuildTargetModel] = None
         self._build_model_searched = False
 
     @property
-    def build_model(self) -> Optional[KojiBuildModel]:
+    def build_model(self) -> Optional[KojiBuildTargetModel]:
         if not self._build_model_searched and not self._build_model:
-            self._build_model = KojiBuildModel.get_by_build_id(build_id=self.build_id)
+            self._build_model = KojiBuildTargetModel.get_by_build_id(
+                build_id=self.build_id
+            )
             self._build_model_searched = True
         return self._build_model
 
@@ -114,9 +116,9 @@ class KojiBuildEvent(AbstractKojiEvent):
         return self._commit_sha
 
     @property
-    def build_model(self) -> Optional[KojiBuildModel]:
+    def build_model(self) -> Optional[KojiBuildTargetModel]:
         if not super().build_model:
-            self._build_model = KojiBuildModel.create(
+            self._build_model = KojiBuildTargetModel.create(
                 build_id=str(self.build_id),
                 commit_sha=self._commit_sha,
                 web_url=self.web_url,

--- a/packit_service/worker/events/testing_farm.py
+++ b/packit_service/worker/events/testing_farm.py
@@ -10,7 +10,7 @@ from packit_service.models import (
     TestingFarmResult,
     AbstractTriggerDbType,
     PullRequestModel,
-    TFTTestRunModel,
+    TFTTestRunTargetModel,
 )
 from packit_service.worker.events.event import AbstractForgeIndependentEvent
 
@@ -57,7 +57,9 @@ class TestingFarmResultsEvent(AbstractForgeIndependentEvent):
         return result
 
     def get_db_trigger(self) -> Optional[AbstractTriggerDbType]:
-        run_model = TFTTestRunModel.get_by_pipeline_id(pipeline_id=self.pipeline_id)
+        run_model = TFTTestRunTargetModel.get_by_pipeline_id(
+            pipeline_id=self.pipeline_id
+        )
         return run_model.get_trigger_object() if run_model else None
 
     def get_base_project(self) -> Optional[GitProject]:

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -21,7 +21,11 @@ from packit_service.constants import (
     PG_BUILD_STATUS_FAILURE,
     PG_BUILD_STATUS_SUCCESS,
 )
-from packit_service.models import AbstractTriggerDbType, CoprBuildModel, SRPMBuildModel
+from packit_service.models import (
+    AbstractTriggerDbType,
+    CoprBuildTargetModel,
+    SRPMBuildModel,
+)
 from packit_service.worker.events import (
     CoprBuildEndEvent,
     AbstractCoprBuildEvent,
@@ -156,7 +160,7 @@ class AbstractCoprBuildReportHandler(JobHandler):
         targets_override = (
             {
                 build.target
-                for build in CoprBuildModel.get_all_by_build_id(
+                for build in CoprBuildTargetModel.get_all_by_build_id(
                     str(self.copr_event.build_id)
                 )
             }
@@ -183,7 +187,7 @@ class AbstractCoprBuildReportHandler(JobHandler):
             if self.copr_event.chroot == COPR_SRPM_CHROOT:
                 self._build = SRPMBuildModel.get_by_copr_build_id(build_id)
             else:
-                self._build = CoprBuildModel.get_by_build_id(
+                self._build = CoprBuildTargetModel.get_by_build_id(
                     build_id, self.copr_event.chroot
                 )
         return self._build
@@ -415,7 +419,9 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
             )
             return TaskResults(success=False, details={"msg": failed_msg})
 
-        for build in CoprBuildModel.get_all_by_build_id(str(self.copr_event.build_id)):
+        for build in CoprBuildTargetModel.get_all_by_build_id(
+            str(self.copr_event.build_id)
+        ):
             # from waiting_for_srpm to pending
             build.set_status("pending")
 

--- a/packit_service/worker/handlers/forges.py
+++ b/packit_service/worker/handlers/forges.py
@@ -13,7 +13,7 @@ from packit.config import (
 from packit.config.package_config import PackageConfig
 
 from packit_service.models import (
-    InstallationModel,
+    GithubInstallationModel,
 )
 from packit_service.worker.events import (
     InstallationEvent,
@@ -62,7 +62,7 @@ class GithubAppInstallationHandler(JobHandler):
         user is a packager.
         :return: TaskResults
         """
-        InstallationModel.create(event=self.installation_event)
+        GithubInstallationModel.create(event=self.installation_event)
         # try to add user to allowlist
         allowlist = Allowlist(
             fas_user=self.service_config.fas_user,

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -21,7 +21,7 @@ from packit_service.constants import (
     PERMISSIONS_ERROR_WRITE_OR_ADMIN,
 )
 from packit_service.constants import KojiTaskState
-from packit_service.models import AbstractTriggerDbType, KojiBuildModel
+from packit_service.models import AbstractTriggerDbType, KojiBuildTargetModel
 from packit_service.service.urls import (
     get_koji_build_info_url,
 )
@@ -152,12 +152,12 @@ class KojiTaskReportHandler(JobHandler):
         )
         self.koji_task_event: KojiTaskEvent = KojiTaskEvent.from_event_dict(event)
         self._db_trigger: Optional[AbstractTriggerDbType] = None
-        self._build: Optional[KojiBuildModel] = None
+        self._build: Optional[KojiBuildTargetModel] = None
 
     @property
-    def build(self) -> Optional[KojiBuildModel]:
+    def build(self) -> Optional[KojiBuildTargetModel]:
         if not self._build:
-            self._build = KojiBuildModel.get_by_build_id(
+            self._build = KojiBuildTargetModel.get_by_build_id(
                 build_id=str(self.koji_task_event.build_id)
             )
         return self._build
@@ -169,7 +169,7 @@ class KojiTaskReportHandler(JobHandler):
         return self._db_trigger
 
     def run(self):
-        build = KojiBuildModel.get_by_build_id(
+        build = KojiBuildTargetModel.get_by_build_id(
             build_id=str(self.koji_task_event.build_id)
         )
 
@@ -272,12 +272,12 @@ class KojiBuildReportHandler(JobHandler):
         )
         self.koji_build_event: KojiBuildEvent = KojiBuildEvent.from_event_dict(event)
         self._db_trigger: Optional[AbstractTriggerDbType] = None
-        self._build: Optional[KojiBuildModel] = None
+        self._build: Optional[KojiBuildTargetModel] = None
 
     @property
-    def build(self) -> Optional[KojiBuildModel]:
+    def build(self) -> Optional[KojiBuildTargetModel]:
         if not self._build:
-            self._build = KojiBuildModel.get_by_build_id(
+            self._build = KojiBuildTargetModel.get_by_build_id(
                 build_id=self.koji_build_event.build_id
             )
         return self._build

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -21,7 +21,7 @@ from packit_service.constants import (
     TESTING_FARM_INSTALLABILITY_TEST_URL,
 )
 from packit_service.models import (
-    TFTTestRunModel,
+    TFTTestRunTargetModel,
     TestingFarmResult,
     ProjectReleaseModel,
     GitBranchModel,
@@ -875,14 +875,14 @@ class Parser:
 
     @staticmethod
     def parse_data_from_testing_farm(
-        tft_test_run: TFTTestRunModel, event: Dict[Any, Any]
+        tft_test_run: TFTTestRunTargetModel, event: Dict[Any, Any]
     ) -> Tuple[str, str, TestingFarmResult, str, str, str, str, str, datetime]:
         """Parses common data from testing farm response.
 
         Such common data is environment, os, summary and others.
 
         Args:
-            tft_test_run (TFTTestRunModel): Entry of the related test run in DB.
+            tft_test_run (TFTTestRunTargetModel): Entry of the related test run in DB.
             event (dict): Response from testing farm converted to a dict.
 
         Returns:
@@ -967,7 +967,7 @@ class Parser:
         request_id: str = event["request_id"]
         logger.info(f"Testing farm notification event. Request ID: {request_id}")
 
-        tft_test_run = TFTTestRunModel.get_by_pipeline_id(request_id)
+        tft_test_run = TFTTestRunTargetModel.get_by_pipeline_id(request_id)
 
         # Testing Farm sends only request/pipeline id in a notification.
         # We need to get more details ourselves.

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -19,8 +19,8 @@ from packit_service.constants import (
     TESTING_FARM_INSTALLABILITY_TEST_REF,
 )
 from packit_service.models import (
-    CoprBuildModel,
-    TFTTestRunModel,
+    CoprBuildTargetModel,
+    TFTTestRunTargetModel,
     TestingFarmResult,
     PipelineModel,
 )
@@ -130,7 +130,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         self,
         chroot: str,
         artifact: Optional[Dict[str, Union[List[str], str]]] = None,
-        build: Optional["CoprBuildModel"] = None,
+        build: Optional["CoprBuildTargetModel"] = None,
     ) -> dict:
         """Prepare a Testing Farm request payload.
 
@@ -220,7 +220,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         TF provides 'installation test', we request it in ['test']['fmf']['url'].
         We don't specify 'artifacts' as in _payload(), but 'variables'.
         """
-        copr_build = CoprBuildModel.get_by_build_id(build_id)
+        copr_build = CoprBuildTargetModel.get_by_build_id(build_id)
         distro, arch = self.chroot2distro_arch(chroot)
         compose = self.distro2compose(distro, arch)
         return {
@@ -352,11 +352,11 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
     def get_latest_copr_build(
         self, target: str, commit_sha: str
-    ) -> Optional[CoprBuildModel]:
+    ) -> Optional[CoprBuildTargetModel]:
         """
         Search a last build for the given target and commit SHA using Copr owner and project.
         """
-        copr_builds = CoprBuildModel.get_all_by(
+        copr_builds = CoprBuildTargetModel.get_all_by(
             project_name=self.job_project,
             commit_sha=commit_sha,
             owner=self.job_owner,
@@ -368,7 +368,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         return list(copr_builds)[0]
 
     def run_testing_farm(
-        self, chroot: str, build: Optional["CoprBuildModel"]
+        self, chroot: str, build: Optional["CoprBuildTargetModel"]
     ) -> TaskResults:
         if chroot not in self.tests_targets:
             # Leaving here just to be sure that we will discover this situation if it occurs.
@@ -482,7 +482,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             else build.runs[-1]
         )
 
-        created_model = TFTTestRunModel.create(
+        created_model = TFTTestRunTargetModel.create(
             pipeline_id=pipeline_id,
             commit_sha=self.metadata.commit_sha,
             status=TestingFarmResult.new,

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -22,7 +22,7 @@ from packit_service.models import (
     CoprBuildModel,
     TFTTestRunModel,
     TestingFarmResult,
-    RunModel,
+    PipelineModel,
 )
 from packit_service.sentry_integration import send_to_sentry
 from packit_service.utils import get_package_nvrs
@@ -474,7 +474,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         )
 
         run_model = (
-            RunModel.create(
+            PipelineModel.create(
                 type=self.db_trigger.job_trigger_model_type,
                 trigger_id=self.db_trigger.id,
             )

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -14,7 +14,7 @@ from packit.local_project import LocalProject
 from packit.utils.repo import RepositoryCache
 from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
-from packit_service.models import GitBranchModel, KojiBuildModel, RunModel
+from packit_service.models import GitBranchModel, KojiBuildModel, PipelineModel
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.tasks import (
@@ -78,7 +78,7 @@ def test_bodhi_update_for_unknown_koji_build(koji_build_completed_old_format):
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         git_branch_model_flexmock
     )
-    flexmock(RunModel).should_receive("create").and_return(run_model_flexmock)
+    flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
     flexmock(KojiBuildModel).should_receive("create").with_args(
         build_id="1864700",
         commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",
@@ -157,7 +157,7 @@ def test_bodhi_update_for_unknown_koji_build_not_for_unfinished(
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         git_branch_model_flexmock
     )
-    flexmock(RunModel).should_receive("create").and_return(run_model_flexmock)
+    flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
     flexmock(KojiBuildModel).should_receive("create").with_args(
         build_id="1864700",
         commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",
@@ -293,7 +293,7 @@ def test_bodhi_update_for_not_configured_branch(koji_build_completed_old_format)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         git_branch_model_flexmock
     )
-    flexmock(RunModel).should_receive("create").and_return(run_model_flexmock)
+    flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
     flexmock(KojiBuildModel).should_receive("create").with_args(
         build_id="1864700",
         commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -14,7 +14,7 @@ from packit.local_project import LocalProject
 from packit.utils.repo import RepositoryCache
 from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
-from packit_service.models import GitBranchModel, KojiBuildModel, PipelineModel
+from packit_service.models import GitBranchModel, KojiBuildTargetModel, PipelineModel
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.tasks import (
@@ -72,14 +72,14 @@ def test_bodhi_update_for_unknown_koji_build(koji_build_completed_old_format):
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
         build_id=1864700
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         git_branch_model_flexmock
     )
     flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
-    flexmock(KojiBuildModel).should_receive("create").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("create").with_args(
         build_id="1864700",
         commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",
         web_url="https://koji.fedoraproject.org/koji/taskinfo?taskID=79721403",
@@ -151,14 +151,14 @@ def test_bodhi_update_for_unknown_koji_build_not_for_unfinished(
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
         build_id=1864700
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         git_branch_model_flexmock
     )
     flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
-    flexmock(KojiBuildModel).should_receive("create").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("create").with_args(
         build_id="1864700",
         commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",
         web_url="https://koji.fedoraproject.org/koji/taskinfo?taskID=79721403",
@@ -217,7 +217,7 @@ def test_bodhi_update_for_known_koji_build(koji_build_completed_old_format):
     )
 
     # Database structure
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
         build_id=1864700
     ).and_return(
         flexmock(
@@ -287,14 +287,14 @@ def test_bodhi_update_for_not_configured_branch(koji_build_completed_old_format)
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
         build_id=1864700
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         git_branch_model_flexmock
     )
     flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
-    flexmock(KojiBuildModel).should_receive("create").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("create").with_args(
         build_id="1864700",
         commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",
         web_url="https://koji.fedoraproject.org/koji/taskinfo?taskID=79721403",
@@ -352,7 +352,7 @@ def test_bodhi_update_fedora_stable_by_default(koji_build_completed_f35):
     ).once()
 
     # Database not touched
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
         build_id=1874070
     ).times(0)
 

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -10,7 +10,7 @@ from ogr.services.github import GithubProject
 from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
 from packit_service.models import (
-    InstallationModel,
+    GithubInstallationModel,
 )
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.monitoring import Pushgateway
@@ -30,7 +30,7 @@ def test_installation():
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
 
-    flexmock(InstallationModel).should_receive("create").once()
+    flexmock(GithubInstallationModel).should_receive("create").once()
     flexmock(Allowlist).should_receive("add_namespace").with_args(
         "github.com/packit-service", "jpopelka"
     ).and_return(False)

--- a/tests/integration/test_koji_build.py
+++ b/tests/integration/test_koji_build.py
@@ -11,7 +11,7 @@ from ogr.services.pagure import PagureProject
 from packit.config import JobConfigTriggerType
 from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
-from packit_service.models import GitBranchModel, KojiBuildModel, RunModel
+from packit_service.models import GitBranchModel, KojiBuildModel, PipelineModel
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.tasks import (
@@ -157,7 +157,7 @@ def test_downstream_koji_build_report_unknown_build(koji_build_fixture, request)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         git_branch_model_flexmock
     )
-    flexmock(RunModel).should_receive("create").and_return(run_model_flexmock)
+    flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
     flexmock(KojiBuildModel).should_receive("create").with_args(
         build_id="1864700",
         commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",

--- a/tests/integration/test_koji_build.py
+++ b/tests/integration/test_koji_build.py
@@ -11,7 +11,7 @@ from ogr.services.pagure import PagureProject
 from packit.config import JobConfigTriggerType
 from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
-from packit_service.models import GitBranchModel, KojiBuildModel, PipelineModel
+from packit_service.models import GitBranchModel, KojiBuildTargetModel, PipelineModel
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.tasks import (
@@ -67,7 +67,7 @@ def test_downstream_koji_build_report_known_build(koji_build_fixture, request):
     flexmock(Pushgateway).should_receive("push").once().and_return()
 
     # Database
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
         build_id=1874074
     ).and_return(
         flexmock(
@@ -151,14 +151,14 @@ def test_downstream_koji_build_report_unknown_build(koji_build_fixture, request)
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
         build_id=1864700
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         git_branch_model_flexmock
     )
     flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
-    flexmock(KojiBuildModel).should_receive("create").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("create").with_args(
         build_id="1864700",
         commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",
         web_url="https://koji.fedoraproject.org/koji/taskinfo?taskID=79721403",
@@ -166,7 +166,7 @@ def test_downstream_koji_build_report_unknown_build(koji_build_fixture, request)
         status="BUILDING",
         run_model=run_model_flexmock,
     ).and_return(flexmock(get_trigger_object=lambda: git_branch_model_flexmock))
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
         build_id=1874074
     ).and_return(
         flexmock(

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -19,11 +19,11 @@ import packit_service
 from packit_service.constants import COPR_API_FAIL_STATE
 from packit_service.config import PackageConfigGetter, ServiceConfig
 from packit_service.models import (
-    CoprBuildModel,
+    CoprBuildTargetModel,
     TestingFarmResult,
-    TFTTestRunModel,
+    TFTTestRunTargetModel,
     JobTriggerModelType,
-    KojiBuildModel,
+    KojiBuildTargetModel,
     SRPMBuildModel,
 )
 from packit_service.worker.events import AbstractCoprBuildEvent, KojiTaskEvent
@@ -215,7 +215,9 @@ def test_copr_build_end(
         pr.should_receive("comment")
     else:
         pr.should_receive("comment").never()
-    flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
+    flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
+        copr_build_pr
+    )
     copr_build_pr.should_call("set_status").with_args("success").once()
     copr_build_pr.should_receive("set_end_time").once()
 
@@ -281,7 +283,7 @@ def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build_branch_pu
         "was_last_packit_comment_with_congratulation"
     ).and_return(False)
 
-    flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(
+    flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
         copr_build_branch_push
     )
 
@@ -339,7 +341,7 @@ def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build_rel
         "was_last_packit_comment_with_congratulation"
     ).and_return(False)
 
-    flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(
+    flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
         copr_build_release
     )
     copr_build_release.should_receive("set_status").with_args("success")
@@ -430,8 +432,10 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
 
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
-    flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
-    flexmock(CoprBuildModel).should_receive("get_by_id").and_return(copr_build_pr)
+    flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
+        copr_build_pr
+    )
+    flexmock(CoprBuildTargetModel).should_receive("get_by_id").and_return(copr_build_pr)
     copr_build_pr.should_call("set_status").with_args("success").once()
     copr_build_pr.should_receive("set_end_time").once()
     flexmock(requests).should_receive("get").and_return(requests.Response())
@@ -527,7 +531,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     )
 
     tft_test_run_model = flexmock(id=5)
-    flexmock(TFTTestRunModel).should_receive("create").with_args(
+    flexmock(TFTTestRunTargetModel).should_receive("create").with_args(
         pipeline_id=pipeline_id,
         commit_sha="0011223344",
         status=TestingFarmResult.new,
@@ -569,7 +573,9 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         copr_build_pr.get_trigger_object()
     )
 
-    flexmock(CoprBuildModel).should_receive("get_all_by").and_return([copr_build_pr])
+    flexmock(CoprBuildTargetModel).should_receive("get_all_by").and_return(
+        [copr_build_pr]
+    )
 
     run_testing_farm_handler(
         package_config=package_config,
@@ -622,8 +628,10 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
 
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
-    flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
-    flexmock(CoprBuildModel).should_receive("get_by_id").and_return(copr_build_pr)
+    flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
+        copr_build_pr
+    )
+    flexmock(CoprBuildTargetModel).should_receive("get_by_id").and_return(copr_build_pr)
     copr_build_pr.should_call("set_status").with_args("success").once()
     copr_build_pr.should_receive("set_end_time").once()
     flexmock(requests).should_receive("get").and_return(requests.Response())
@@ -748,8 +756,10 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
 
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
-    flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
-    flexmock(CoprBuildModel).should_receive("get_by_id").and_return(copr_build_pr)
+    flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
+        copr_build_pr
+    )
+    flexmock(CoprBuildTargetModel).should_receive("get_by_id").and_return(copr_build_pr)
     copr_build_pr.should_call("set_status").with_args("success").once()
     copr_build_pr.should_receive("set_end_time").once()
     url = get_copr_build_info_url(1)
@@ -785,7 +795,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         )
     )
 
-    flexmock(CoprBuildModel).should_receive("set_status").with_args("failure")
+    flexmock(CoprBuildTargetModel).should_receive("set_status").with_args("failure")
     flexmock(StatusReporter).should_receive("report").with_args(
         state=BaseCommitStatus.running,
         description="Build succeeded. Submitting the tests ...",
@@ -846,7 +856,9 @@ def test_copr_build_start(copr_build_start, pc_build_pr, copr_build_pr):
         EXPECTED_BUILD_CHECK_NAME
     )
 
-    flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
+    flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
+        copr_build_pr
+    )
     url = get_copr_build_info_url(1)
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -895,7 +907,9 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build_pr
         EXPECTED_TESTING_FARM_CHECK_NAME
     )
 
-    flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
+    flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
+        copr_build_pr
+    )
     url = get_copr_build_info_url(1)
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -951,7 +965,9 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_bui
         "was_last_packit_comment_with_congratulation"
     ).and_return(True)
 
-    flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
+    flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
+        copr_build_pr
+    )
     copr_build_pr.should_call("set_status").with_args("success").once()
     copr_build_pr.should_receive("set_end_time").once()
     url = get_copr_build_info_url(1)
@@ -996,7 +1012,9 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
         pc_koji_build_pr
     )
 
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").and_return(koji_build_pr)
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").and_return(
+        koji_build_pr
+    )
     url = get_koji_build_info_url(1)
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -1034,7 +1052,7 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
 
 
 def test_koji_build_start_build_not_found(koji_build_scratch_start):
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").and_return(None)
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").and_return(None)
 
     # check if packit-service set correct PR status
     flexmock(StatusReporter).should_receive("report").never()
@@ -1056,7 +1074,9 @@ def test_koji_build_end(koji_build_scratch_end, pc_koji_build_pr, koji_build_pr)
         pc_koji_build_pr
     )
 
-    flexmock(KojiBuildModel).should_receive("get_by_build_id").and_return(koji_build_pr)
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").and_return(
+        koji_build_pr
+    )
     url = get_koji_build_info_url(1)
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -1100,7 +1120,7 @@ def test_srpm_build_end(srpm_build_end, pc_build_pr, srpm_build_model):
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
     )
-    flexmock(CoprBuildModel).should_receive("get_all_by_build_id").and_return(
+    flexmock(CoprBuildTargetModel).should_receive("get_all_by_build_id").and_return(
         [
             flexmock(target="fedora-33-x86_64")
             .should_receive("set_status")
@@ -1162,7 +1182,7 @@ def test_srpm_build_end_failure(srpm_build_end, pc_build_pr, srpm_build_model):
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
     )
-    flexmock(CoprBuildModel).should_receive("get_all_by_build_id").and_return(
+    flexmock(CoprBuildTargetModel).should_receive("get_all_by_build_id").and_return(
         [flexmock(target="fedora-33-x86_64")]
     )
     (
@@ -1219,7 +1239,7 @@ def test_srpm_build_start(srpm_build_start, pc_build_pr, srpm_build_model):
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
     )
-    flexmock(CoprBuildModel).should_receive("get_all_by_build_id").and_return(
+    flexmock(CoprBuildTargetModel).should_receive("get_all_by_build_id").and_return(
         [flexmock(target="fedora-33-x86_64")]
     )
     flexmock(Pushgateway).should_receive("push").once().and_return()

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -26,10 +26,10 @@ from packit_service.models import (
     PullRequestModel,
     JobTriggerModelType,
     JobTriggerModel,
-    TFTTestRunModel,
+    TFTTestRunTargetModel,
     TestingFarmResult,
     PipelineModel,
-    CoprBuildModel,
+    CoprBuildTargetModel,
 )
 from packit_service.service.db_triggers import AddPullRequestDbTrigger
 from packit_service.worker.build import copr_build
@@ -889,7 +889,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
     tft_test_run_model = flexmock(id=5)
     run_model = flexmock()
     flexmock(PipelineModel).should_receive("create").and_return(run_model)
-    flexmock(TFTTestRunModel).should_receive("create").with_args(
+    flexmock(TFTTestRunTargetModel).should_receive("create").with_args(
         pipeline_id=pipeline_id,
         commit_sha="12345",
         status=TestingFarmResult.new,
@@ -1151,7 +1151,7 @@ def test_rebuild_failed(
     flexmock(comment).should_receive("add_reaction").with_args("+1").once()
     flexmock(copr_build).should_receive("get_valid_build_targets").and_return(set())
 
-    model = flexmock(CoprBuildModel, status="failed", target="target")
+    model = flexmock(CoprBuildTargetModel, status="failed", target="target")
     flexmock(model).should_receive("get_all_by").and_return(flexmock())
     flexmock(AbstractForgeIndependentEvent).should_receive(
         "get_all_build_failed_targets"
@@ -1224,7 +1224,7 @@ def test_retest_failed(
         flexmock(status=PG_BUILD_STATUS_SUCCESS)
     )
 
-    model = flexmock(TFTTestRunModel, status="failed", target="tf_target")
+    model = flexmock(TFTTestRunTargetModel, status="failed", target="tf_target")
     flexmock(model).should_receive("get_all_by_commit_target").and_return(flexmock())
     flexmock(AbstractForgeIndependentEvent).should_receive(
         "get_all_tf_failed_targets"

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -28,7 +28,7 @@ from packit_service.models import (
     JobTriggerModel,
     TFTTestRunModel,
     TestingFarmResult,
-    RunModel,
+    PipelineModel,
     CoprBuildModel,
 )
 from packit_service.service.db_triggers import AddPullRequestDbTrigger
@@ -888,7 +888,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
 
     tft_test_run_model = flexmock(id=5)
     run_model = flexmock()
-    flexmock(RunModel).should_receive("create").and_return(run_model)
+    flexmock(PipelineModel).should_receive("create").and_return(run_model)
     flexmock(TFTTestRunModel).should_receive("create").with_args(
         pipeline_id=pipeline_id,
         commit_sha="12345",

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -34,7 +34,7 @@ from packit.exceptions import FailedCreateSRPM, PackitCoprSettingsException
 from packit_service import sentry_integration
 from packit_service.config import ServiceConfig, Deployment
 from packit_service.models import (
-    CoprBuildModel,
+    CoprBuildTargetModel,
     SRPMBuildModel,
     JobTriggerModel,
     JobTriggerModelType,
@@ -207,7 +207,7 @@ def test_copr_build_check_names(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -347,7 +347,7 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -473,7 +473,7 @@ def test_copr_build_check_names_multiple_jobs(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -575,7 +575,7 @@ def test_copr_build_check_names_custom_owner(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -663,7 +663,7 @@ def test_copr_build_success_set_test_check(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
@@ -743,7 +743,7 @@ def test_copr_build_for_branch(branch_push_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PushGitHubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -825,7 +825,7 @@ def test_copr_build_for_branch_failed(branch_push_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PushGitHubEvent).should_receive("db_trigger").and_raise(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_raise(
@@ -906,7 +906,7 @@ def test_copr_build_for_release(release_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
@@ -974,7 +974,7 @@ def test_copr_build_success(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -1075,7 +1075,7 @@ def test_copr_build_fails_in_packit(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
 
     flexmock(PackitAPI).should_receive("create_srpm").and_raise(
@@ -1149,7 +1149,7 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
         )
     )
 
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
     flexmock(GithubProject).should_receive("get_pr").with_args(342).and_return(
@@ -1266,7 +1266,7 @@ def test_copr_build_no_targets(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -1362,7 +1362,7 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(MergeRequestGitlabEvent).should_receive("db_trigger").and_return(
         flexmock()
     )
@@ -1464,7 +1464,7 @@ def test_copr_build_success_set_test_check_gitlab(gitlab_mr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
@@ -1543,7 +1543,7 @@ def test_copr_build_for_branch_gitlab(branch_push_event_gitlab):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PushGitHubEvent).should_receive("db_trigger").and_return(flexmock())
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -1619,7 +1619,7 @@ def test_copr_build_success_gitlab(gitlab_mr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(MergeRequestGitlabEvent).should_receive("db_trigger").and_return(
         flexmock()
     )
@@ -1720,7 +1720,7 @@ def test_copr_build_fails_in_packit_gitlab(gitlab_mr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
 
     flexmock(PackitAPI).should_receive("create_srpm").and_raise(
@@ -1783,7 +1783,7 @@ def test_copr_build_success_gitlab_comment(gitlab_mr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(MergeRequestGitlabEvent).should_receive("db_trigger").and_return(
         flexmock()
     )
@@ -1871,7 +1871,7 @@ def test_copr_build_no_targets_gitlab(gitlab_mr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(MergeRequestGitlabEvent).should_receive("db_trigger").and_return(
         flexmock()
     )
@@ -1955,7 +1955,7 @@ def test_copr_build_targets_override(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
 
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
@@ -2017,9 +2017,9 @@ def test_run_copr_build_from_source_script(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(CoprBuildModel).should_receive("create").and_return(flexmock(id=1)).times(
-        4
-    )
+    flexmock(CoprBuildTargetModel).should_receive("create").and_return(
+        flexmock(id=1)
+    ).times(4)
     flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
 
     # copr build

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -17,10 +17,10 @@ from ogr.services.pagure import PagureProject
 from packit_service.config import ServiceConfig, PackageConfigGetter
 from packit_service.constants import KojiBuildState, KojiTaskState
 from packit_service.models import (
-    CoprBuildModel,
-    KojiBuildModel,
+    CoprBuildTargetModel,
+    KojiBuildTargetModel,
     TestingFarmResult,
-    TFTTestRunModel,
+    TFTTestRunTargetModel,
     AllowlistStatus,
     JobTriggerModel,
     GitBranchModel,
@@ -745,7 +745,7 @@ class TestEvents:
         flexmock(TestingFarmJobHelper).should_receive("get_request_details").with_args(
             request_id
         ).and_return(testing_farm_results)
-        flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
+        flexmock(TFTTestRunTargetModel).should_receive("get_by_pipeline_id").and_return(
             flexmock(
                 job_trigger=flexmock(),
                 data={"base_project_url": "https://github.com/packit/packit"},
@@ -778,7 +778,7 @@ class TestEvents:
         flexmock(TestingFarmJobHelper).should_receive("get_request_details").with_args(
             request_id
         ).and_return(testing_farm_results_error)
-        flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
+        flexmock(TFTTestRunTargetModel).should_receive("get_by_pipeline_id").and_return(
             flexmock(
                 job_trigger=flexmock(),
                 data={"base_project_url": "https://github.com/packit/packit"},
@@ -807,7 +807,7 @@ class TestEvents:
     def test_parse_copr_build_event_start(
         self, copr_build_results_start, copr_build_pr
     ):
-        flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(
+        flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
             copr_build_pr
         )
 
@@ -848,7 +848,7 @@ class TestEvents:
         assert event_object.package_config
 
     def test_parse_copr_build_event_end(self, copr_build_results_end, copr_build_pr):
-        flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(
+        flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
             copr_build_pr
         )
 
@@ -894,7 +894,7 @@ class TestEvents:
     def test_parse_koji_build_scratch_event_start(
         self, koji_build_scratch_start, koji_build_pr
     ):
-        flexmock(KojiBuildModel).should_receive("get_by_build_id").and_return(
+        flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").and_return(
             koji_build_pr
         )
 
@@ -911,7 +911,7 @@ class TestEvents:
     def test_parse_koji_build_scratch_event_end(
         self, koji_build_scratch_end, koji_build_pr
     ):
-        flexmock(KojiBuildModel).should_receive("get_by_build_id").and_return(
+        flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").and_return(
             koji_build_pr
         )
 
@@ -1261,7 +1261,7 @@ class TestEvents:
         flexmock(TestingFarmJobHelper).should_receive("get_request_details").with_args(
             request_id
         ).and_return(testing_farm_results)
-        flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").with_args(
+        flexmock(TFTTestRunTargetModel).should_receive("get_by_pipeline_id").with_args(
             request_id
         ).and_return(flexmock(data={"base_project_url": "abc"}, commit_sha="12345"))
         event_object = Parser.parse_event(testing_farm_notification)
@@ -1289,7 +1289,7 @@ class TestEvents:
         flexmock(TestingFarmJobHelper).should_receive("get_request_details").and_return(
             testing_farm_results
         )
-        flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
+        flexmock(TFTTestRunTargetModel).should_receive("get_by_pipeline_id").and_return(
             flexmock(data={"base_project_url": "abc"}, commit_sha="12345")
         )
         event_object = Parser.parse_event(testing_farm_notification)
@@ -1576,7 +1576,7 @@ class TestCentOSEventParser:
     def test_parse_copr_build_event_start(
         self, copr_build_results_start, copr_build_centos_pr
     ):
-        flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(
+        flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
             copr_build_centos_pr
         )
 
@@ -1628,7 +1628,7 @@ class TestCentOSEventParser:
     def test_parse_copr_build_event_end(
         self, copr_build_results_end, copr_build_centos_pr
     ):
-        flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(
+        flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
             copr_build_centos_pr
         )
 

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -21,7 +21,7 @@ from packit_service import sentry_integration
 from packit_service.config import ServiceConfig
 from packit_service.models import (
     SRPMBuildModel,
-    KojiBuildModel,
+    KojiBuildTargetModel,
     JobTriggerModel,
     JobTriggerModelType,
 )
@@ -151,7 +151,7 @@ def test_koji_build_check_names(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(KojiBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(KojiBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     # koji build
@@ -225,7 +225,7 @@ def test_koji_build_failed_kerberos(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(KojiBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(KojiBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     flexmock(PackitAPI).should_receive("init_kerberos_ticket").and_raise(
@@ -300,7 +300,7 @@ def test_koji_build_target_not_supported(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(KojiBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(KojiBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     response = helper.run_koji_build()
@@ -356,7 +356,7 @@ def test_koji_build_with_multiple_targets(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(KojiBuildModel).should_receive("create").and_return(
+    flexmock(KojiBuildTargetModel).should_receive("create").and_return(
         flexmock(id=1)
     ).and_return(flexmock(id=2))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
@@ -438,7 +438,7 @@ def test_koji_build_failed(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(KojiBuildModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(KojiBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     # koji build
@@ -506,7 +506,7 @@ def test_koji_build_failed_srpm(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(KojiBuildModel).should_receive("create").never()
+    flexmock(KojiBuildTargetModel).should_receive("create").never()
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
 
     result = helper.run_koji_build()
@@ -560,7 +560,7 @@ def test_koji_build_targets_override(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(KojiBuildModel).should_receive("create").and_return(
+    flexmock(KojiBuildTargetModel).should_receive("create").and_return(
         flexmock(id=1)
     ).and_return(flexmock(id=2))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -10,7 +10,7 @@ from packit.local_project import LocalProject
 
 import packit_service.service.urls as urls
 from packit_service.config import PackageConfigGetter
-from packit_service.models import TFTTestRunModel
+from packit_service.models import TFTTestRunTargetModel
 
 # These names are definitely not nice, still they help with making classes
 # whose names start with Testing* or Test* to become invisible for pytest,
@@ -132,7 +132,7 @@ def test_testing_farm_response(
         "some url"
     ).and_return().once()
 
-    flexmock(TFTTestRunModel).should_receive("get_by_pipeline_id").and_return(
+    flexmock(TFTTestRunTargetModel).should_receive("get_by_pipeline_id").and_return(
         tft_test_run_model
     )
     flexmock(JobTriggerModel).should_receive("get_or_create").and_return(

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -10,7 +10,7 @@ import pytest
 from flexmock import flexmock
 
 from packit_service.models import (
-    CoprBuildModel,
+    CoprBuildTargetModel,
     JobTriggerModelType,
     SRPMBuildModel,
 )
@@ -85,7 +85,9 @@ def test_get_logs(client):
     copr_build_mock.should_receive("get_project").and_return(project_mock)
     copr_build_mock.should_receive("get_srpm_build").and_return(srpm_build_mock)
 
-    flexmock(CoprBuildModel).should_receive("get_by_id").and_return(copr_build_mock)
+    flexmock(CoprBuildTargetModel).should_receive("get_by_id").and_return(
+        copr_build_mock
+    )
 
     logs_url = get_copr_build_info_url(1)
     assert logs_url == "https://localhost/results/copr-builds/1"

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -18,7 +18,7 @@ import pytest
 from ogr import GithubService, GitlabService, PagureService
 from packit_service.config import ServiceConfig
 from packit_service.models import (
-    CoprBuildModel,
+    CoprBuildTargetModel,
     JobTriggerModel,
     get_sa_session,
     SRPMBuildModel,
@@ -30,8 +30,8 @@ from packit_service.models import (
     IssueModel,
     PipelineModel,
     JobTriggerModelType,
-    KojiBuildModel,
-    TFTTestRunModel,
+    KojiBuildTargetModel,
+    TFTTestRunTargetModel,
     TestingFarmResult,
     InstallationModel,
     BugzillaModel,
@@ -155,9 +155,9 @@ def clean_db():
         session.query(PipelineModel).delete()
         session.query(JobTriggerModel).delete()
 
-        session.query(TFTTestRunModel).delete()
-        session.query(CoprBuildModel).delete()
-        session.query(KojiBuildModel).delete()
+        session.query(TFTTestRunTargetModel).delete()
+        session.query(CoprBuildTargetModel).delete()
+        session.query(KojiBuildTargetModel).delete()
         session.query(SRPMBuildModel).delete()
 
         session.query(GitBranchModel).delete()
@@ -342,7 +342,7 @@ def an_issue_model():
 @pytest.fixture()
 def a_copr_build_for_pr(srpm_build_model_with_new_run_for_pr):
     _, run_model = srpm_build_model_with_new_run_for_pr
-    copr_build_model = CoprBuildModel.create(
+    copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
         project_name=SampleValues.project,
@@ -362,7 +362,7 @@ def a_copr_build_for_pr(srpm_build_model_with_new_run_for_pr):
 @pytest.fixture()
 def a_copr_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
     _, run_model = srpm_build_model_with_new_run_for_branch
-    copr_build_model = CoprBuildModel.create(
+    copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
         project_name=SampleValues.project,
@@ -381,7 +381,7 @@ def a_copr_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
 @pytest.fixture()
 def a_copr_build_for_release(srpm_build_model_with_new_run_for_release):
     _, run_model = srpm_build_model_with_new_run_for_release
-    copr_build_model = CoprBuildModel.create(
+    copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
         project_name=SampleValues.project,
@@ -400,7 +400,7 @@ def a_copr_build_for_release(srpm_build_model_with_new_run_for_release):
 @pytest.fixture()
 def a_copr_build_waiting_for_srpm(srpm_build_in_copr_model):
     _, run_model = srpm_build_in_copr_model
-    copr_build_model = CoprBuildModel.create(
+    copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
         project_name=SampleValues.project,
@@ -431,7 +431,7 @@ def multiple_copr_builds(pr_model, different_pr_model):
 
     yield [
         # Two chroots for one run model
-        CoprBuildModel.create(
+        CoprBuildTargetModel.create(
             build_id=SampleValues.build_id,
             commit_sha=SampleValues.ref,
             project_name=SampleValues.project,
@@ -441,7 +441,7 @@ def multiple_copr_builds(pr_model, different_pr_model):
             status=SampleValues.status_success,
             run_model=run_model_for_pr,
         ),
-        CoprBuildModel.create(
+        CoprBuildTargetModel.create(
             build_id=SampleValues.build_id,
             commit_sha=SampleValues.ref,
             project_name=SampleValues.project,
@@ -452,7 +452,7 @@ def multiple_copr_builds(pr_model, different_pr_model):
             run_model=run_model_for_pr,
         ),
         # Same PR, same ref, but different run model
-        CoprBuildModel.create(
+        CoprBuildTargetModel.create(
             build_id=SampleValues.different_build_id,
             commit_sha=SampleValues.ref,
             project_name=SampleValues.project,
@@ -463,7 +463,7 @@ def multiple_copr_builds(pr_model, different_pr_model):
             run_model=run_model_for_same_pr,
         ),
         # Different PR
-        CoprBuildModel.create(
+        CoprBuildTargetModel.create(
             build_id=SampleValues.another_different_build_id,
             commit_sha=SampleValues.different_ref,
             project_name=SampleValues.different_project_name,
@@ -494,7 +494,7 @@ def too_many_copr_builds(pr_model, different_pr_model):
 
         builds_list += [
             # The following two are similar, except for target, status
-            CoprBuildModel.create(
+            CoprBuildTargetModel.create(
                 build_id=SampleValues.build_id + str(i),
                 commit_sha=SampleValues.ref,
                 project_name=SampleValues.project,
@@ -504,7 +504,7 @@ def too_many_copr_builds(pr_model, different_pr_model):
                 status=SampleValues.status_success,
                 run_model=run_model_for_pr,
             ),
-            CoprBuildModel.create(
+            CoprBuildTargetModel.create(
                 build_id=SampleValues.build_id + str(i),
                 commit_sha=SampleValues.ref,
                 project_name=SampleValues.project,
@@ -515,7 +515,7 @@ def too_many_copr_builds(pr_model, different_pr_model):
                 run_model=run_model_for_pr,
             ),
             # Same PR, different run model
-            CoprBuildModel.create(
+            CoprBuildTargetModel.create(
                 build_id=SampleValues.different_build_id + str(i),
                 commit_sha=SampleValues.different_commit_sha,
                 project_name=SampleValues.different_project_name,
@@ -526,7 +526,7 @@ def too_many_copr_builds(pr_model, different_pr_model):
                 run_model=run_model_for_same_pr,
             ),
             # Different PR:
-            CoprBuildModel.create(
+            CoprBuildTargetModel.create(
                 build_id=SampleValues.different_build_id + str(i),
                 commit_sha=SampleValues.different_commit_sha,
                 project_name=SampleValues.different_project_name,
@@ -552,7 +552,7 @@ def copr_builds_with_different_triggers(
 
     yield [
         # pull request trigger
-        CoprBuildModel.create(
+        CoprBuildTargetModel.create(
             build_id=SampleValues.build_id,
             commit_sha=SampleValues.ref,
             project_name=SampleValues.project,
@@ -563,7 +563,7 @@ def copr_builds_with_different_triggers(
             run_model=run_model_for_pr,
         ),
         # branch push trigger
-        CoprBuildModel.create(
+        CoprBuildTargetModel.create(
             build_id=SampleValues.different_build_id,
             commit_sha=SampleValues.ref,
             project_name=SampleValues.project,
@@ -574,7 +574,7 @@ def copr_builds_with_different_triggers(
             run_model=run_model_for_branch,
         ),
         # release trigger
-        CoprBuildModel.create(
+        CoprBuildTargetModel.create(
             build_id=SampleValues.another_different_build_id,
             commit_sha=SampleValues.ref,
             project_name=SampleValues.project,
@@ -590,7 +590,7 @@ def copr_builds_with_different_triggers(
 @pytest.fixture()
 def a_koji_build_for_pr(srpm_build_model_with_new_run_for_pr):
     _, run_model = srpm_build_model_with_new_run_for_pr
-    koji_build_model = KojiBuildModel.create(
+    koji_build_model = KojiBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
         web_url=SampleValues.koji_web_url,
@@ -608,7 +608,7 @@ def a_koji_build_for_pr(srpm_build_model_with_new_run_for_pr):
 def a_koji_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
     _, run_model = srpm_build_model_with_new_run_for_branch
 
-    yield KojiBuildModel.create(
+    yield KojiBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
         web_url=SampleValues.koji_web_url,
@@ -622,7 +622,7 @@ def a_koji_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
 def a_koji_build_for_release(srpm_build_model_with_new_run_for_release):
     _, run_model = srpm_build_model_with_new_run_for_release
 
-    yield KojiBuildModel.create(
+    yield KojiBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
         web_url=SampleValues.koji_web_url,
@@ -646,7 +646,7 @@ def multiple_koji_builds(pr_model, different_pr_model):
 
     yield [
         # Two builds for same run
-        KojiBuildModel.create(
+        KojiBuildTargetModel.create(
             build_id=SampleValues.build_id,
             commit_sha=SampleValues.commit_sha,
             web_url=SampleValues.koji_web_url,
@@ -654,7 +654,7 @@ def multiple_koji_builds(pr_model, different_pr_model):
             status=SampleValues.status_pending,
             run_model=run_model_for_pr,
         ),
-        KojiBuildModel.create(
+        KojiBuildTargetModel.create(
             build_id=SampleValues.different_build_id,
             commit_sha=SampleValues.commit_sha,
             web_url=SampleValues.koji_web_url,
@@ -663,7 +663,7 @@ def multiple_koji_builds(pr_model, different_pr_model):
             run_model=run_model_for_pr,
         ),
         # Same PR, different run
-        KojiBuildModel.create(
+        KojiBuildTargetModel.create(
             build_id=SampleValues.different_build_id,
             commit_sha=SampleValues.commit_sha,
             web_url=SampleValues.koji_web_url,
@@ -672,7 +672,7 @@ def multiple_koji_builds(pr_model, different_pr_model):
             run_model=run_model_for_same_pr,
         ),
         # Completely different build
-        KojiBuildModel.create(
+        KojiBuildTargetModel.create(
             build_id=SampleValues.another_different_build_id,
             commit_sha=SampleValues.different_commit_sha,
             web_url=SampleValues.koji_web_url,
@@ -686,7 +686,7 @@ def multiple_koji_builds(pr_model, different_pr_model):
 @pytest.fixture()
 def a_new_test_run_pr(srpm_build_model_with_new_run_for_pr, a_copr_build_for_pr):
     _, run_model = srpm_build_model_with_new_run_for_pr
-    yield TFTTestRunModel.create(
+    yield TFTTestRunTargetModel.create(
         pipeline_id=SampleValues.pipeline_id,
         commit_sha=SampleValues.commit_sha,
         web_url=SampleValues.testing_farm_url,
@@ -701,7 +701,7 @@ def a_new_test_run_branch_push(
     srpm_build_model_with_new_run_for_branch, a_copr_build_for_branch_push
 ):
     _, run_model = srpm_build_model_with_new_run_for_branch
-    yield TFTTestRunModel.create(
+    yield TFTTestRunTargetModel.create(
         pipeline_id=SampleValues.pipeline_id,
         commit_sha=SampleValues.commit_sha,
         web_url=SampleValues.testing_farm_url,
@@ -723,7 +723,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
         trigger_model=different_pr_model, commit_sha=SampleValues.commit_sha
     )
 
-    CoprBuildModel.create(
+    CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.ref,
         project_name=SampleValues.project,
@@ -735,7 +735,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
     )
 
     # Same PR, same ref, but different run model
-    CoprBuildModel.create(
+    CoprBuildTargetModel.create(
         build_id=SampleValues.different_build_id,
         commit_sha=SampleValues.ref,
         project_name=SampleValues.project,
@@ -747,7 +747,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
     )
 
     # Different PR
-    CoprBuildModel.create(
+    CoprBuildTargetModel.create(
         build_id=SampleValues.another_different_build_id,
         commit_sha=SampleValues.different_ref,
         project_name=SampleValues.different_project_name,
@@ -759,7 +759,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
     )
 
     yield [
-        TFTTestRunModel.create(
+        TFTTestRunTargetModel.create(
             pipeline_id=SampleValues.pipeline_id,
             commit_sha=SampleValues.commit_sha,
             web_url=SampleValues.testing_farm_url,
@@ -768,7 +768,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
             run_model=run_model_for_pr,
         ),
         # Same commit_sha but different chroot and pipeline_id
-        TFTTestRunModel.create(
+        TFTTestRunTargetModel.create(
             pipeline_id=SampleValues.different_pipeline_id,
             commit_sha=SampleValues.commit_sha,
             web_url=SampleValues.testing_farm_url,
@@ -777,7 +777,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
             run_model=run_model_for_pr,
         ),
         # Same PR, different run model
-        TFTTestRunModel.create(
+        TFTTestRunTargetModel.create(
             pipeline_id=SampleValues.different_pipeline_id,
             commit_sha=SampleValues.commit_sha,
             web_url=SampleValues.testing_farm_url,
@@ -786,7 +786,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
             run_model=run_model_for_same_pr,
         ),
         # Completely different build
-        TFTTestRunModel.create(
+        TFTTestRunTargetModel.create(
             pipeline_id=SampleValues.another_different_pipeline_id,
             commit_sha=SampleValues.different_commit_sha,
             web_url=SampleValues.testing_farm_url,
@@ -1658,7 +1658,7 @@ def few_runs(pr_model, different_pr_model):
     )
 
     for target in (SampleValues.target, SampleValues.different_target):
-        copr_build = CoprBuildModel.create(
+        copr_build = CoprBuildTargetModel.create(
             build_id=SampleValues.build_id,
             commit_sha=SampleValues.ref,
             project_name=SampleValues.project,
@@ -1669,7 +1669,7 @@ def few_runs(pr_model, different_pr_model):
             run_model=run_model_for_pr,
         )
 
-        TFTTestRunModel.create(
+        TFTTestRunTargetModel.create(
             pipeline_id=SampleValues.pipeline_id,
             commit_sha=SampleValues.commit_sha,
             web_url=SampleValues.testing_farm_url,
@@ -1684,7 +1684,7 @@ def few_runs(pr_model, different_pr_model):
 
     runs = []
     for target in (SampleValues.target, SampleValues.different_target):
-        copr_build = CoprBuildModel.create(
+        copr_build = CoprBuildTargetModel.create(
             build_id=SampleValues.build_id,
             commit_sha=SampleValues.ref,
             project_name=SampleValues.project,
@@ -1696,7 +1696,7 @@ def few_runs(pr_model, different_pr_model):
         )
         runs.append(copr_build.runs[0])
 
-        TFTTestRunModel.create(
+        TFTTestRunTargetModel.create(
             pipeline_id=SampleValues.pipeline_id,
             commit_sha=SampleValues.commit_sha,
             web_url=SampleValues.testing_farm_url,
@@ -1706,7 +1706,7 @@ def few_runs(pr_model, different_pr_model):
         )
 
     for i, target in enumerate((SampleValues.target, SampleValues.different_target)):
-        TFTTestRunModel.create(
+        TFTTestRunTargetModel.create(
             pipeline_id=SampleValues.pipeline_id,
             commit_sha=SampleValues.commit_sha,
             web_url=SampleValues.testing_farm_url,
@@ -1727,7 +1727,7 @@ def runs_without_build(pr_model, branch_model):
         type=branch_model.job_trigger_model_type, trigger_id=branch_model.id
     )
 
-    TFTTestRunModel.create(
+    TFTTestRunTargetModel.create(
         pipeline_id=SampleValues.pipeline_id,
         commit_sha=SampleValues.commit_sha,
         web_url=SampleValues.testing_farm_url,
@@ -1735,7 +1735,7 @@ def runs_without_build(pr_model, branch_model):
         status=TestingFarmResult.new,
         run_model=run_model_for_pr_only_test,
     ),
-    TFTTestRunModel.create(
+    TFTTestRunTargetModel.create(
         pipeline_id=SampleValues.pipeline_id,
         commit_sha=SampleValues.commit_sha,
         web_url=SampleValues.testing_farm_url,

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -33,7 +33,7 @@ from packit_service.models import (
     KojiBuildTargetModel,
     TFTTestRunTargetModel,
     TestingFarmResult,
-    InstallationModel,
+    GithubInstallationModel,
     BugzillaModel,
     ProjectAuthenticationIssueModel,
 )
@@ -149,7 +149,7 @@ def clean_db():
     with get_sa_session() as session:
 
         session.query(AllowlistModel).delete()
-        session.query(InstallationModel).delete()
+        session.query(GithubInstallationModel).delete()
         session.query(BugzillaModel).delete()
 
         session.query(PipelineModel).delete()
@@ -858,12 +858,12 @@ def installation_events():
 @pytest.fixture()
 def multiple_installation_entries(installation_events):
     with get_sa_session() as session:
-        session.query(InstallationModel).delete()
+        session.query(GithubInstallationModel).delete()
         yield [
-            InstallationModel.create(
+            GithubInstallationModel.create(
                 event=installation_events[0],
             ),
-            InstallationModel.create(
+            GithubInstallationModel.create(
                 event=installation_events[1],
             ),
         ]

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -28,7 +28,7 @@ from packit_service.models import (
     GitBranchModel,
     ProjectReleaseModel,
     IssueModel,
-    RunModel,
+    PipelineModel,
     JobTriggerModelType,
     KojiBuildModel,
     TFTTestRunModel,
@@ -152,7 +152,7 @@ def clean_db():
         session.query(InstallationModel).delete()
         session.query(BugzillaModel).delete()
 
-        session.query(RunModel).delete()
+        session.query(PipelineModel).delete()
         session.query(JobTriggerModel).delete()
 
         session.query(TFTTestRunModel).delete()
@@ -256,7 +256,7 @@ def pr_trigger_model(pr_model):
 
 @pytest.fixture()
 def different_pr_trigger_model(different_pr_model):
-    yield RunModel.get_or_create(
+    yield PipelineModel.get_or_create(
         type=JobTriggerModelType.pull_request, trigger_id=different_pr_model.id
     )
 
@@ -1720,10 +1720,10 @@ def few_runs(pr_model, different_pr_model):
 
 @pytest.fixture()
 def runs_without_build(pr_model, branch_model):
-    run_model_for_pr_only_test = RunModel.create(
+    run_model_for_pr_only_test = PipelineModel.create(
         type=pr_model.job_trigger_model_type, trigger_id=pr_model.id
     )
-    run_model_for_branch_only_test = RunModel.create(
+    run_model_for_branch_only_test = PipelineModel.create(
         type=branch_model.job_trigger_model_type, trigger_id=branch_model.id
     )
 

--- a/tests_requre/database/test_events.py
+++ b/tests_requre/database/test_events.py
@@ -10,8 +10,8 @@ from packit_service.models import (
     GitProjectModel,
     GitBranchModel,
     PullRequestModel,
-    CoprBuildModel,
-    TFTTestRunModel,
+    CoprBuildTargetModel,
+    TFTTestRunTargetModel,
 )
 from packit_service.worker.events import (
     ReleaseEvent,
@@ -447,7 +447,7 @@ def test_filter_failed_models_targets_copr(
     clean_before_and_after, multiple_copr_builds
 ):
     builds_list = list(
-        CoprBuildModel.get_all_by(
+        CoprBuildTargetModel.get_all_by(
             project_name=SampleValues.project,
             commit_sha=SampleValues.ref,
         )
@@ -474,7 +474,9 @@ def test_filter_failed_models_targets_tf(
     clean_before_and_after, multiple_new_test_runs
 ):
     test_list = list(
-        TFTTestRunModel.get_all_by_commit_target(commit_sha=SampleValues.commit_sha)
+        TFTTestRunTargetModel.get_all_by_commit_target(
+            commit_sha=SampleValues.commit_sha
+        )
     )
     assert len(test_list) == 3
 

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -10,7 +10,7 @@ from packit_service.models import (
     CoprBuildTargetModel,
     GitBranchModel,
     GitProjectModel,
-    InstallationModel,
+    GithubInstallationModel,
     JobTriggerModelType,
     KojiBuildTargetModel,
     ProjectAuthenticationIssueModel,
@@ -700,15 +700,15 @@ def test_project_property_for_koji_build(a_koji_build_for_pr):
 
 
 def test_get_installations(clean_before_and_after, multiple_installation_entries):
-    results = list(InstallationModel.get_all())
+    results = list(GithubInstallationModel.get_all())
     assert len(results) == 2
 
 
 def test_get_installation_by_account(
     clean_before_and_after, multiple_installation_entries
 ):
-    assert InstallationModel.get_by_account_login("teg").sender_login == "teg"
-    assert InstallationModel.get_by_account_login("Pac23").sender_login == "Pac23"
+    assert GithubInstallationModel.get_by_account_login("teg").sender_login == "teg"
+    assert GithubInstallationModel.get_by_account_login("Pac23").sender_login == "Pac23"
 
 
 def test_pr_get_copr_builds(

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -7,17 +7,17 @@ from sqlalchemy.exc import ProgrammingError
 
 from packit_service.models import (
     BugzillaModel,
-    CoprBuildModel,
+    CoprBuildTargetModel,
     GitBranchModel,
     GitProjectModel,
     InstallationModel,
     JobTriggerModelType,
-    KojiBuildModel,
+    KojiBuildTargetModel,
     ProjectAuthenticationIssueModel,
     ProjectReleaseModel,
     PullRequestModel,
     SRPMBuildModel,
-    TFTTestRunModel,
+    TFTTestRunTargetModel,
     TestingFarmResult,
     get_sa_session,
     PipelineModel,
@@ -100,7 +100,7 @@ def test_copr_build_get_branch(
 
 def test_get_merged_chroots(clean_before_and_after, too_many_copr_builds):
     # fetch 10 merged groups of builds
-    builds_list = list(CoprBuildModel.get_merged_chroots(10, 20))
+    builds_list = list(CoprBuildTargetModel.get_merged_chroots(10, 20))
     assert len(builds_list) == 10
     # two merged chroots so two statuses
     assert len(builds_list[0].status) == 2
@@ -120,21 +120,21 @@ def test_get_copr_build(clean_before_and_after, a_copr_build_for_pr):
     assert a_copr_build_for_pr.id
 
     # pass in a build_id and a target
-    b = CoprBuildModel.get_by_build_id(
+    b = CoprBuildTargetModel.get_by_build_id(
         a_copr_build_for_pr.build_id, SampleValues.target
     )
     assert b.id == a_copr_build_for_pr.id
     # let's make sure passing int works as well
-    b2 = CoprBuildModel.get_by_build_id(
+    b2 = CoprBuildTargetModel.get_by_build_id(
         int(a_copr_build_for_pr.build_id), SampleValues.target
     )
     assert b2.id == a_copr_build_for_pr.id
 
     # pass in a build_id and without a target
-    b3 = CoprBuildModel.get_by_build_id(a_copr_build_for_pr.build_id, None)
+    b3 = CoprBuildTargetModel.get_by_build_id(a_copr_build_for_pr.build_id, None)
     assert b3.commit_sha == a_copr_build_for_pr.commit_sha
 
-    b4 = CoprBuildModel.get_by_id(b.id)
+    b4 = CoprBuildTargetModel.get_by_id(b.id)
     assert b4.id == a_copr_build_for_pr.id
 
 
@@ -142,7 +142,7 @@ def test_copr_build_set_status(clean_before_and_after, a_copr_build_for_pr):
     assert a_copr_build_for_pr.status == "pending"
     a_copr_build_for_pr.set_status("awesome")
     assert a_copr_build_for_pr.status == "awesome"
-    b = CoprBuildModel.get_by_build_id(
+    b = CoprBuildTargetModel.get_by_build_id(
         a_copr_build_for_pr.build_id, SampleValues.target
     )
     assert b.status == "awesome"
@@ -152,7 +152,7 @@ def test_copr_build_set_build_logs_url(clean_before_and_after, a_copr_build_for_
     url = "https://copr.fp.o/logs/12456/build.log"
     a_copr_build_for_pr.set_build_logs_url(url)
     assert a_copr_build_for_pr.build_logs_url == url
-    b = CoprBuildModel.get_by_build_id(
+    b = CoprBuildTargetModel.get_by_build_id(
         a_copr_build_for_pr.build_id, SampleValues.target
     )
     assert b.build_logs_url == url
@@ -173,16 +173,16 @@ def test_create_koji_build(clean_before_and_after, a_koji_build_for_pr):
 
 def test_get_koji_build(clean_before_and_after, a_koji_build_for_pr):
     assert a_koji_build_for_pr.id
-    b = KojiBuildModel.get_by_build_id(
+    b = KojiBuildTargetModel.get_by_build_id(
         a_koji_build_for_pr.build_id, SampleValues.target
     )
     assert b.id == a_koji_build_for_pr.id
     # let's make sure passing int works as well
-    b = KojiBuildModel.get_by_build_id(
+    b = KojiBuildTargetModel.get_by_build_id(
         int(a_koji_build_for_pr.build_id), SampleValues.target
     )
     assert b.id == a_koji_build_for_pr.id
-    b2 = KojiBuildModel.get_by_id(b.id)
+    b2 = KojiBuildTargetModel.get_by_id(b.id)
     assert b2.id == a_koji_build_for_pr.id
 
 
@@ -190,7 +190,7 @@ def test_koji_build_set_status(clean_before_and_after, a_koji_build_for_pr):
     assert a_koji_build_for_pr.status == "pending"
     a_koji_build_for_pr.set_status("awesome")
     assert a_koji_build_for_pr.status == "awesome"
-    b = KojiBuildModel.get_by_build_id(
+    b = KojiBuildTargetModel.get_by_build_id(
         a_koji_build_for_pr.build_id, SampleValues.target
     )
     assert b.status == "awesome"
@@ -203,7 +203,7 @@ def test_koji_build_set_build_logs_url(clean_before_and_after, a_koji_build_for_
     )
     a_koji_build_for_pr.set_build_logs_url(url)
     assert a_koji_build_for_pr.build_logs_url == url
-    b = KojiBuildModel.get_by_build_id(
+    b = KojiBuildTargetModel.get_by_build_id(
         a_koji_build_for_pr.build_id, SampleValues.target
     )
     assert b.build_logs_url == url
@@ -274,7 +274,7 @@ def test_get_srpm_builds_in_give_range(
 
 
 def test_get_all_builds(clean_before_and_after, multiple_copr_builds):
-    builds_list = list(CoprBuildModel.get_all())
+    builds_list = list(CoprBuildTargetModel.get_all())
     assert len({builds_list[i].id for i in range(4)})
     # All builds has to have exactly one PipelineModel connected
     assert all(len(build.runs) == 1 for build in builds_list)
@@ -283,7 +283,7 @@ def test_get_all_builds(clean_before_and_after, multiple_copr_builds):
 
 
 def test_get_all_build_id(clean_before_and_after, multiple_copr_builds):
-    builds_list = list(CoprBuildModel.get_all_by_build_id(str(123456)))
+    builds_list = list(CoprBuildTargetModel.get_all_by_build_id(str(123456)))
     assert len(builds_list) == 2
     # both should have the same project_name
     assert builds_list[1].project_name == builds_list[0].project_name
@@ -293,17 +293,19 @@ def test_get_all_build_id(clean_before_and_after, multiple_copr_builds):
 # returns the first copr build with given build id and target
 def test_get_by_build_id(clean_before_and_after, multiple_copr_builds):
     # these are not iterable and thus should be accessible directly
-    build_a = CoprBuildModel.get_by_build_id(SampleValues.build_id, SampleValues.target)
+    build_a = CoprBuildTargetModel.get_by_build_id(
+        SampleValues.build_id, SampleValues.target
+    )
     assert build_a.project_name == "the-project-name"
     assert build_a.target == "fedora-42-x86_64"
 
-    build_b = CoprBuildModel.get_by_build_id(
+    build_b = CoprBuildTargetModel.get_by_build_id(
         SampleValues.build_id, SampleValues.different_target
     )
     assert build_b.project_name == "the-project-name"
     assert build_b.target == "fedora-43-x86_64"
 
-    build_c = CoprBuildModel.get_by_build_id(
+    build_c = CoprBuildTargetModel.get_by_build_id(
         SampleValues.another_different_build_id, SampleValues.target
     )
     assert build_c.project_name == "different-project-name"
@@ -313,7 +315,7 @@ def test_copr_get_all_by_owner_project_commit_target(
     clean_before_and_after, multiple_copr_builds
 ):
     builds_list = list(
-        CoprBuildModel.get_all_by(
+        CoprBuildTargetModel.get_all_by(
             owner=SampleValues.owner,
             project_name=SampleValues.project,
             target=SampleValues.target,
@@ -330,7 +332,7 @@ def test_copr_get_all_by_owner_project_commit_target(
 
     # test without target and owner
     builds_list_without_target = list(
-        CoprBuildModel.get_all_by(
+        CoprBuildTargetModel.get_all_by(
             project_name=SampleValues.project,
             commit_sha=SampleValues.ref,
         )
@@ -398,7 +400,7 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
     srpm_build_for_copr.set_logs("asd\nqwe\n")
     srpm_build_for_copr.set_status("success")
 
-    copr_build = CoprBuildModel.create(
+    copr_build = CoprBuildTargetModel.create(
         build_id="123456",
         commit_sha="687abc76d67d",
         project_name="SomeUser-hello-world-9",
@@ -408,7 +410,7 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
         status="pending",
         run_model=run_model_for_copr,
     )
-    koji_build = KojiBuildModel.create(
+    koji_build = KojiBuildTargetModel.create(
         build_id="987654",
         commit_sha="687abc76d67d",
         web_url="https://copr.something.somewhere/123456",
@@ -446,7 +448,7 @@ def test_tmt_test_run(clean_before_and_after, a_new_test_run_pr):
     assert a_new_test_run_pr.target == "fedora-42-x86_64"
     assert a_new_test_run_pr.status == TestingFarmResult.new
 
-    b = TFTTestRunModel.get_by_pipeline_id(a_new_test_run_pr.pipeline_id)
+    b = TFTTestRunTargetModel.get_by_pipeline_id(a_new_test_run_pr.pipeline_id)
     assert b
     assert b.id == a_new_test_run_pr.id
 
@@ -457,11 +459,11 @@ def test_tmt_test_multiple_runs(clean_before_and_after, multiple_new_test_runs):
     assert multiple_new_test_runs[1].pipeline_id == SampleValues.different_pipeline_id
 
     with get_sa_session() as session:
-        test_runs = session.query(TFTTestRunModel).all()
+        test_runs = session.query(TFTTestRunTargetModel).all()
         assert len(test_runs) == 4
-        # Separate PipelineModel for each TFTTestRunModel
+        # Separate PipelineModel for each TFTTestRunTargetModel
         assert len({m.runs[0] for m in multiple_new_test_runs}) == 4
-        # Exactly one PipelineModel for each TFTTestRunModel
+        # Exactly one PipelineModel for each TFTTestRunTargetModel
         assert all(len(m.runs) == 1 for m in multiple_new_test_runs)
         # Two JobTriggerModels:
         assert len({m.get_trigger_object() for m in multiple_new_test_runs}) == 2
@@ -472,7 +474,7 @@ def test_tmt_test_run_set_status(clean_before_and_after, a_new_test_run_pr):
     a_new_test_run_pr.set_status(TestingFarmResult.running)
     assert a_new_test_run_pr.status == TestingFarmResult.running
 
-    b = TFTTestRunModel.get_by_pipeline_id(a_new_test_run_pr.pipeline_id)
+    b = TFTTestRunTargetModel.get_by_pipeline_id(a_new_test_run_pr.pipeline_id)
     assert b
     assert b.status == TestingFarmResult.running
 
@@ -499,7 +501,7 @@ def test_tmt_test_run_set_web_url(
     clean_before_and_after, srpm_build_model_with_new_run_for_pr
 ):
     _, run_model = srpm_build_model_with_new_run_for_pr
-    test_run_model = TFTTestRunModel.create(
+    test_run_model = TFTTestRunTargetModel.create(
         pipeline_id="123456",
         commit_sha="687abc76d67d",
         target=SampleValues.target,
@@ -514,7 +516,7 @@ def test_tmt_test_run_set_web_url(
     test_run_model.set_web_url(new_url)
     assert test_run_model.web_url == new_url
 
-    test_run_for_pipeline_id = TFTTestRunModel.get_by_pipeline_id(
+    test_run_for_pipeline_id = TFTTestRunTargetModel.get_by_pipeline_id(
         test_run_model.pipeline_id
     )
     assert test_run_for_pipeline_id
@@ -525,7 +527,7 @@ def test_tmt_test_get_by_pipeline_id_pr(
     clean_before_and_after, pr_model, srpm_build_model_with_new_run_for_pr
 ):
     _, run_model = srpm_build_model_with_new_run_for_pr
-    test_run_model = TFTTestRunModel.create(
+    test_run_model = TFTTestRunTargetModel.create(
         pipeline_id="123456",
         commit_sha="687abc76d67d",
         target=SampleValues.target,
@@ -533,7 +535,7 @@ def test_tmt_test_get_by_pipeline_id_pr(
         run_model=run_model,
     )
 
-    test_run_for_pipeline_id = TFTTestRunModel.get_by_pipeline_id(
+    test_run_for_pipeline_id = TFTTestRunTargetModel.get_by_pipeline_id(
         test_run_model.pipeline_id
     )
     assert test_run_for_pipeline_id
@@ -542,7 +544,7 @@ def test_tmt_test_get_by_pipeline_id_pr(
 
 def test_tmt_test_get_range(clean_before_and_after, multiple_new_test_runs):
     assert multiple_new_test_runs
-    results = TFTTestRunModel.get_range(0, 10)
+    results = TFTTestRunTargetModel.get_range(0, 10)
     assert len(list(results)) == 4
 
 
@@ -553,7 +555,7 @@ def test_tmt_test_get_by_pipeline_id_branch_push(
     a_copr_build_for_branch_push,
 ):
     _, run_model = srpm_build_model_with_new_run_for_branch
-    test_run_model = TFTTestRunModel.create(
+    test_run_model = TFTTestRunTargetModel.create(
         pipeline_id="123456",
         commit_sha="687abc76d67d",
         target=SampleValues.target,
@@ -561,7 +563,7 @@ def test_tmt_test_get_by_pipeline_id_branch_push(
         run_model=run_model,
     )
 
-    test_run = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
+    test_run = TFTTestRunTargetModel.get_by_pipeline_id(test_run_model.pipeline_id)
     assert test_run
     assert test_run.get_trigger_object() == branch_model
 
@@ -573,7 +575,7 @@ def test_tmt_test_get_by_pipeline_id_release(
     a_copr_build_for_release,
 ):
     _, run_model = srpm_build_model_with_new_run_for_release
-    test_run_model = TFTTestRunModel.create(
+    test_run_model = TFTTestRunTargetModel.create(
         pipeline_id="123456",
         commit_sha="687abc76d67d",
         target=SampleValues.target,
@@ -581,7 +583,7 @@ def test_tmt_test_get_by_pipeline_id_release(
         run_model=run_model,
     )
 
-    test_run = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
+    test_run = TFTTestRunTargetModel.get_by_pipeline_id(test_run_model.pipeline_id)
     assert test_run
     assert test_run.get_trigger_object() == release_model
 
@@ -786,7 +788,7 @@ def test_merged_runs(clean_before_and_after, few_runs):
         assert len(merged_run.copr_build_id) == 2 * i
 
         for copr_build in map(
-            lambda ids: CoprBuildModel.get_by_id(ids[0]), merged_run.copr_build_id
+            lambda ids: CoprBuildTargetModel.get_by_id(ids[0]), merged_run.copr_build_id
         ):
             assert copr_build.get_srpm_build().id == srpm_build_id
 
@@ -804,7 +806,7 @@ def test_merged_chroots_on_tests_without_build(
 
 def test_tf_get_all_by_commit_target(clean_before_and_after, multiple_new_test_runs):
     test_list = list(
-        TFTTestRunModel.get_all_by_commit_target(
+        TFTTestRunTargetModel.get_all_by_commit_target(
             commit_sha=SampleValues.commit_sha, target=SampleValues.target
         )
     )
@@ -813,7 +815,7 @@ def test_tf_get_all_by_commit_target(clean_before_and_after, multiple_new_test_r
 
     # test without target
     test_list = list(
-        TFTTestRunModel.get_all_by_commit_target(
+        TFTTestRunTargetModel.get_all_by_commit_target(
             commit_sha=SampleValues.commit_sha,
         )
     )

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -20,7 +20,7 @@ from packit_service.models import (
     TFTTestRunModel,
     TestingFarmResult,
     get_sa_session,
-    RunModel,
+    PipelineModel,
 )
 from tests_requre.conftest import SampleValues
 
@@ -276,9 +276,9 @@ def test_get_srpm_builds_in_give_range(
 def test_get_all_builds(clean_before_and_after, multiple_copr_builds):
     builds_list = list(CoprBuildModel.get_all())
     assert len({builds_list[i].id for i in range(4)})
-    # All builds has to have exactly one RunModel connected
+    # All builds has to have exactly one PipelineModel connected
     assert all(len(build.runs) == 1 for build in builds_list)
-    # All builds has to have a different RunModel connected.
+    # All builds has to have a different PipelineModel connected.
     assert len({build.runs[0] for build in builds_list}) == 4
 
 
@@ -459,9 +459,9 @@ def test_tmt_test_multiple_runs(clean_before_and_after, multiple_new_test_runs):
     with get_sa_session() as session:
         test_runs = session.query(TFTTestRunModel).all()
         assert len(test_runs) == 4
-        # Separate RunModel for each TFTTestRunModel
+        # Separate PipelineModel for each TFTTestRunModel
         assert len({m.runs[0] for m in multiple_new_test_runs}) == 4
-        # Exactly one RunModel for each TFTTestRunModel
+        # Exactly one PipelineModel for each TFTTestRunModel
         assert all(len(m.runs) == 1 for m in multiple_new_test_runs)
         # Two JobTriggerModels:
         assert len({m.get_trigger_object() for m in multiple_new_test_runs}) == 2
@@ -776,7 +776,7 @@ def test_project_token_model(clean_before_and_after):
 
 def test_merged_runs(clean_before_and_after, few_runs):
     for i, run_id in enumerate(few_runs, 1):
-        merged_run = RunModel.get_merged_run(run_id)
+        merged_run = PipelineModel.get_merged_run(run_id)
         srpm_build_id = merged_run.srpm_build_id
 
         # for different_pr (i=1) there are Copr builds twice, since the second
@@ -796,7 +796,7 @@ def test_merged_runs(clean_before_and_after, few_runs):
 def test_merged_chroots_on_tests_without_build(
     clean_before_and_after, runs_without_build
 ):
-    result = list(RunModel.get_merged_chroots(0, 10))
+    result = list(PipelineModel.get_merged_chroots(0, 10))
     assert len(result) == 2
     for item in result:
         assert len(item.test_run_id[0]) == 1

--- a/tests_requre/database/test_tasks.py
+++ b/tests_requre/database/test_tasks.py
@@ -12,7 +12,7 @@ from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerTyp
 from packit.config.job_config import JobMetadataConfig
 from packit_service.constants import PG_BUILD_STATUS_SUCCESS
 from packit_service.models import (
-    CoprBuildModel,
+    CoprBuildTargetModel,
     SRPMBuildModel,
     PullRequestModel,
 )
@@ -61,7 +61,7 @@ def packit_build_752():
     )
     srpm_build.set_logs("asd\nqwe\n")
     srpm_build.set_status("success")
-    yield CoprBuildModel.create(
+    yield CoprBuildTargetModel.create(
         build_id=str(BUILD_ID),
         commit_sha="687abc76d67d",
         project_name="packit-service-packit-752",

--- a/tests_requre/service/test_api.py
+++ b/tests_requre/service/test_api.py
@@ -3,7 +3,7 @@
 
 from flask import url_for
 
-from packit_service.models import TestingFarmResult, RunModel
+from packit_service.models import TestingFarmResult, PipelineModel
 from packit_service.service.api.runs import process_runs
 from tests_requre.conftest import SampleValues
 
@@ -455,7 +455,7 @@ def test_meta(client, clean_before_and_after, a_copr_build_for_pr):
 
 
 def test_process_runs_without_build(clean_before_and_after, runs_without_build):
-    merged_runs = RunModel.get_merged_chroots(0, 10)
+    merged_runs = PipelineModel.get_merged_chroots(0, 10)
     result = process_runs(merged_runs)
     for item in result:
         assert not item["srpm"]


### PR DESCRIPTION
Summary of the changes:
 - Renamed `RunModel` to `PipelineModel`
 - Renamed `InstallationModel` to `GithubInstallationModel`
 - Renamed Koji, Copr and TF models, they now contain the word `Target` to emphasize that it's a single build/test run (to enable creation of group models, see comment in  #1327 )

Fixes #1326 

---
N/A
