### PR TITLE
compose: Allow the server name to be fully configurable

### DIFF
--- a/files/run_httpd.sh
+++ b/files/run_httpd.sh
@@ -20,14 +20,16 @@ if [[ $n -eq $ATTEMPTS ]]; then
 fi
 
 export PACKIT_SERVICE_CONFIG="${HOME}/.config/packit-service.yaml"
+SERVER_NAME=$(sed -nr 's/^server_name: ([^:]+)(:([0-9]+))?$/\1/p' "$PACKIT_SERVICE_CONFIG")
+HTTPS_PORT=$(sed -nr 's/^server_name: ([^:]+)(:([0-9]+))?$/\3/p' "$PACKIT_SERVICE_CONFIG")
 
 exec mod_wsgi-express-3 start-server \
-    --https-port 8443 \
+    --https-port ${HTTPS_PORT:-8443} \
     --access-log \
     --log-to-terminal \
     --ssl-certificate-file /secrets/fullchain.pem \
     --ssl-certificate-key-file /secrets/privkey.pem \
-    --server-name ${DEPLOYMENT}.packit.dev \
+    --server-name $SERVER_NAME \
     --processes 2 \
     --locale "C.UTF-8" \
     /usr/share/packit/packit.wsgi


### PR DESCRIPTION
Don't require the service to bind to 'dev.packit.dev' when running
things with docker-compose, but instead allow the server name to be
fully specified, so that it's possible to configure something like
'service.localhost'.

Additionally: take the server name and the HTTPS port numbers provided
as options for mod_wsgi-express from 'packit-service.yaml'.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>