### PR TITLE
Fix task names for Koji

### DIFF
--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -217,8 +217,8 @@ class TaskName(str, enum.Enum):
     testing_farm = "task.run_testing_farm_handler"
     testing_farm_results = "task.run_testing_farm_results_handler"
     propose_downstream = "task.run_propose_downstream_handler"
-    koji_build = "task.run_koji_build_handler"
-    koji_build_report = "task.run_koji_build_report_handler"
+    upstream_koji_build = "task.run_koji_build_handler"
+    upstream_koji_build_report = "task.run_koji_build_report_handler"
     downstream_koji_build = "task.run_downstream_koji_build_handler"
     downstream_koji_build_report = "task.run_downstream_koji_build_report_handler"
     # Fedora notification is ok for now

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 @reacts_to(CheckRerunCommitEvent)
 @reacts_to(CheckRerunReleaseEvent)
 class KojiBuildHandler(JobHandler):
-    task_name = TaskName.koji_build
+    task_name = TaskName.upstream_koji_build
 
     def __init__(
         self,
@@ -141,7 +141,7 @@ class KojiBuildHandler(JobHandler):
 @configured_as(job_type=JobType.production_build)
 @reacts_to(event=KojiTaskEvent)
 class KojiTaskReportHandler(JobHandler):
-    task_name = TaskName.koji_build_report
+    task_name = TaskName.upstream_koji_build_report
 
     def __init__(
         self, package_config: PackageConfig, job_config: JobConfig, event: dict

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -261,7 +261,7 @@ class KojiTaskReportHandler(JobHandler):
 @configured_as(job_type=JobType.bodhi_update)
 @reacts_to(event=KojiBuildEvent)
 class KojiBuildReportHandler(JobHandler):
-    task_name = TaskName.koji_build_report
+    task_name = TaskName.downstream_koji_build_report
 
     def __init__(
         self, package_config: PackageConfig, job_config: JobConfig, event: dict

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -183,7 +183,7 @@ def run_propose_downstream_handler(
 
 
 @celery_app.task(
-    name=TaskName.koji_build, base=HandlerTaskWithRetry, queue="long-running"
+    name=TaskName.upstream_koji_build, base=HandlerTaskWithRetry, queue="long-running"
 )
 def run_koji_build_handler(event: dict, package_config: dict, job_config: dict):
     handler = KojiBuildHandler(
@@ -194,7 +194,7 @@ def run_koji_build_handler(event: dict, package_config: dict, job_config: dict):
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.koji_build_report, base=HandlerTaskWithRetry)
+@celery_app.task(name=TaskName.upstream_koji_build_report, base=HandlerTaskWithRetry)
 def run_koji_build_report_handler(event: dict, package_config: dict, job_config: dict):
     handler = KojiTaskReportHandler(
         package_config=load_package_config(package_config),


### PR DESCRIPTION
* [Use the correct task name for downstream Koji builds](https://github.com/packit/packit-service/commit/07bd35da95004e13039476ccdf3c1a9544816cdd)
  * Fixes: #1388 
* [Rename tasks for upstream Koji build to be more explicit](https://github.com/packit/packit-service/commit/2e919a1d6b3bec84ea405721d419cb1051f9c0a7)
  * The reason is to avoid confusion about if we mean upstream or downstream Koji build.

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
