### PR TITLE
Fix mapping of test targets to build targets

### DIFF
--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -715,7 +715,7 @@ def test_pr_test_command_handler(pr_embedded_command_comment_event):
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(copr_build).should_receive("get_valid_build_targets").twice().and_return(
+    flexmock(copr_build).should_receive("get_valid_build_targets").times(3).and_return(
         {"test-target"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
@@ -1218,7 +1218,7 @@ def test_retest_failed(
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(copr_build).should_receive("get_valid_build_targets").twice().and_return(
+    flexmock(copr_build).should_receive("get_valid_build_targets").times(3).and_return(
         {"test-target"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(


### PR DESCRIPTION
Don't try to reverse map the test targets, go through the not mapped test targets and check their mapped values for a match.

The problem in the previous implementation was, that for test targets that were hardcoded in our default build -> test mapping we picked the hardcoded build target, e.g. if test configuration had `centos-stream-8`, then `test_target2build_target(centos-stream-8-x86_64`) returned `epel-8-x86_64` ([see](https://github.com/packit/packit-service/blob/f2d1cd6adcd525dd4373c988f716a345e0514ede/packit_service/constants.py#L128)).

Tricky question in the end: is it a valid use case to test more builds with one test target? This would not work in that case correctly.

---

RELEASE NOTES BEGIN

RELEASE NOTES END
