### PR TITLE
add metrics for number of tasks in celery queue

### DIFF
--- a/packit_service/worker/monitoring.py
+++ b/packit_service/worker/monitoring.py
@@ -5,7 +5,13 @@ import logging
 import os
 from datetime import datetime, timezone
 
-from prometheus_client import CollectorRegistry, Counter, push_to_gateway, Histogram
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    push_to_gateway,
+    Histogram,
+    Gauge,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +90,14 @@ class Pushgateway:
             "Time it takes to set the initial status",
             registry=self.registry,
             buckets=(5, 15, 30, float("inf")),
+        )
+
+        self.celery_tasks_count = (
+            Gauge(
+                "celery_task_in_queue",
+                "Number of celery tasks in the queue",
+                registry=self.registry,
+            ),
         )
 
         self.copr_build_finished_time = Histogram(


### PR DESCRIPTION
I realized that we don't need to use any of the external tools or
projects since we already gather metrics on our own: we can easily just
get the current number of celery tasks and record it in a push gateway.

I haven't actually try this code, yet.

TODO:

- [ ] get approval for the design (where should we record these?)