### PR TITLE
Use nvr for bodhi updates

### DIFF
--- a/packit_service/worker/events/koji.py
+++ b/packit_service/worker/events/koji.py
@@ -116,6 +116,10 @@ class KojiBuildEvent(AbstractKojiEvent):
         return self._commit_sha
 
     @property
+    def nvr(self) -> str:
+        return f"{self.package_name}-{self.version}-{self.release}"
+
+    @property
     def build_model(self) -> Optional[KojiBuildTargetModel]:
         if not super().build_model:
             self._build_model = KojiBuildTargetModel.create(

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -113,7 +113,9 @@ class CreateBodhiUpdateHandler(JobHandler):
                 dist_git_branch=self.koji_build_event.git_ref,
                 update_type="enhancement",
                 update_notes=DEFAULT_BODHI_NOTE,
-                koji_builds=[str(self.koji_build_event.build_id)],
+                koji_builds=[
+                    self.koji_build_event.nvr  # it accepts NVRs, not build IDs
+                ],
             )
         except PackitException as ex:
             packit_api.downstream_local_project.git_project.commit_comment(

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1103,7 +1103,7 @@ class Parser:
         epoch = event.get("epoch")
 
         # "release": "1.fc36"
-        release, _ = event.get("release").split(".")
+        release = event.get("release")
 
         # "request": [
         #       "git+https://src.fedoraproject.org/rpms/packit.git#0eb3e12005cb18f15d3054020f7ac934c01eae08",

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -64,7 +64,7 @@ def test_bodhi_update_for_unknown_koji_build(koji_build_completed_old_format):
         dist_git_branch="rawhide",
         update_type="enhancement",
         update_notes=DEFAULT_BODHI_NOTE,
-        koji_builds=["1864700"],
+        koji_builds=["packit-0.43.0-1.fc36"],
     )
 
     # Database structure
@@ -213,7 +213,7 @@ def test_bodhi_update_for_known_koji_build(koji_build_completed_old_format):
         dist_git_branch="rawhide",
         update_type="enhancement",
         update_notes=DEFAULT_BODHI_NOTE,
-        koji_builds=["1864700"],
+        koji_builds=["packit-0.43.0-1.fc36"],
     )
 
     # Database structure
@@ -348,7 +348,7 @@ def test_bodhi_update_fedora_stable_by_default(koji_build_completed_f35):
         dist_git_branch="f35",
         update_type="enhancement",
         update_notes=DEFAULT_BODHI_NOTE,
-        koji_builds=["1874070"],
+        koji_builds=["python-ogr-0.34.0-1.fc35"],
     ).once()
 
     # Database not touched

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -880,7 +880,8 @@ class TestEvents:
         assert event_object.git_ref == "rawhide"
         assert event_object.epoch is None
         assert event_object.version == "0.43.0"
-        assert event_object.release == "1"
+        assert event_object.release == "1.fc36"
+        assert event_object.nvr == "packit-0.43.0-1.fc36"
         assert event_object.project_url == "https://src.fedoraproject.org/rpms/packit"
 
         assert isinstance(event_object.project, PagureProject)
@@ -917,7 +918,8 @@ class TestEvents:
         assert event_object.git_ref == "rawhide"
         assert event_object.epoch is None
         assert event_object.version == "0.34.0"
-        assert event_object.release == "1"
+        assert event_object.release == "1.fc36"
+        assert event_object.nvr == "python-ogr-0.34.0-1.fc36"
         assert (
             event_object.project_url == "https://src.fedoraproject.org/rpms/python-ogr"
         )
@@ -954,7 +956,8 @@ class TestEvents:
         assert event_object.git_ref == "f35"
         assert event_object.epoch is None
         assert event_object.version == "0.34.0"
-        assert event_object.release == "1"
+        assert event_object.release == "1.fc35"
+        assert event_object.nvr == "python-ogr-0.34.0-1.fc35"
         assert (
             event_object.project_url == "https://src.fedoraproject.org/rpms/python-ogr"
         )
@@ -993,7 +996,7 @@ class TestEvents:
         assert event_object.git_ref == "epel8"
         assert event_object.epoch is None
         assert event_object.version == "0.34.0"
-        assert event_object.release == "1"
+        assert event_object.release == "1.el8"
         assert (
             event_object.project_url == "https://src.fedoraproject.org/rpms/python-ogr"
         )
@@ -1032,7 +1035,8 @@ class TestEvents:
         assert event_object.git_ref == "rawhide"
         assert event_object.epoch is None
         assert event_object.version == "0.43.0"
-        assert event_object.release == "1"
+        assert event_object.release == "1.fc36"
+        assert event_object.nvr == "packit-0.43.0-1.fc36"
         assert event_object.project_url == "https://src.fedoraproject.org/rpms/packit"
 
         assert isinstance(event_object.project, PagureProject)
@@ -1069,7 +1073,8 @@ class TestEvents:
         assert event_object.git_ref == "rawhide"
         assert event_object.epoch is None
         assert event_object.version == "0.34.0"
-        assert event_object.release == "1"
+        assert event_object.release == "1.fc36"
+        assert event_object.nvr == "python-ogr-0.34.0-1.fc36"
         assert (
             event_object.project_url == "https://src.fedoraproject.org/rpms/python-ogr"
         )
@@ -1108,7 +1113,8 @@ class TestEvents:
         assert event_object.git_ref == "f35"
         assert event_object.epoch is None
         assert event_object.version == "0.34.0"
-        assert event_object.release == "1"
+        assert event_object.release == "1.fc35"
+        assert event_object.nvr == "python-ogr-0.34.0-1.fc35"
         assert (
             event_object.project_url == "https://src.fedoraproject.org/rpms/python-ogr"
         )
@@ -1147,7 +1153,8 @@ class TestEvents:
         assert event_object.git_ref == "epel8"
         assert event_object.epoch is None
         assert event_object.version == "0.34.0"
-        assert event_object.release == "1"
+        assert event_object.release == "1.el8"
+        assert event_object.nvr == "python-ogr-0.34.0-1.el8"
         assert (
             event_object.project_url == "https://src.fedoraproject.org/rpms/python-ogr"
         )


### PR DESCRIPTION
Bodhi accepts NVRs as Koji build, not build IDs

---

RELEASE NOTES BEGIN
n/a
RELEASE NOTES END