### PR TITLE
Send PR-specific env.vars. to TF

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -109,10 +109,44 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         return self.metadata.commit_sha
 
     @property
+    def source_branch_sha(self) -> Optional[str]:
+        if not self.metadata.pr_id:
+            return None
+        return self.project.get_pr(int(self.metadata.pr_id)).head_commit
+
+    @property
     def target_branch_sha(self) -> Optional[str]:
         if not self.metadata.pr_id:
             return None
         return self.project.get_pr(int(self.metadata.pr_id)).target_branch_head_commit
+
+    @property
+    def target_branch(self) -> Optional[str]:
+        if not self.metadata.pr_id:
+            return None
+        return self.project.get_pr(int(self.metadata.pr_id)).target_branch
+
+    @property
+    def source_branch(self) -> Optional[str]:
+        if not self.metadata.pr_id:
+            return None
+        return self.project.get_pr(int(self.metadata.pr_id)).source_branch
+
+    @property
+    def target_project_url(self) -> Optional[str]:
+        if not self.metadata.pr_id:
+            return None
+        return self.project.get_pr(
+            int(self.metadata.pr_id)
+        ).target_project.get_web_url()
+
+    @property
+    def source_project_url(self) -> Optional[str]:
+        if not self.metadata.pr_id:
+            return None
+        return self.project.get_pr(
+            int(self.metadata.pr_id)
+        ).source_project.get_web_url()
 
     @staticmethod
     def _artifact(
@@ -179,7 +213,12 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             "PACKIT_BUILD_LOG_URL": build_log_url,
             "PACKIT_SRPM_URL": srpm_url,
             "PACKIT_COMMIT_SHA": self.metadata.commit_sha,
+            "PACKIT_SOURCE_SHA": self.source_branch_sha,
             "PACKIT_TARGET_SHA": self.target_branch_sha,
+            "PACKIT_SOURCE_BRANCH": self.source_branch,
+            "PACKIT_TARGET_BRANCH": self.target_branch,
+            "PACKIT_SOURCE_URL": self.source_project_url,
+            "PACKIT_TARGET_URL": self.target_project_url,
         }
         predefined_environment = {
             k: v for k, v in predefined_environment.items() if v is not None

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -393,8 +393,16 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(
-            source_project=flexmock(get_web_url=lambda: "https://github.com/foo/bar"),
+            source_project=flexmock(
+                get_web_url=lambda: "https://github.com/source/bar"
+            ),
+            target_project=flexmock(
+                get_web_url=lambda: "https://github.com/target/bar"
+            ),
+            head_commit="0011223344",
             target_branch_head_commit="deadbeef",
+            source_branch="the-source-branch",
+            target_branch="the-target-branch",
         )
         .should_receive("comment")
         .mock()
@@ -460,12 +468,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
 
     payload = {
         "api_key": "secret token",
-        "test": {
-            "fmf": {
-                "url": "https://github.com/foo/bar",
-                "ref": "0011223344",
-            },
-        },
+        "test": {"fmf": {"url": "https://github.com/source/bar", "ref": "0011223344"}},
         "environments": [
             {
                 "arch": "x86_64",
@@ -486,10 +489,15 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
                 ],
                 "variables": {
                     "PACKIT_FULL_REPO_NAME": "foo/bar",
-                    "PACKIT_COMMIT_SHA": "0011223344",
                     "PACKIT_PACKAGE_NVR": "bar-0.1-1",
                     "PACKIT_BUILD_LOG_URL": "https://log-url",
+                    "PACKIT_COMMIT_SHA": "0011223344",
+                    "PACKIT_SOURCE_SHA": "0011223344",
                     "PACKIT_TARGET_SHA": "deadbeef",
+                    "PACKIT_SOURCE_BRANCH": "the-source-branch",
+                    "PACKIT_TARGET_BRANCH": "the-target-branch",
+                    "PACKIT_SOURCE_URL": "https://github.com/source/bar",
+                    "PACKIT_TARGET_URL": "https://github.com/target/bar",
                 },
             }
         ],
@@ -586,10 +594,21 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
 
 def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_web_url").and_return(
+        "https://github.com/target/bar"
+    )
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(
-            source_project=flexmock(get_web_url=lambda: "abc"),
+            source_project=flexmock(
+                get_web_url=lambda: "https://github.com/source/bar"
+            ),
+            target_project=flexmock(
+                get_web_url=lambda: "https://github.com/target/bar"
+            ),
+            head_commit="0011223344",
             target_branch_head_commit="deadbeef",
+            source_branch="the-source-branch",
+            target_branch="the-target-branch",
         )
         .should_receive("comment")
         .mock()
@@ -713,10 +732,21 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
 
 def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_pr):
     flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_web_url").and_return(
+        "https://github.com/target/bar"
+    )
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(
-            source_project=flexmock(get_web_url=lambda: "abc"),
+            source_project=flexmock(
+                get_web_url=lambda: "https://github.com/source/bar"
+            ),
+            target_project=flexmock(
+                get_web_url=lambda: "https://github.com/target/bar"
+            ),
+            head_commit="0011223344",
             target_branch_head_commit="deadbeef",
+            source_branch="the-source-branch",
+            target_branch="the-target-branch",
         )
         .should_receive("comment")
         .mock()

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -758,9 +758,16 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
         + "}"
     )
     pr = flexmock(
-        head_commit="12345",
-        source_project=flexmock(get_web_url=lambda: "https://github.com/foo/bar"),
-        target_branch_head_commit="6789a",
+        source_project=flexmock(
+            get_web_url=lambda: "https://github.com/someone/hello-world"
+        ),
+        target_project=flexmock(
+            get_web_url=lambda: "https://github.com/packit-service/hello-world"
+        ),
+        head_commit="0011223344",
+        target_branch_head_commit="deadbeef",
+        source_branch="the-source-branch",
+        target_branch="the-target-branch",
     )
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
@@ -771,7 +778,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
         full_repo_name="packit-service/hello-world",
         get_file_content=lambda path, ref: packit_yaml,
         get_files=lambda ref, filter_regex: ["the-specfile.spec"],
-        get_web_url=lambda: "https://github.com/the-namespace/the-repo",
+        get_web_url=lambda: "https://github.com/packit-service/hello-world",
     )
     flexmock(Github, get_repo=lambda full_name_or_id: None)
 
@@ -824,9 +831,9 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
         "api_key": "secret token",
         "test": {
             "fmf": {
-                "url": "https://github.com/foo/bar",
-                "ref": "12345",
-            },
+                "url": "https://github.com/someone/hello-world",
+                "ref": "0011223344",
+            }
         },
         "environments": [
             {
@@ -845,8 +852,13 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
                     "PACKIT_DOWNSTREAM_NAME": "hello-world",
                     "PACKIT_DOWNSTREAM_URL": "https://src.fedoraproject.org/rpms/hello-world.git",
                     "PACKIT_PACKAGE_NAME": "hello-world",
-                    "PACKIT_COMMIT_SHA": "12345",
-                    "PACKIT_TARGET_SHA": "6789a",
+                    "PACKIT_COMMIT_SHA": "0011223344",
+                    "PACKIT_SOURCE_SHA": "0011223344",
+                    "PACKIT_TARGET_SHA": "deadbeef",
+                    "PACKIT_SOURCE_BRANCH": "the-source-branch",
+                    "PACKIT_TARGET_BRANCH": "the-target-branch",
+                    "PACKIT_SOURCE_URL": "https://github.com/someone/hello-world",
+                    "PACKIT_TARGET_URL": "https://github.com/packit-service/hello-world",
                 },
             }
         ],
@@ -884,7 +896,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
     ).once()
 
     flexmock(GithubProject).should_receive("get_web_url").and_return(
-        "https://github.com/foo/bar"
+        "https://github.com/packit-service/hello-world"
     )
 
     tft_test_run_model = flexmock(id=5)
@@ -892,12 +904,12 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
     flexmock(PipelineModel).should_receive("create").and_return(run_model)
     flexmock(TFTTestRunTargetModel).should_receive("create").with_args(
         pipeline_id=pipeline_id,
-        commit_sha="12345",
+        commit_sha="0011223344",
         status=TestingFarmResult.new,
         target="fedora-rawhide-x86_64",
         web_url=None,
         run_model=run_model,
-        data={"base_project_url": "https://github.com/foo/bar"},
+        data={"base_project_url": "https://github.com/packit-service/hello-world"},
     ).and_return(tft_test_run_model)
 
     flexmock(StatusReporter).should_receive("report").with_args(

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -308,7 +308,7 @@ def test_artifact(
             "packit",
             "packit-service",
             "feb41e5",
-            "https://github.com/packit/packit",
+            "https://github.com/source/packit",
             "master",
             "me",
             "cool-project",
@@ -329,7 +329,7 @@ def test_artifact(
             "packit",
             "packit-service",
             "feb41e5",
-            "https://github.com/packit/packit",
+            "https://github.com/source/packit",
             "master",
             "me",
             "cool-project",
@@ -350,7 +350,7 @@ def test_artifact(
             "packit",
             "packit-service",
             "feb41e5",
-            "https://github.com/packit/packit",
+            "https://github.com/source/packit",
             "master",
             "me",
             "cool-project",
@@ -372,7 +372,7 @@ def test_artifact(
             "packit",
             "packit-service",
             "feb41e5",
-            "https://github.com/packit/packit",
+            "https://github.com/source/packit",
             "master",
             "me",
             "cool-project",
@@ -432,8 +432,12 @@ def test_payload(
     )
     package_config = flexmock(jobs=[])
     pr = flexmock(
-        source_project=flexmock(get_web_url=lambda: project_url),
-        target_branch_head_commit="deadbeef",
+        source_project=flexmock(get_web_url=lambda: "https://github.com/source/packit"),
+        target_project=flexmock(get_web_url=lambda: "https://github.com/packit/packit"),
+        head_commit=commit_sha,
+        target_branch_head_commit="abcdefgh",
+        source_branch="the-source-branch",
+        target_branch="the-target-branch",
     )
     project = flexmock(
         repo=repo,
@@ -513,12 +517,17 @@ def test_payload(
             "artifacts": [artifact],
             "tmt": {"context": {"distro": distro, "arch": arch, "trigger": "commit"}},
             "variables": {
-                "PACKIT_FULL_REPO_NAME": f"{namespace}/{repo}",
-                "PACKIT_COMMIT_SHA": commit_sha,
-                "PACKIT_PACKAGE_NVR": f"{repo}-0.1-1",
                 "PACKIT_BUILD_LOG_URL": log_url,
+                "PACKIT_COMMIT_SHA": commit_sha,
+                "PACKIT_FULL_REPO_NAME": f"{namespace}/{repo}",
+                "PACKIT_PACKAGE_NVR": f"{repo}-0.1-1",
+                "PACKIT_SOURCE_BRANCH": "the-source-branch",
+                "PACKIT_SOURCE_SHA": "feb41e5",
+                "PACKIT_SOURCE_URL": "https://github.com/source/packit",
                 "PACKIT_SRPM_URL": srpm_url,
-                "PACKIT_TARGET_SHA": "deadbeef",
+                "PACKIT_TARGET_BRANCH": "the-target-branch",
+                "PACKIT_TARGET_SHA": "abcdefgh",
+                "PACKIT_TARGET_URL": "https://github.com/packit/packit",
             },
         }
     ]
@@ -559,7 +568,7 @@ def test_test_repo(fmf_url, fmf_ref, result_url, result_ref):
     tf_token = "very-secret"
     ps_deployment = "test"
     repo = "packit"
-    project_url = "https://github.com/packit/packit"
+    source_project_url = "https://github.com/packit/packit"
     git_ref = "master"
     namespace = "packit-service"
     commit_sha = "feb41e5"
@@ -576,14 +585,20 @@ def test_test_repo(fmf_url, fmf_ref, result_url, result_ref):
     )
     package_config = flexmock(jobs=[])
     pr = flexmock(
-        source_project=flexmock(get_web_url=lambda: project_url),
-        target_branch_head_commit="deadbeef",
+        source_project=flexmock(
+            get_web_url=lambda: source_project_url,
+        ),
+        target_project=flexmock(get_web_url=lambda: "https://github.com/target/bar"),
+        head_commit=commit_sha,
+        target_branch_head_commit="abcdefgh",
+        source_branch="the-source-branch",
+        target_branch="the-target-branch",
     )
     project = flexmock(
         repo=repo,
         namespace=namespace,
         service="GitHub",
-        get_git_urls=lambda: {"git": f"{project_url}.git"},
+        get_git_urls=lambda: {"git": f"{source_project_url}.git"},
         get_pr=lambda id_: pr,
         full_repo_name=f"{namespace}/{repo}",
     )
@@ -591,7 +606,7 @@ def test_test_repo(fmf_url, fmf_ref, result_url, result_ref):
         trigger=flexmock(),
         commit_sha=commit_sha,
         git_ref=git_ref,
-        project_url=project_url,
+        project_url=source_project_url,
         pr_id=123,
     )
     db_trigger = flexmock()


### PR DESCRIPTION
There will be a variable for commit, branch and url both for PR source and PR target.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>
Fixes: #1379

---

RELEASE NOTES BEGIN
When running tests for the pull-request job, we now expose environment variables for commit hash, branch and URL both for pull-request source and target. In the test environment, you can use the following variables: `PACKIT_SOURCE_SHA`, `PACKIT_TARGET_SHA`, `PACKIT_SOURCE_BRANCH`, `PACKIT_TARGET_BRANCH`, `PACKIT_SOURCE_URL` and `PACKIT_TARGET_URL`. These variables are not set for test runs for releases and branch pushes.
RELEASE NOTES END