### PR TITLE
Don't add commit comments for non final states

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: pyupgrade
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.6.0
     hooks:
       - id: prettier
         exclude: tests_openshift/openshift_integration/test_data/
@@ -43,7 +43,7 @@ repos:
           - --max-line-length=100
           - --per-file-ignores=files/packit.wsgi:F401,E402
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.940
+    rev: v0.942
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]


### PR DESCRIPTION
to avoid multiple comments.

The `_add_commit_comment_with_status()` is used as a fallback if setting commit status fails.

Fixes #1411

([I need this for hardly as well](https://github.com/packit/hardly/blob/159f66731a9241217a338bc39b6ced5218b27687/hardly/handlers/distgit.py#L193))

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
