### PR TITLE
Use srpm deps from package config in Copr request

### DIFF
--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -19,7 +19,6 @@ from packit_service.celerizer import celery_app
 from packit_service.config import Deployment, ServiceConfig
 from packit_service.constants import (
     MSG_RETRIGGER,
-    SRPM_BUILD_DEPS,
     PG_BUILD_STATUS_SUCCESS,
     DEFAULT_MAPPING_INTERNAL_TF,
     DEFAULT_MAPPING_TF,
@@ -402,7 +401,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                     projectname=self.job_project,
                     script=script,
                     script_builddeps=self.get_packit_copr_download_urls()
-                    + SRPM_BUILD_DEPS,
+                    + self.package_config.srpm_build_deps,
                     buildopts={
                         "chroots": list(self.build_targets),
                     },

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -109,10 +109,7 @@ class CoprBuildHandler(JobHandler):
         return self._copr_build_helper
 
     def run(self) -> TaskResults:
-        if (
-            f"{self.project.service.hostname}/{self.project.full_repo_name}"
-            in self.service_config.enabled_projects_for_srpm_in_copr
-        ):
+        if self.package_config.srpm_build_deps is not None:
             return self.copr_build_helper.run_copr_build_from_source_script()
         return self.copr_build_helper.run_copr_build()
 

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -2004,6 +2004,7 @@ def test_run_copr_build_from_source_script(github_pr_event):
             job_trigger_model_type=JobTriggerModelType.pull_request,
         ),
     )
+    helper.package_config.srpm_build_deps = ["make", "findutils"]
     flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
         type=JobTriggerModelType.pull_request, trigger_id=123
     ).and_return(flexmock(id=2, type=JobTriggerModelType.pull_request))


### PR DESCRIPTION
Use `srpm_build_deps` as an indicator to run SRPMs in Copr
and use them in the Copr API request.


---

You can now define `srpm_build_deps` in your Packit configuration file to state which RPM dependencies are needed for your `actions` to be run when building SRPM. This key will be an indicator to build your SRPM in Copr and the dependencies will be installed in the build environment.
