### PR TITLE
Update Koji build states

### DIFF
--- a/packit_service/worker/events/koji.py
+++ b/packit_service/worker/events/koji.py
@@ -55,20 +55,6 @@ class AbstractKojiEvent(AbstractForgeIndependentEvent):
         return self._target
 
     @staticmethod
-    def get_koji_build_logs_url(
-        rpm_build_task_id: int,
-        koji_logs_url: str = "https://kojipkgs.fedoraproject.org",
-    ) -> str:
-        """
-        Constructs the log URL for the given Koji task.
-        You can redefine the Koji instance using the one defined in the service config.
-        """
-        return (
-            f"{koji_logs_url}//work/tasks/"
-            f"{rpm_build_task_id % 10000}/{rpm_build_task_id}/build.log"
-        )
-
-    @staticmethod
     def get_koji_rpm_build_web_url(
         rpm_build_task_id: int,
         koji_web_url: str = "https://koji.fedoraproject.org",
@@ -290,3 +276,18 @@ class KojiTaskEvent(AbstractKojiEvent):
         result["git_ref"] = self.git_ref
         result["identifier"] = self.identifier
         return result
+
+    @staticmethod
+    def get_koji_build_logs_url(
+        rpm_build_task_id: int,
+        koji_logs_url: str = "https://kojipkgs.fedoraproject.org",
+    ) -> str:
+        """
+        Constructs the log URL for the given Koji task.
+        You can redefine the Koji instance using the one defined in the service config.
+        TODO: this does not work for non-scratch builds
+        """
+        return (
+            f"{koji_logs_url}//work/tasks/"
+            f"{rpm_build_task_id % 10000}/{rpm_build_task_id}/build.log"
+        )

--- a/packit_service/worker/handlers/__init__.py
+++ b/packit_service/worker/handlers/__init__.py
@@ -30,7 +30,7 @@ from packit_service.worker.handlers.forges import (
 )
 from packit_service.worker.handlers.koji import (
     KojiBuildHandler,
-    KojiBuildReportHandler,
+    KojiTaskReportHandler,
 )
 from packit_service.worker.handlers.testing_farm import (
     TestingFarmHandler,
@@ -48,7 +48,7 @@ __all__ = [
     SyncFromDownstream.__name__,
     ProposeDownstreamHandler.__name__,
     KojiBuildHandler.__name__,
-    KojiBuildReportHandler.__name__,
+    KojiTaskReportHandler.__name__,
     TestingFarmHandler.__name__,
     TestingFarmResultsHandler.__name__,
 ]

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -220,6 +220,7 @@ class TaskName(str, enum.Enum):
     koji_build = "task.run_koji_build_handler"
     koji_build_report = "task.run_koji_build_report_handler"
     downstream_koji_build = "task.run_downstream_koji_build_handler"
+    downstream_koji_build_report = "task.run_downstream_koji_build_report_handler"
     # Fedora notification is ok for now
     # downstream_koji_build_report = "task.run_downstream_koji_build_report_handler"
     sync_from_downstream = "task.run_sync_from_downstream_handler"

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -143,7 +143,7 @@ class KojiBuildHandler(JobHandler):
 
 @configured_as(job_type=JobType.production_build)
 @reacts_to(event=KojiTaskEvent)
-class KojiBuildReportHandler(JobHandler):
+class KojiTaskReportHandler(JobHandler):
     task_name = TaskName.koji_build_report
 
     def __init__(

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -24,7 +24,7 @@ from packit_service.worker.handlers import (
     BugzillaHandler,
     CoprBuildEndHandler,
     CoprBuildStartHandler,
-    KojiBuildReportHandler,
+    KojiTaskReportHandler,
     SyncFromDownstream,
     CoprBuildHandler,
     GithubAppInstallationHandler,
@@ -195,6 +195,16 @@ def run_koji_build_handler(event: dict, package_config: dict, job_config: dict):
     return get_handlers_task_results(handler.run_job(), event)
 
 
+@celery_app.task(name=TaskName.koji_build_report, base=HandlerTaskWithRetry)
+def run_koji_build_report_handler(event: dict, package_config: dict, job_config: dict):
+    handler = KojiTaskReportHandler(
+        package_config=load_package_config(package_config),
+        job_config=load_job_config(job_config),
+        event=event,
+    )
+    return get_handlers_task_results(handler.run_job(), event)
+
+
 @celery_app.task(
     name=TaskName.sync_from_downstream, base=HandlerTaskWithRetry, queue="long-running"
 )
@@ -236,16 +246,6 @@ def run_bodhi_update(event: dict, package_config: dict, job_config: dict):
 @celery_app.task(name=TaskName.bugzilla, base=HandlerTaskWithRetry)
 def run_bugzilla_handler(event: dict, package_config: dict, job_config: dict):
     handler = BugzillaHandler(
-        package_config=load_package_config(package_config),
-        job_config=load_job_config(job_config),
-        event=event,
-    )
-    return get_handlers_task_results(handler.run_job(), event)
-
-
-@celery_app.task(name=TaskName.koji_build_report, base=HandlerTaskWithRetry)
-def run_koji_build_report_handler(event: dict, package_config: dict, job_config: dict):
-    handler = KojiBuildReportHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -36,6 +36,7 @@ from packit_service.worker.handlers import (
 from packit_service.worker.handlers.abstract import TaskName
 from packit_service.worker.handlers.bodhi import CreateBodhiUpdateHandler
 from packit_service.worker.handlers.distgit import DownstreamKojiBuildHandler
+from packit_service.worker.handlers.koji import KojiBuildReportHandler
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.result import TaskResults
 
@@ -224,6 +225,18 @@ def run_sync_from_downstream_handler(
 )
 def run_downstream_koji_build(event: dict, package_config: dict, job_config: dict):
     handler = DownstreamKojiBuildHandler(
+        package_config=load_package_config(package_config),
+        job_config=load_job_config(job_config),
+        event=event,
+    )
+    return get_handlers_task_results(handler.run_job(), event)
+
+
+@celery_app.task(name=TaskName.downstream_koji_build_report, base=HandlerTaskWithRetry)
+def run_downstream_koji_build_report(
+    event: dict, package_config: dict, job_config: dict
+):
+    handler = KojiBuildReportHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,3 +323,55 @@ def cache_clear(request):
 
     if getattr(request.module, "CACHE_CLEAR", None):
         [f.cache_clear() for f in getattr(request.module, "CACHE_CLEAR")]
+
+
+@pytest.fixture()
+def koji_build_start_old_format():
+    with open(DATA_DIR / "fedmsg" / "koji_build_start_old_format.json", "r") as outfile:
+        return json.load(outfile)
+
+
+@pytest.fixture()
+def koji_build_start_rawhide():
+    with open(DATA_DIR / "fedmsg" / "koji_build_start_rawhide.json", "r") as outfile:
+        return json.load(outfile)
+
+
+@pytest.fixture()
+def koji_build_start_f35():
+    with open(DATA_DIR / "fedmsg" / "koji_build_start_f35.json", "r") as outfile:
+        return json.load(outfile)
+
+
+@pytest.fixture()
+def koji_build_start_epel8():
+    with open(DATA_DIR / "fedmsg" / "koji_build_start_epel8.json", "r") as outfile:
+        return json.load(outfile)
+
+
+@pytest.fixture()
+def koji_build_completed_old_format():
+    with open(
+        DATA_DIR / "fedmsg" / "koji_build_completed_old_format.json", "r"
+    ) as outfile:
+        return json.load(outfile)
+
+
+@pytest.fixture()
+def koji_build_completed_rawhide():
+    with open(
+        DATA_DIR / "fedmsg" / "koji_build_completed_rawhide.json", "r"
+    ) as outfile:
+        return json.load(outfile)
+
+
+@pytest.fixture()
+def koji_build_completed_f35():
+    with open(DATA_DIR / "fedmsg" / "koji_build_completed_f35.json", "r") as outfile:
+        return json.load(outfile)
+
+
+@pytest.fixture()
+def koji_build_completed_epel8():
+    with open(DATA_DIR / "fedmsg" / "koji_build_completed_epel8.json", "r") as outfile:
+        return json.load(outfile)

--- a/tests/integration/test_koji_build.py
+++ b/tests/integration/test_koji_build.py
@@ -1,0 +1,203 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import json
+
+import pytest
+from celery.canvas import Signature
+from flexmock import flexmock
+
+from ogr.services.pagure import PagureProject
+from packit.config import JobConfigTriggerType
+from packit_service.config import ServiceConfig
+from packit_service.constants import SANDCASTLE_WORK_DIR
+from packit_service.models import GitBranchModel, KojiBuildModel, RunModel
+from packit_service.worker.jobs import SteveJobs
+from packit_service.worker.monitoring import Pushgateway
+from packit_service.worker.tasks import (
+    run_downstream_koji_build_report,
+)
+from tests.conftest import koji_build_completed_rawhide, koji_build_start_rawhide
+from tests.spellbook import first_dict_value, get_parameters_from_results
+
+
+@pytest.mark.parametrize(
+    "koji_build_fixture", [koji_build_start_rawhide, koji_build_completed_rawhide]
+)
+def test_downstream_koji_build_report_known_build(koji_build_fixture, request):
+    koji_build_event = request.getfixturevalue(koji_build_fixture.__name__)
+    packit_yaml = (
+        "{'specfile_path': 'python-ogr.spec', 'synced_files': [],"
+        "'jobs': [{'trigger': 'commit', 'job': 'koji_build'}],"
+        "'downstream_package_name': 'python-ogr'}"
+    )
+    pagure_project = flexmock(
+        PagureProject,
+        full_repo_name="rpms/python-ogr",
+        get_web_url=lambda: "https://src.fedoraproject.org/rpms/python-ogr",
+        default_branch="main",
+    )
+    pagure_project.should_receive("get_files").with_args(
+        ref="e029dd5250dde9a37a2cdddb6d822d973b09e5da", filter_regex=r".+\.spec$"
+    ).and_return(["python-ogr.spec"])
+    pagure_project.should_receive("get_file_content").with_args(
+        path=".distro/source-git.yaml", ref="e029dd5250dde9a37a2cdddb6d822d973b09e5da"
+    ).and_raise(FileNotFoundError, "Not found.")
+    pagure_project.should_receive("get_file_content").with_args(
+        path=".packit.yaml", ref="e029dd5250dde9a37a2cdddb6d822d973b09e5da"
+    ).and_return(packit_yaml)
+
+    flexmock(GitBranchModel).should_receive("get_or_create").with_args(
+        branch_name="main",
+        namespace="rpms",
+        repo_name="python-ogr",
+        project_url="https://src.fedoraproject.org/rpms/python-ogr",
+    ).and_return(flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.commit))
+
+    flexmock(ServiceConfig).should_receive("get_service_config").and_return(
+        ServiceConfig(
+            command_handler_work_dir=SANDCASTLE_WORK_DIR,
+            repository_cache="/tmp/repository-cache",
+            add_repositories_to_repository_cache=False,
+        )
+    )
+
+    # 1*KojiBuildReportHandler
+    flexmock(Signature).should_receive("apply_async").once()
+    flexmock(Pushgateway).should_receive("push").once().and_return()
+
+    # Database
+    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+        build_id=1874074
+    ).and_return(
+        flexmock(
+            target="target",
+            status="pending",
+            web_url="some-url",
+            build_logs_url=None,
+            get_trigger_object=lambda: flexmock(
+                id=1, job_config_trigger_type=JobConfigTriggerType.commit
+            ),
+        )
+        .should_receive("set_build_logs_url")
+        .with_args()
+        .and_return()
+        .mock()
+    ).times(
+        2
+    )  # event during parsing + handler during run
+
+    processing_results = SteveJobs().process_message(koji_build_event)
+    # 1*KojiBuildReportHandler
+    event_dict, job, job_config, package_config = get_parameters_from_results(
+        processing_results
+    )
+    assert json.dumps(event_dict)
+    results = run_downstream_koji_build_report(
+        package_config=package_config,
+        event=event_dict,
+        job_config=job_config,
+    )
+
+    assert first_dict_value(results["job"])["success"]
+
+
+@pytest.mark.parametrize(
+    "koji_build_fixture", [koji_build_start_rawhide, koji_build_completed_rawhide]
+)
+def test_downstream_koji_build_report_unknown_build(koji_build_fixture, request):
+    koji_build_event = request.getfixturevalue(koji_build_fixture.__name__)
+
+    packit_yaml = (
+        "{'specfile_path': 'python-ogr.spec', 'synced_files': [],"
+        "'jobs': [{'trigger': 'commit', 'job': 'koji_build'}],"
+        "'downstream_package_name': 'python-ogr'}"
+    )
+    pagure_project = flexmock(
+        PagureProject,
+        full_repo_name="rpms/python-ogr",
+        get_web_url=lambda: "https://src.fedoraproject.org/rpms/python-ogr",
+        default_branch="main",
+    )
+    pagure_project.should_receive("get_files").with_args(
+        ref="e029dd5250dde9a37a2cdddb6d822d973b09e5da", filter_regex=r".+\.spec$"
+    ).and_return(["python-ogr.spec"])
+    pagure_project.should_receive("get_file_content").with_args(
+        path=".distro/source-git.yaml", ref="e029dd5250dde9a37a2cdddb6d822d973b09e5da"
+    ).and_raise(FileNotFoundError, "Not found.")
+    pagure_project.should_receive("get_file_content").with_args(
+        path=".packit.yaml", ref="e029dd5250dde9a37a2cdddb6d822d973b09e5da"
+    ).and_return(packit_yaml)
+
+    flexmock(GitBranchModel).should_receive("get_or_create").with_args(
+        branch_name="main",
+        namespace="rpms",
+        repo_name="python-ogr",
+        project_url="https://src.fedoraproject.org/rpms/python-ogr",
+    ).and_return(flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.commit))
+
+    flexmock(ServiceConfig).should_receive("get_service_config").and_return(
+        ServiceConfig(
+            command_handler_work_dir=SANDCASTLE_WORK_DIR,
+            repository_cache="/tmp/repository-cache",
+            add_repositories_to_repository_cache=False,
+        )
+    )
+
+    # 1*KojiBuildReportHandler
+    flexmock(Signature).should_receive("apply_async").once()
+    flexmock(Pushgateway).should_receive("push").once().and_return()
+
+    # Database
+    run_model_flexmock = flexmock()
+    git_branch_model_flexmock = flexmock(
+        id=1, job_config_trigger_type=JobConfigTriggerType.commit
+    )
+    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+        build_id=1864700
+    ).and_return(None)
+    flexmock(GitBranchModel).should_receive("get_or_create").and_return(
+        git_branch_model_flexmock
+    )
+    flexmock(RunModel).should_receive("create").and_return(run_model_flexmock)
+    flexmock(KojiBuildModel).should_receive("create").with_args(
+        build_id="1864700",
+        commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",
+        web_url="https://koji.fedoraproject.org/koji/taskinfo?taskID=79721403",
+        target="noarch",
+        status="BUILDING",
+        run_model=run_model_flexmock,
+    ).and_return(flexmock(get_trigger_object=lambda: git_branch_model_flexmock))
+    flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
+        build_id=1874074
+    ).and_return(
+        flexmock(
+            target="noarch",
+            status="BUILDING",
+            web_url="https://koji.fedoraproject.org/koji/taskinfo?taskID=79721403",
+            build_logs_url=None,
+            get_trigger_object=lambda: flexmock(
+                id=1, job_config_trigger_type=JobConfigTriggerType.commit
+            ),
+        )
+        .should_receive("set_build_logs_url")
+        .with_args()
+        .and_return()
+        .mock()
+    ).times(
+        2
+    )  # event during parsing + handler during run
+
+    processing_results = SteveJobs().process_message(koji_build_event)
+    # 1*KojiBuildReportHandler
+    event_dict, job, job_config, package_config = get_parameters_from_results(
+        processing_results
+    )
+    assert json.dumps(event_dict)
+    results = run_downstream_koji_build_report(
+        package_config=package_config,
+        event=event_dict,
+        job_config=job_config,
+    )
+
+    assert first_dict_value(results["job"])["success"]

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -1005,7 +1005,7 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
 
     koji_build_pr.should_receive("set_build_start_time").once()
     koji_build_pr.should_receive("set_build_finished_time").with_args(None).once()
-    koji_build_pr.should_receive("set_status").with_args("pending").once()
+    koji_build_pr.should_receive("set_status").with_args("running").once()
     koji_build_pr.should_receive("set_build_logs_url")
     koji_build_pr.should_receive("set_web_url")
 
@@ -1072,7 +1072,7 @@ def test_koji_build_end(koji_build_scratch_end, pc_koji_build_pr, koji_build_pr)
     # check if packit-service set correct PR status
     flexmock(StatusReporter).should_receive("report").with_args(
         state=BaseCommitStatus.success,
-        description="RPMs were built successfully.",
+        description="RPM build succeeded.",
         url=url,
         check_names="production-build:rawhide",
         markdown_content=None,

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -36,7 +36,7 @@ from packit_service.worker.handlers import (
     TestingFarmResultsHandler,
     CoprBuildHandler,
     KojiBuildHandler,
-    KojiBuildReportHandler,
+    KojiTaskReportHandler,
     ProposeDownstreamHandler,
 )
 from packit_service.worker.handlers.bodhi import CreateBodhiUpdateHandler
@@ -282,7 +282,7 @@ from packit_service.worker.jobs import (
                     trigger=JobConfigTriggerType.pull_request,
                 ),
             ],
-            {KojiBuildReportHandler},
+            {KojiTaskReportHandler},
             id="config=production_build_for_pr&pull_request&KojiBuildEvent",
         ),
         # Build and test:
@@ -786,7 +786,7 @@ from packit_service.worker.jobs import (
                     trigger=JobConfigTriggerType.pull_request,
                 ),
             ],
-            {KojiBuildReportHandler},
+            {KojiTaskReportHandler},
             id="config=build_for_pr+production_build_for_pr"
             "&pull_request&KojiBuildEvent",
         ),
@@ -1777,7 +1777,7 @@ def test_get_handlers_for_check_rerun_event(
             id="build_for_pr+production_build_for_pr&KojiBuildHandler&PullRequestGithubEvent",
         ),
         pytest.param(
-            KojiBuildReportHandler,
+            KojiTaskReportHandler,
             KojiTaskEvent,
             flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
             [

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -41,6 +41,7 @@ from packit_service.worker.handlers import (
 )
 from packit_service.worker.handlers.bodhi import CreateBodhiUpdateHandler
 from packit_service.worker.handlers.distgit import DownstreamKojiBuildHandler
+from packit_service.worker.handlers.koji import KojiBuildReportHandler
 from packit_service.worker.jobs import (
     get_config_for_handler_kls,
     get_handlers_for_event,
@@ -807,11 +808,23 @@ from packit_service.worker.jobs import (
             flexmock(job_config_trigger_type=JobConfigTriggerType.commit),
             [
                 JobConfig(
+                    type=JobType.koji_build,
+                    trigger=JobConfigTriggerType.commit,
+                ),
+            ],
+            {KojiBuildReportHandler},
+            id="config=koji_build_for_commit&build&DownstreamKojiBuildHandler",
+        ),
+        pytest.param(
+            KojiBuildEvent,
+            flexmock(job_config_trigger_type=JobConfigTriggerType.commit),
+            [
+                JobConfig(
                     type=JobType.bodhi_update,
                     trigger=JobConfigTriggerType.commit,
                 ),
             ],
-            {CreateBodhiUpdateHandler},
+            {CreateBodhiUpdateHandler, KojiBuildReportHandler},
             id="config=bodhi_update_for_commit&commit&CreateBodhiUpdateHandler",
         ),
     ],
@@ -1904,6 +1917,24 @@ def test_get_handlers_for_check_rerun_event(
             id="koji_build_for_commit&DownstreamKojiBuildHandler&PushPagureEvent",
         ),
         pytest.param(
+            KojiBuildReportHandler,
+            KojiBuildEvent,
+            flexmock(job_config_trigger_type=JobConfigTriggerType.commit),
+            [
+                JobConfig(
+                    type=JobType.koji_build,
+                    trigger=JobConfigTriggerType.commit,
+                )
+            ],
+            [
+                JobConfig(
+                    type=JobType.koji_build,
+                    trigger=JobConfigTriggerType.commit,
+                )
+            ],
+            id="koji_build_for_commit&KojiBuildReportHandler&KojiBuildEvent",
+        ),
+        pytest.param(
             CreateBodhiUpdateHandler,
             KojiBuildEvent,
             flexmock(job_config_trigger_type=JobConfigTriggerType.commit),
@@ -1920,6 +1951,24 @@ def test_get_handlers_for_check_rerun_event(
                 )
             ],
             id="bodhi_update_for_commit&CreateBodhiUpdateHandler&KojiBuildEvent",
+        ),
+        pytest.param(
+            KojiBuildReportHandler,
+            KojiBuildEvent,
+            flexmock(job_config_trigger_type=JobConfigTriggerType.commit),
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.commit,
+                )
+            ],
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.commit,
+                )
+            ],
+            id="bodhi_update_for_commit&KojiBuildReportHandler&KojiBuildEvent",
         ),
     ],
 )


### PR DESCRIPTION
This is to update our database entries for non-scratch Koji builds to have an up-to-date status in a database.

* I suggest going commit-by-commit when reviewing (refactoring and renames makes the whole diff messy). 

---

N/A
