### PR TITLE
Use 'eyes' instead of 'thumbsup/+1' as a reaction to /packit comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,6 @@ Merge before/after
 
 ---
 
-<!-- release notes for changelog/blog follow -->
+RELEASE NOTES BEGIN
+￼
+RELEASE NOTES END

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -136,6 +136,8 @@ DEFAULT_MAPPING_INTERNAL_TF = {
     "epel-9": "centos-stream-9",
 }
 
+COMMENT_REACTION = "eyes"
+
 
 class KojiTaskState(Enum):
     """

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -13,7 +13,7 @@ from celery import group
 from packit.config import JobConfig, PackageConfig
 
 from packit_service.config import ServiceConfig
-from packit_service.constants import TASK_ACCEPTED
+from packit_service.constants import TASK_ACCEPTED, COMMENT_REACTION
 from packit_service.log_versions import log_job_versions
 from packit_service.worker.events.comment import AbstractCommentEvent
 from packit_service.worker.events import (
@@ -90,7 +90,7 @@ def get_handlers_for_event(
         if handlers_triggered_by_comment and not isinstance(
             event, PullRequestCommentPagureEvent
         ):
-            event.comment_object.add_reaction("+1")
+            event.comment_object.add_reaction(COMMENT_REACTION)
 
     if isinstance(event, CheckRerunEvent):
         handlers_triggered_by_check_rerun = get_handlers_for_check_rerun(

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -19,7 +19,7 @@ from packit.distgit import DistGit
 from packit.config import JobConfigTriggerType
 from packit.local_project import LocalProject
 from packit_service.config import ServiceConfig
-from packit_service.constants import SANDCASTLE_WORK_DIR
+from packit_service.constants import SANDCASTLE_WORK_DIR, COMMENT_REACTION
 from packit_service.models import IssueModel
 from packit_service.worker.events import IssueCommentEvent, IssueCommentGitlabEvent
 from packit_service.worker.jobs import SteveJobs
@@ -62,7 +62,7 @@ def mock_comment(request):
     flexmock(project_class).should_receive("get_issue").and_return(issue)
     comment = flexmock()
     flexmock(issue).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
     flexmock(issue).should_receive("close").and_return(issue)
     gr = release_class(
         tag_name="0.5.1",

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -21,6 +21,7 @@ from packit_service.constants import (
     SANDCASTLE_WORK_DIR,
     TASK_ACCEPTED,
     PG_BUILD_STATUS_SUCCESS,
+    COMMENT_REACTION,
 )
 from packit_service.models import (
     PullRequestModel,
@@ -193,7 +194,7 @@ def test_pr_comment_copr_build_handler(
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
 
     processing_results = SteveJobs().process_message(pr_copr_build_comment_event)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -252,7 +253,7 @@ def test_pr_comment_build_handler(
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
 
     processing_results = SteveJobs().process_message(pr_build_comment_event)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -311,7 +312,7 @@ def test_pr_comment_build_test_handler(
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
 
     processing_results = SteveJobs().process_message(pr_build_comment_event)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -380,7 +381,7 @@ def test_pr_comment_build_build_and_test_handler(
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
 
     processing_results = SteveJobs().process_message(pr_build_comment_event)
     assert len(processing_results) == 2
@@ -470,7 +471,7 @@ def test_pr_comment_production_build_handler(pr_production_build_comment_event):
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
 
     processing_results = SteveJobs().process_message(pr_production_build_comment_event)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -558,7 +559,7 @@ def test_pr_embedded_command_handler(
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
     flexmock(copr_build).should_receive("get_valid_build_targets").and_return(set())
     flexmock(CoprBuildJobHelper).should_receive("report_status_to_build").with_args(
         description=TASK_ACCEPTED,
@@ -680,7 +681,7 @@ def test_pr_test_command_handler(pr_embedded_command_comment_event):
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
     flexmock(
         GithubProject,
         full_repo_name="packit-service/hello-world",
@@ -764,7 +765,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
     flexmock(
         GithubProject,
         full_repo_name="packit-service/hello-world",
@@ -938,7 +939,7 @@ def test_pr_test_command_handler_missing_build(pr_embedded_command_comment_event
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
     flexmock(
         GithubProject,
         full_repo_name="packit-service/hello-world",
@@ -1030,7 +1031,7 @@ def test_pr_test_command_handler_not_allowed_external_contributor_on_internal_TF
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
     gh_project = flexmock(
         GithubProject,
         full_repo_name="packit-service/hello-world",
@@ -1148,7 +1149,7 @@ def test_rebuild_failed(
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
     flexmock(copr_build).should_receive("get_valid_build_targets").and_return(set())
 
     model = flexmock(CoprBuildTargetModel, status="failed", target="target")
@@ -1202,7 +1203,7 @@ def test_retest_failed(
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
     flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args("+1").once()
+    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
 
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=9,

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -8,6 +8,7 @@ from flexmock import flexmock
 
 from packit.config import JobConfig, JobConfigTriggerType, JobType
 from packit.config.job_config import JobMetadataConfig
+from packit_service.constants import COMMENT_REACTION
 from packit_service.worker.events import (
     CoprBuildEndEvent,
     CoprBuildStartEvent,
@@ -1001,7 +1002,9 @@ def test_get_handlers_for_comment_event(event_cls, comment, db_trigger, jobs, re
     if comment:
         comment_object = flexmock()
         event._comment_object = comment_object
-        flexmock(comment_object).should_receive("add_reaction").with_args("+1").once()
+        flexmock(comment_object).should_receive("add_reaction").with_args(
+            COMMENT_REACTION
+        ).once()
 
     event_handlers = set(
         get_handlers_for_event(


### PR DESCRIPTION
https://github.com/packit/packit-service/issues/1361#issuecomment-1055790961 suggests using :rocket: instead of :+1: as a reaction to `/packit comment`.
The :+1: can be understood as "done", while :rocket: as "running".

WDYT?

---

TODO
