### PR TITLE
Set default loglevel for workers to debug

### DIFF
--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -20,12 +20,6 @@ DEFAULT_CELERY_COMMAND="worker"
 # Whether to run Celery worker or beat (task scheduler)
 CELERY_COMMAND="${CELERY_COMMAND:-$DEFAULT_CELERY_COMMAND}"
 
-if [[ ${DEPLOYMENT} == "prod" ]]; then
-  LOGLEVEL="${LOGLEVEL:-INFO}"
-else
-  LOGLEVEL="${LOGLEVEL:-DEBUG}"
-fi
-
 if [[ "${CELERY_COMMAND}" == "beat" ]]; then
     # when using the database backend, celery beat must be running for the results to be expired.
     # https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html#starting-the-scheduler
@@ -45,5 +39,5 @@ elif [[ "${CELERY_COMMAND}" == "worker" ]]; then
     # concurrency: Number of concurrent worker processes/threads/green threads executing tasks.
     # prefetch-multiplier: How many messages to prefetch at a time multiplied by the number of concurrent processes.
     # http://docs.celeryproject.org/en/latest/userguide/optimizing.html#prefetch-limits
-    exec celery --app="${APP}" worker --loglevel="${LOGLEVEL}" --concurrency=1 --prefetch-multiplier=1 --queues="${QUEUES}"
+    exec celery --app="${APP}" worker --loglevel="${LOGLEVEL:-DEBUG}" --concurrency=1 --prefetch-multiplier=1 --queues="${QUEUES}"
 fi


### PR DESCRIPTION
It can still be changed with `LOGLEVEL` env. var.
We discussed that it's sometimes handy and we already have `debug: true` in all `packit-service.yaml`s to enable debug logs from `packit`.

---

N/A
