### PR TITLE
Copr result event needs to match the job config

### DIFF
--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -217,6 +217,20 @@ class CoprBuildStartHandler(AbstractCoprBuildReportHandler):
         copr_build_logs = self.copr_event.get_copr_build_logs_url()
         self.build.set_build_logs_url(copr_build_logs)
 
+    def pre_check(self) -> bool:
+        if (
+            self.copr_event.owner == self.copr_build_helper.job_owner
+            and self.copr_event.project_name == self.copr_build_helper.job_project
+        ):
+            return True
+
+        logger.debug(
+            f"The Copr project {self.copr_event.owner}/{self.copr_event.project_name} "
+            f"does not match the configuration "
+            f"({self.copr_build_helper.job_owner}/{self.copr_build_helper.job_project} expected)."
+        )
+        return False
+
     def run(self):
         if not self.build:
             model = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,8 +136,8 @@ def srpm_build_model(
 
 
 def copr_build_model(
-    repo_name="bar",
-    repo_namespace="foo",
+    repo_name="hello-world",
+    repo_namespace="packit-service",
     forge_instance="github.com",
     job_config_trigger_type=JobConfigTriggerType.pull_request,
     job_trigger_model_type=JobTriggerModelType.pull_request,
@@ -150,7 +150,7 @@ def copr_build_model(
     )
     pr_model = flexmock(
         id=1,
-        pr_id=123,
+        pr_id=24,
         project=project_model,
         job_config_trigger_type=job_config_trigger_type,
         job_trigger_model_type=JobTriggerModelType.pull_request,

--- a/tests/data/fedmsg/srpm_build_end.json
+++ b/tests/data/fedmsg/srpm_build_end.json
@@ -1,15 +1,15 @@
 {
   "topic": "org.fedoraproject.prod.copr.build.end",
   "status": 1,
-  "what": "build end: user:lbarczio copr:ogr-custom-source build:3122876 pkg:None version:None ip:2620:52:3:1:dead:beef:cafe:c195 pid:2810668 status:1",
+  "what": "build end: user:packit copr:foo-bar-123-stg build:3122876 pkg:None version:None ip:2620:52:3:1:dead:beef:cafe:c195 pid:2810668 status:1",
   "chroot": "srpm-builds",
   "ip": "2620:52:3:1:dead:beef:cafe:c195",
-  "user": "lbarczio",
+  "user": "packit",
   "who": "backend.worker-rpm_build_worker:3122876",
   "pid": 2810668,
-  "copr": "ogr-custom-source",
+  "copr": "foo-bar-123-stg",
   "version": null,
   "build": 3122876,
-  "owner": "lbarczio",
+  "owner": "packit",
   "pkg": null
 }

--- a/tests/data/fedmsg/srpm_build_start.json
+++ b/tests/data/fedmsg/srpm_build_start.json
@@ -1,15 +1,15 @@
 {
   "topic": "org.fedoraproject.prod.copr.build.start",
   "status": 3,
-  "what": "build start: user:lbarczio copr:ogr-custom-source pkg:None build:3122876 ip:2620:52:3:1:dead:beef:cafe:c195 pid:2810668",
+  "what": "build start: user:packit copr:foo-bar-123-stg pkg:None build:3122876 ip:2620:52:3:1:dead:beef:cafe:c195 pid:2810668",
   "chroot": "srpm-builds",
   "ip": "2620:52:3:1:dead:beef:cafe:c195",
-  "user": "lbarczio",
+  "user": "packit",
   "who": "backend.worker-rpm_build_worker:3122876",
   "pid": 2810668,
-  "copr": "ogr-custom-source",
+  "copr": "foo-bar-123-stg",
   "version": null,
   "build": 3122876,
-  "owner": "lbarczio",
+  "owner": "packit",
   "pkg": null
 }

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -7,7 +7,10 @@ from datetime import datetime
 import pytest
 import requests
 from celery.canvas import Signature
+from copr.v3 import Client
 from flexmock import flexmock
+from packit.copr_helper import CoprHelper
+
 from ogr.services.github import GithubProject
 from ogr.utils import RequestResponse
 from packit.config import JobConfig, JobType, JobConfigTriggerType
@@ -484,12 +487,12 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
                     {
                         "id": "1:fedora-rawhide-x86_64",
                         "type": "fedora-copr-build",
-                        "packages": ["bar-0.1-1.noarch"],
+                        "packages": ["hello-world-0.1-1.noarch"],
                     },
                 ],
                 "variables": {
-                    "PACKIT_FULL_REPO_NAME": "foo/bar",
-                    "PACKIT_PACKAGE_NVR": "bar-0.1-1",
+                    "PACKIT_FULL_REPO_NAME": "packit-service/hello-world",
+                    "PACKIT_PACKAGE_NVR": "hello-world-0.1-1",
                     "PACKIT_BUILD_LOG_URL": "https://log-url",
                     "PACKIT_COMMIT_SHA": "0011223344",
                     "PACKIT_SOURCE_SHA": "0011223344",
@@ -878,6 +881,9 @@ def test_copr_build_start(copr_build_start, pc_build_pr, copr_build_pr):
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
     )
+    flexmock(CoprHelper).should_receive("get_copr_client").and_return(
+        Client(config={"username": "packit"})
+    )
     flexmock(CoprBuildJobHelper).should_receive("get_build_check").and_return(
         EXPECTED_BUILD_CHECK_NAME
     )
@@ -925,6 +931,9 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build_pr
     )
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
         pc_tests
+    )
+    flexmock(CoprHelper).should_receive("get_copr_client").and_return(
+        Client(config={"username": "packit"})
     )
     flexmock(TestingFarmJobHelper).should_receive("get_build_check").and_return(
         EXPECTED_BUILD_CHECK_NAME
@@ -1264,6 +1273,9 @@ def test_srpm_build_start(srpm_build_start, pc_build_pr, srpm_build_model):
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
+    )
+    flexmock(CoprHelper).should_receive("get_copr_client").and_return(
+        Client(config={"username": "packit"})
     )
     flexmock(CoprBuildTargetModel).should_receive("get_all_by_build_id").and_return(
         [flexmock(target="fedora-33-x86_64")]

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -756,13 +756,15 @@ class TestEvents:
         assert event_object.status == 3
         assert event_object.owner == "packit"
         assert event_object.project_name == "packit-service-hello-world-24-stg"
-        assert event_object.project_url == "https://github.com/foo/bar"
-        assert event_object.base_repo_name == "bar"
-        assert event_object.base_repo_namespace == "foo"
+        assert (
+            event_object.project_url == "https://github.com/packit-service/hello-world"
+        )
+        assert event_object.base_repo_name == "hello-world"
+        assert event_object.base_repo_namespace == "packit-service"
         assert event_object.pkg == "hello"
 
         assert isinstance(event_object.project, GithubProject)
-        assert event_object.project.full_repo_name == "foo/bar"
+        assert event_object.project.full_repo_name == "packit-service/hello-world"
 
         assert (
             not event_object.base_project  # With Github app, we cannot work with fork repo
@@ -773,7 +775,7 @@ class TestEvents:
         ).with_args(
             base_project=None,
             project=event_object.project,
-            pr_id=123,
+            pr_id=24,
             reference="0011223344",
             fail_when_missing=False,
             spec_file_path=None,
@@ -797,8 +799,8 @@ class TestEvents:
         assert event_object.status == 1
         assert event_object.owner == "packit"
         assert event_object.project_name == "packit-service-hello-world-24-stg"
-        assert event_object.base_repo_name == "bar"
-        assert event_object.base_repo_namespace == "foo"
+        assert event_object.base_repo_name == "hello-world"
+        assert event_object.base_repo_namespace == "packit-service"
         assert event_object.pkg == "hello"
         assert event_object.git_ref == "0011223344"
 
@@ -806,7 +808,7 @@ class TestEvents:
             pr_id=123
         ).and_return(flexmock(author="the-fork"))
         assert isinstance(event_object.project, GithubProject)
-        assert event_object.project.full_repo_name == "foo/bar"
+        assert event_object.project.full_repo_name == "packit-service/hello-world"
 
         assert (
             not event_object.base_project  # With Github app, we cannot work with fork repo
@@ -817,7 +819,7 @@ class TestEvents:
         ).with_args(
             base_project=None,
             project=event_object.project,
-            pr_id=123,
+            pr_id=24,
             reference="0011223344",
             fail_when_missing=False,
             spec_file_path=None,
@@ -1543,9 +1545,9 @@ class TestCentOSEventParser:
         assert event_object.base_repo_namespace == "source-git"
         assert event_object.pkg == "hello"
 
-        flexmock(PagureProject).should_receive("get_pr").with_args(
-            pr_id=123
-        ).and_return(flexmock(author="the-fork"))
+        flexmock(PagureProject).should_receive("get_pr").with_args(pr_id=24).and_return(
+            flexmock(author="the-fork")
+        )
         assert isinstance(event_object.project, PagureProject)
         assert event_object.project.full_repo_name == "source-git/packit-hello-world"
         assert isinstance(event_object.base_project, PagureProject)
@@ -1559,7 +1561,7 @@ class TestCentOSEventParser:
         ).with_args(
             base_project=event_object.base_project,
             project=event_object.project,
-            pr_id=123,
+            pr_id=24,
             reference="0011223344",
             fail_when_missing=False,
             spec_file_path="SPECS/packit-hello-world.spec",
@@ -1592,9 +1594,9 @@ class TestCentOSEventParser:
         assert event_object.pkg == "hello"
         assert event_object.git_ref == "0011223344"
 
-        flexmock(PagureProject).should_receive("get_pr").with_args(
-            pr_id=123
-        ).and_return(flexmock(author="the-fork"))
+        flexmock(PagureProject).should_receive("get_pr").with_args(pr_id=24).and_return(
+            flexmock(author="the-fork")
+        )
         assert isinstance(event_object.project, PagureProject)
         assert event_object.project.full_repo_name == "source-git/packit-hello-world"
         assert isinstance(event_object.base_project, PagureProject)
@@ -1608,7 +1610,7 @@ class TestCentOSEventParser:
         ).with_args(
             base_project=event_object.base_project,
             project=event_object.project,
-            pr_id=123,
+            pr_id=24,
             reference="0011223344",
             fail_when_missing=False,
             spec_file_path="SPECS/packit-hello-world.spec",


### PR DESCRIPTION
This is especially needed for the jobs with identifiers specfied
to avoid updating the wrong statuses.

The tests were updated because now it's important that the config and the event
works with the same Copr owner and project.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
