### PR TITLE
Fix propose downstream bugs

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -272,6 +272,14 @@ class ProposeDownstreamHandler(JobHandler):
             for branch, model in zip(
                 branches, propose_downstream_model.propose_downstream_targets
             ):
+                # skip submitting a branch if we already did that (even if it failed)
+                if model.status not in [
+                    ProposeDownstreamTargetStatus.running,
+                    ProposeDownstreamTargetStatus.retry,
+                    ProposeDownstreamTargetStatus.queued,
+                ]:
+                    continue
+
                 model.set_status(status=ProposeDownstreamTargetStatus.running)
                 buffer, handler = gather_packit_logs_to_buffer(
                     logging_level=logging.DEBUG

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -138,6 +138,7 @@ class ProposeDownstreamHandler(JobHandler):
         package_config: PackageConfig,
         job_config: JobConfig,
         event: dict,
+        propose_downstream_run_id: Optional[int] = None,
         task: Task = None,
     ):
         super().__init__(
@@ -147,7 +148,11 @@ class ProposeDownstreamHandler(JobHandler):
         )
         self.task = task
 
-    def sync_branch(self, branch: str) -> Optional[PullRequest]:
+        self._propose_downstream_run_id = propose_downstream_run_id
+
+    def sync_branch(
+        self, branch: str, model: ProposeDownstreamModel
+    ) -> Optional[PullRequest]:
         try:
             downstream_pr = self.api.sync_release(
                 dist_git_branch=branch, tag=self.data.tag_name
@@ -166,7 +171,14 @@ class ProposeDownstreamHandler(JobHandler):
                     logger.info(f"Will retry for the {retries + 1}. time in {delay}s.")
                     # throw=False so that exception is not raised and task
                     # is not retried also automatically
-                    self.task.retry(exc=ex, countdown=delay, throw=False)
+                    self.task.retry(
+                        exc=ex,
+                        countdown=delay,
+                        throw=False,
+                        args=(),
+                        # https://stackoverflow.com/questions/68915407/celery-retry-with-updated-arguments
+                        kwargs={"propose_downstream_run_id": model.id},
+                    )
                     raise AbortProposeDownstream()
             raise ex
         finally:
@@ -211,6 +223,16 @@ class ProposeDownstreamHandler(JobHandler):
             body=body_msg,
         )
 
+    def _get_or_create_propose_downstream_run(self) -> ProposeDownstreamModel:
+        if self._propose_downstream_run_id is not None:
+            return ProposeDownstreamModel.get_by_id(self._propose_downstream_run_id)
+
+        propose_downstream_model, _ = ProposeDownstreamModel.create_with_new_run(
+            status=ProposeDownstreamStatus.running,
+            trigger_model=self.data.db_trigger,
+        )
+        return propose_downstream_model
+
     def run(self) -> TaskResults:
         """
         Sync the upstream release to dist-git as a pull request.
@@ -234,13 +256,9 @@ class ProposeDownstreamHandler(JobHandler):
             stage=self.service_config.use_stage(),
         )
 
-        propose_downstream_model, _ = ProposeDownstreamModel.create_with_new_run(
-            status=ProposeDownstreamStatus.running,
-            trigger_model=self.data.db_trigger,
-        )
-
         errors = {}
         default_dg_branch = self.api.dg.local_project.git_project.default_branch
+        propose_downstream_model = self._get_or_create_propose_downstream_run()
 
         try:
             branches = list(
@@ -261,7 +279,9 @@ class ProposeDownstreamHandler(JobHandler):
 
                 try:
                     model.set_start_time(start_time=datetime.utcnow())
-                    downstream_pr = self.sync_branch(branch=branch)
+                    downstream_pr = self.sync_branch(
+                        branch=branch, model=propose_downstream_model
+                    )
                     if downstream_pr is not None:
                         model.set_downstream_pr_url(downstream_pr_url=downstream_pr.url)
                         model.set_status(status=ProposeDownstreamTargetStatus.submitted)

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -171,12 +171,17 @@ def run_testing_farm_results_handler(
     queue="long-running",
 )
 def run_propose_downstream_handler(
-    self, event: dict, package_config: dict, job_config: dict
+    self,
+    event: dict,
+    package_config: dict,
+    job_config: dict,
+    propose_downstream_run_id: Optional[int] = None,
 ):
     handler = ProposeDownstreamHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,
+        propose_downstream_run_id=propose_downstream_run_id,
         task=self,
     )
     return get_handlers_task_results(handler.run_job(), event)

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -165,7 +165,7 @@ def test_issue_comment_propose_downstream_handler(
         trigger_model=trigger,
     ).and_return(propose_downstream_model, run_model).once()
 
-    model = flexmock(ProposeDownstreamTargetModel)
+    model = flexmock(status="queued")
     flexmock(ProposeDownstreamTargetModel).should_receive("create").with_args(
         status=ProposeDownstreamTargetStatus.queued
     ).and_return(model).once()

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -56,7 +56,7 @@ def mock_propose_downstream_functionality():
         project_url="https://github.com/packit-service/hello-world",
         commit_hash="123456",
     ).and_return(trigger).once()
-    propose_downstream_model = flexmock(propose_downstream_targets=[])
+    propose_downstream_model = flexmock(id=123, propose_downstream_targets=[])
     flexmock(ProposeDownstreamModel).should_receive("create_with_new_run").with_args(
         status=ProposeDownstreamStatus.running,
         trigger_model=trigger,

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -62,7 +62,7 @@ def mock_propose_downstream_functionality():
         trigger_model=trigger,
     ).and_return(propose_downstream_model, run_model).once()
 
-    model = flexmock(ProposeDownstreamTargetModel)
+    model = flexmock(status="queued")
     flexmock(ProposeDownstreamTargetModel).should_receive("create").with_args(
         status=ProposeDownstreamTargetStatus.queued
     ).and_return(model)

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -104,7 +104,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
         trigger_model=trigger,
     ).and_return(propose_downstream_model, run_model).times(1 if success else 0)
 
-    model = flexmock(ProposeDownstreamTargetModel)
+    model = flexmock(status="queued")
     flexmock(ProposeDownstreamTargetModel).should_receive("create").with_args(
         status=ProposeDownstreamTargetStatus.queued
     ).and_return(model).times(1 if success else 0)


### PR DESCRIPTION
Each bug and solution is separated and properly described in commits.

Notes to the `Fix duplicate propose-downstream jobs in dashboard`:
according to [this answer](https://stackoverflow.com/questions/68915407/celery-retry-with-updated-arguments) and [celery docs](https://docs.celeryq.dev/en/stable/reference/celery.app.task.html#celery.app.task.Task.retry) (see the `**kwargs` bullet point in parameters) this solution should work (passing propose-downstream id to `retry`). But I don't know how to test it so I am not sure if it really works. Are there any `flexmock` tools how to run the retried task which was pushed back to the queue and check if the `propose_downstream_run_id` has correct value?

