### PR TITLE
Report better message when we fail updating our chroot set

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -27,6 +27,15 @@ MSG_RETRIGGER = (
     "You can retrigger the {job} by adding a comment (`/packit {command}`) "
     "into this {place}."
 )
+COPR_CHROOT_CHANGE_MSG = (
+    "Settings of a Copr project {owner}/{project} need to be updated, "
+    "but Packit can't do that when there are previous builds still in progress.\n"
+    "You should be able to resolve the problem by recreating this pull request "
+    "or running `/packit build` after all builds finished.\n\n"
+    "This was the change Packit tried to do:\n\n"
+    "{table}"
+    "\n"
+)
 
 FILE_DOWNLOAD_FAILURE = "Failed to download file from URL"
 

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -100,7 +100,7 @@ def build_helper(
     selected_job=None,
     project_type: Type[GitProject] = GithubProject,
     build_targets_override=None,
-):
+) -> CoprBuildJobHelper:
     if jobs and metadata:
         raise Exception("Only one of jobs and metadata can be used.")
 
@@ -119,7 +119,7 @@ def build_helper(
     ]
 
     pkg_conf = PackageConfig(jobs=jobs, downstream_package_name="dummy")
-    handler = CoprBuildJobHelper(
+    helper = CoprBuildJobHelper(
         service_config=ServiceConfig(),
         package_config=pkg_conf,
         job_config=selected_job or jobs[0],
@@ -143,8 +143,8 @@ def build_helper(
         build_targets_override=build_targets_override,
         pushgateway=Pushgateway(),
     )
-    handler._api = PackitAPI(ServiceConfig(), pkg_conf)
-    return handler
+    helper._api = PackitAPI(ServiceConfig(), pkg_conf)
+    return helper
 
 
 def test_copr_build_check_names(github_pr_event):


### PR DESCRIPTION
The original problem is a limitation in Copr that you cannot update
chroots of a project while builds are running.

Unfortunately, Packit did not detect this well and reported confusing
message to users about permissions:

https://github.com/packit/hello-world/pull/677#issuecomment-1065106598

This commit fixes the particular case and provides a more helpful error
message to users how to proceed and what the problem is.

On top of it, if project chroots require update, the message now
contains a markdown-formatted diff.

Related: https://github.com/packit/packit/issues/1303

---

Example comment:

Settings of a Copr project packit/the-example-namespace-the-example-repo-342-stg need to be updated, but there was an issue while Packit performed the change.
You should be able to resolve the problem by recreating this pull request or running `/packit build` after all builds finished.

This was the change Packit tried to do:
| field | old value | new value |
| ----- | --------- | --------- |
| chroots | ['f30', 'f31'] | ['f31', 'f32'] |
| description | old | new |

Diff of chroots:
```diff
-f30
+f32
```


RELEASE NOTES BEGIN

Packit no longer provides a misleading comment when it fails to update a set of targets on its own Copr projects.
￼
RELEASE NOTES END