### PR TITLE
Reduce db connections for events

### DIFF
--- a/packit_service/worker/events/copr.py
+++ b/packit_service/worker/events/copr.py
@@ -66,8 +66,7 @@ class AbstractCoprBuildEvent(AbstractForgeIndependentEvent):
         self.pkg = pkg
         self.timestamp = timestamp
 
-    @property
-    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
+    def get_db_trigger(self) -> Optional[AbstractTriggerDbType]:
         return self.build.get_trigger_object()
 
     def get_base_project(self) -> Optional[GitProject]:

--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -7,11 +7,11 @@ Generic/abstract event classes.
 import copy
 from datetime import datetime, timezone
 from logging import getLogger
-from typing import Dict, Iterable, Optional, Union, Set, List
+from typing import Dict, Iterable, Optional, Type, Union, Set, List
 
 from ogr.abstract import GitProject
 from ogr.parsing import RepoUrl
-from packit.config import PackageConfig
+from packit.config import JobConfigTriggerType, PackageConfig
 
 from packit_service.config import PackageConfigGetter, ServiceConfig
 from packit_service.models import (
@@ -25,6 +25,32 @@ from packit_service.models import (
 )
 
 logger = getLogger(__name__)
+
+
+MAP_EVENT_TO_JOB_CONFIG_TRIGGER_TYPE: Dict[Type["Event"], JobConfigTriggerType] = {}
+
+
+def use_for_job_config_trigger(trigger_type: JobConfigTriggerType):
+    """
+    [class decorator]
+    Specify a trigger_type which this event class matches
+    so we don't need to search database to get that information.
+
+    In other words, what job-config in the configuration file
+    is compatible with this event.
+
+    Example:
+    ```
+    @use_for_job_config_trigger(trigger_type=JobConfigTriggerType.commit)
+    class KojiBuildEvent(AbstractKojiEvent):
+    ```
+    """
+
+    def _add_to_mapping(kls: Type["Event"]):
+        MAP_EVENT_TO_JOB_CONFIG_TRIGGER_TYPE[kls] = trigger_type
+        return kls
+
+    return _add_to_mapping
 
 
 class EventData:
@@ -255,6 +281,23 @@ class Event:
         if not self._db_trigger:
             self._db_trigger = self.get_db_trigger()
         return self._db_trigger
+
+    @property
+    def job_config_trigger_type(self) -> JobConfigTriggerType:
+        """
+        By default, we can use a database model related to this to get the config trigger type.
+
+        Set this for an event subclass if it is clear and
+        can be determined without any database connections
+        by using a `@use_for_job_config_trigger` decorator.
+        """
+        for (
+            event_cls,
+            job_config_trigger_type,
+        ) in MAP_EVENT_TO_JOB_CONFIG_TRIGGER_TYPE.items():
+            if isinstance(self, event_cls):
+                return job_config_trigger_type
+        return self.db_trigger.job_config_trigger_type
 
     @property
     def project(self):

--- a/packit_service/worker/events/github.py
+++ b/packit_service/worker/events/github.py
@@ -228,17 +228,6 @@ class CheckRerunEvent(AbstractGithubEvent):
     def targets_override(self) -> Optional[Set[str]]:
         return {self.check_name_target}
 
-    @property
-    def db_trigger(
-        self,
-    ) -> Union[PullRequestModel, GitBranchModel, ProjectReleaseModel]:
-        return self._db_trigger
-
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
-        result = super().get_dict()
-        result.pop("_db_trigger")
-        return result
-
 
 class CheckRerunCommitEvent(CheckRerunEvent):
     _db_trigger: GitBranchModel

--- a/packit_service/worker/events/koji.py
+++ b/packit_service/worker/events/koji.py
@@ -33,7 +33,6 @@ class AbstractKojiEvent(AbstractForgeIndependentEvent):
         self._target: Optional[str] = None
         self._build_model: Optional[KojiBuildModel] = None
         self._build_model_searched = False
-        self._db_trigger: Optional[AbstractTriggerDbType] = None
 
     @property
     def build_model(self) -> Optional[KojiBuildModel]:
@@ -42,11 +41,8 @@ class AbstractKojiEvent(AbstractForgeIndependentEvent):
             self._build_model_searched = True
         return self._build_model
 
-    @property
-    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
-        if not self._db_trigger and self.build_model:
-            self._db_trigger = self.build_model.get_trigger_object()
-        return self._db_trigger
+    def get_db_trigger(self) -> Optional[AbstractTriggerDbType]:
+        return self.build_model.get_trigger_object() if self.build_model else None
 
     @property
     def target(self) -> Optional[str]:
@@ -69,7 +65,6 @@ class AbstractKojiEvent(AbstractForgeIndependentEvent):
         result = super().get_dict()
         result.pop("_build_model")
         result.pop("_build_model_searched")
-        result.pop("_db_trigger")
         return result
 
 

--- a/packit_service/worker/events/koji.py
+++ b/packit_service/worker/events/koji.py
@@ -3,6 +3,8 @@
 
 from typing import Union, Optional, Dict
 
+from packit.config import JobConfigTriggerType
+
 from ogr.abstract import GitProject
 from ogr.services.pagure import PagureProject
 
@@ -16,7 +18,10 @@ from packit_service.models import (
     GitBranchModel,
     RunModel,
 )
-from packit_service.worker.events.event import AbstractForgeIndependentEvent
+from packit_service.worker.events.event import (
+    AbstractForgeIndependentEvent,
+    use_for_job_config_trigger,
+)
 
 
 class AbstractKojiEvent(AbstractForgeIndependentEvent):
@@ -68,6 +73,7 @@ class AbstractKojiEvent(AbstractForgeIndependentEvent):
         return result
 
 
+@use_for_job_config_trigger(trigger_type=JobConfigTriggerType.commit)
 class KojiBuildEvent(AbstractKojiEvent):
     def __init__(
         self,

--- a/packit_service/worker/events/testing_farm.py
+++ b/packit_service/worker/events/testing_farm.py
@@ -54,16 +54,11 @@ class TestingFarmResultsEvent(AbstractForgeIndependentEvent):
         result = super().get_dict()
         result["result"] = result["result"].value
         result["pr_id"] = self.pr_id
-        result.pop("_db_trigger")
         return result
 
-    @property
-    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
-        if not self._db_trigger:
-            run_model = TFTTestRunModel.get_by_pipeline_id(pipeline_id=self.pipeline_id)
-            if run_model:
-                self._db_trigger = run_model.get_trigger_object()
-        return self._db_trigger
+    def get_db_trigger(self) -> Optional[AbstractTriggerDbType]:
+        run_model = TFTTestRunModel.get_by_pipeline_id(pipeline_id=self.pipeline_id)
+        return run_model.get_trigger_object() if run_model else None
 
     def get_base_project(self) -> Optional[GitProject]:
         if self.pr_id is not None:

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -76,7 +76,7 @@ def get_handlers_for_event(
     jobs_matching_trigger = []
     for job in package_config.jobs:
         if (
-            job.trigger == event.db_trigger.job_config_trigger_type
+            job.trigger == event.job_config_trigger_type
             and job not in jobs_matching_trigger
         ):
             jobs_matching_trigger.append(job)
@@ -168,7 +168,7 @@ def get_config_for_handler_kls(
     """
     jobs_matching_trigger: List[JobConfig] = []
     for job in package_config.jobs:
-        if job.trigger == event.db_trigger.job_config_trigger_type:
+        if job.trigger == event.job_config_trigger_type:
             jobs_matching_trigger.append(job)
 
     matching_jobs: List[JobConfig] = []

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -351,16 +351,10 @@ def test_bodhi_update_fedora_stable_by_default(koji_build_completed_f35):
         koji_builds=["1874070"],
     ).once()
 
-    # Database structure
+    # Database not touched
     flexmock(KojiBuildModel).should_receive("get_by_build_id").with_args(
         build_id=1874070
-    ).and_return(
-        flexmock(
-            get_trigger_object=lambda: flexmock(
-                id=1, job_config_trigger_type=JobConfigTriggerType.commit
-            )
-        )
-    ).once()
+    ).times(0)
 
     processing_results = SteveJobs().process_message(koji_build_completed_f35)
     # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler

--- a/tests/integration/test_koji_build.py
+++ b/tests/integration/test_koji_build.py
@@ -83,9 +83,7 @@ def test_downstream_koji_build_report_known_build(koji_build_fixture, request):
         .with_args()
         .and_return()
         .mock()
-    ).times(
-        2
-    )  # event during parsing + handler during run
+    ).once()  # only when running a handler
 
     processing_results = SteveJobs().process_message(koji_build_event)
     # 1*KojiBuildReportHandler
@@ -184,9 +182,7 @@ def test_downstream_koji_build_report_unknown_build(koji_build_fixture, request)
         .with_args()
         .and_return()
         .mock()
-    ).times(
-        2
-    )  # event during parsing + handler during run
+    ).once()  # only when running a handler
 
     processing_results = SteveJobs().process_message(koji_build_event)
     # 1*KojiBuildReportHandler


### PR DESCRIPTION
* [Make the db_trigger property of Events lazy](https://github.com/packit/packit-service/commit/f330e90d03ea939bef679d4763da91e7371080c0)
  * We use lazy property to touch database only when needed.
  * We don't expand the property when dumping the event to json to avoid creation of database models during event parsing.
    (We don't know if there will be any handler for this event so it might be a useless database entry.
    E.g. we don't need to save each and every finished Koji build to our database.)
* [Be able to hardcode a job_config_trigger_type for event class](https://github.com/packit/packit-service/commit/4c63a23df0fcbde4f9eb6e489e8680c58c707c7a)
  * For some events we know the config trigger
    and we don't need to do a database query for that.
    (And even create a new entry there.)

---

N/A
