### PR TITLE
fix(handlers): react to `rawhide` on distgit

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -326,7 +326,9 @@ class DownstreamKojiBuildHandler(JobHandler):
         if self.data.event_type in (PushPagureEvent.__name__,):
             if self.data.git_ref not in (
                 configured_branches := get_branches(
-                    *self.job_config.metadata.dist_git_branches, default="main"
+                    *self.job_config.metadata.dist_git_branches,
+                    default="main",
+                    with_aliases=True,
                 )
             ):
                 logger.info(


### PR DESCRIPTION
When expanding branches from packit configuration, request from packit
to include also aliases, i.e. react to `rawhide` as well as `main`.

Signed-off-by: Matej Focko <mfocko@redhat.com>

Fixes #1356

Merge after packit/packit#1512

---

RELEASE NOTES BEGIN
Packit now reacts to dist-git pushes to either `rawhide` or `main` when configured to do Koji builds for `rawhide`.
RELEASE NOTES END
