### PR TITLE
Issue repository can be used for failures of downstream jobs

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -272,17 +272,26 @@ class ServiceConfig(Config):
 class PackageConfigGetter:
     @staticmethod
     def create_issue_if_needed(
-        project: GitProject, title: str, message: str
+        project: GitProject,
+        title: str,
+        message: str,
+        comment_to_existing: Optional[str] = None,
     ) -> Optional[Issue]:
         # TODO: Improve filtering
         issues = project.get_issue_list()
         title = f"[packit] {title}"
 
-        if any(title in issue.title for issue in issues):
-            return None
+        for issue in issues:
+            if title in issue.title:
+                if comment_to_existing:
+                    issue.comment(body=comment_to_existing)
+                    logger.debug(f"Issue #{issue.id} updated: {issue.url}")
+                return None
 
         # TODO: store in DB
-        return project.create_issue(title=title, body=message)
+        issue = project.create_issue(title=title, body=message)
+        logger.debug(f"Issue #{issue.id} created: {issue.url}")
+        return issue
 
     @staticmethod
     def get_package_config_from_repo(

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -138,13 +138,13 @@ class CreateBodhiUpdateHandler(JobHandler):
                 f"Bodhi update failed to be created for '{self.koji_build_event.nvr}':\n"
                 "```\n"
                 f"{ex}\n"
-                "```\n\n"
-                f"*Get in [touch with us]({CONTACTS_URL}) if you need some help.*"
+                "```"
             )
             PackageConfigGetter.create_issue_if_needed(
                 project=issue_repo,
                 title="Fedora Bodhi update failed to be created",
-                message=body,
+                message=body
+                + f"\n\n*Get in [touch with us]({CONTACTS_URL}) if you need some help.*",
                 comment_to_existing=body,
             )
             raise ex

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -17,6 +17,7 @@ from packit.config.aliases import get_branches
 from packit.config import JobConfig, JobType, PackageConfig
 from packit.local_project import LocalProject
 from packit.utils.repo import RepositoryCache
+from packit_service.config import PackageConfigGetter
 from packit_service.constants import CONTACTS_URL, KojiBuildState
 from packit_service.worker.events.koji import KojiBuildEvent
 from packit_service.worker.handlers.abstract import (
@@ -118,13 +119,33 @@ class CreateBodhiUpdateHandler(JobHandler):
                 ],
             )
         except PackitException as ex:
-            packit_api.downstream_local_project.git_project.commit_comment(
-                commit=packit_api.downstream_local_project.commit_hexsha,
-                body="Bodhi update failed:\n"
+            if not self.job_config.issue_repository:
+                logger.debug(
+                    "No issue repository configured. User will not be notified about the failure."
+                )
+                raise ex
+
+            logger.debug(
+                f"Issue repository configured. We will create "
+                f"a new issue in {self.job_config.issue_repository}"
+                "or update the existing one."
+            )
+
+            issue_repo = self.service_config.get_project(
+                url=self.job_config.issue_repository
+            )
+            body = (
+                f"Bodhi update failed to be created for '{self.koji_build_event.nvr}':\n"
                 "```\n"
-                "{ex}\n"
+                f"{ex}\n"
                 "```\n\n"
-                f"*Get in [touch with us]({CONTACTS_URL}) if you need some help.*",
+                f"*Get in [touch with us]({CONTACTS_URL}) if you need some help.*"
+            )
+            PackageConfigGetter.create_issue_if_needed(
+                project=issue_repo,
+                title="Fedora Bodhi update failed to be created",
+                message=body,
+                comment_to_existing=body,
             )
             raise ex
         return TaskResults(success=True, details={})

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -413,13 +413,13 @@ class DownstreamKojiBuildHandler(JobHandler):
                 f"Koji build on '{self.dg_branch}' branch failed:\n"
                 "```\n"
                 f"{ex}\n"
-                "```\n\n"
-                f"*Get in [touch with us]({CONTACTS_URL}) if you need some help.*"
+                "```"
             )
             PackageConfigGetter.create_issue_if_needed(
                 project=issue_repo,
                 title="Fedora Koji build failed to be triggered",
-                message=body,
+                message=body
+                + f"\n\n*Get in [touch with us]({CONTACTS_URL}) if you need some help.*",
                 comment_to_existing=body,
             )
             raise ex

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -3,8 +3,12 @@
 
 import json
 
+import pytest
 from celery.canvas import Signature
 from flexmock import flexmock
+
+from ogr.services.github import GithubProject
+from packit.exceptions import PackitException
 
 from ogr.services.pagure import PagureProject
 from packit.api import PackitAPI
@@ -91,6 +95,246 @@ def test_bodhi_update_for_unknown_koji_build(koji_build_completed_old_format):
     )
 
     assert first_dict_value(results["job"])["success"]
+
+
+def test_bodhi_update_for_unknown_koji_build_failed(koji_build_completed_old_format):
+
+    packit_yaml = (
+        "{'specfile_path': 'packit.spec',"
+        "'jobs': [{'trigger': 'commit', 'job': 'bodhi_update',"
+        "'metadata': {'dist_git_branches': ['rawhide']}}],"
+        "'downstream_package_name': 'packit'}"
+    )
+    pagure_project_mock = flexmock(
+        PagureProject,
+        full_repo_name="rpms/packit",
+        get_web_url=lambda: "https://src.fedoraproject.org/rpms/packit",
+        default_branch="main",
+    )
+    pagure_project_mock.should_receive("get_files").with_args(
+        ref="0eb3e12005cb18f15d3054020f7ac934c01eae08", filter_regex=r".+\.spec$"
+    ).and_return(["packit.spec"])
+    pagure_project_mock.should_receive("get_file_content").with_args(
+        path=".distro/source-git.yaml", ref="0eb3e12005cb18f15d3054020f7ac934c01eae08"
+    ).and_raise(FileNotFoundError, "Not found.")
+    pagure_project_mock.should_receive("get_file_content").with_args(
+        path=".packit.yaml", ref="0eb3e12005cb18f15d3054020f7ac934c01eae08"
+    ).and_return(packit_yaml)
+
+    flexmock(LocalProject, refresh_the_arguments=lambda: None)
+    # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
+    flexmock(Signature).should_receive("apply_async").times(2)
+    flexmock(PackitAPI).should_receive("create_update").with_args(
+        dist_git_branch="rawhide",
+        update_type="enhancement",
+        update_notes=DEFAULT_BODHI_NOTE,
+        koji_builds=["packit-0.43.0-1.fc36"],
+    ).and_raise(PackitException, "Failed to create an update")
+
+    pagure_project_mock.should_receive("get_issue_list").times(0)
+    pagure_project_mock.should_receive("create_issue").times(0)
+
+    # Database structure
+    run_model_flexmock = flexmock()
+    git_branch_model_flexmock = flexmock(
+        id=1, job_config_trigger_type=JobConfigTriggerType.commit
+    )
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+        build_id=1864700
+    ).and_return(None)
+    flexmock(GitBranchModel).should_receive("get_or_create").and_return(
+        git_branch_model_flexmock
+    )
+    flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
+    flexmock(KojiBuildTargetModel).should_receive("create").with_args(
+        build_id="1864700",
+        commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",
+        web_url="https://koji.fedoraproject.org/koji/taskinfo?taskID=79721403",
+        target="noarch",
+        status="COMPLETE",
+        run_model=run_model_flexmock,
+    ).and_return(flexmock(get_trigger_object=lambda: git_branch_model_flexmock))
+
+    processing_results = SteveJobs().process_message(koji_build_completed_old_format)
+    # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
+    assert len(processing_results) == 2
+    processing_results.pop()
+    event_dict, job, job_config, package_config = get_parameters_from_results(
+        processing_results
+    )
+    with pytest.raises(PackitException):
+        run_bodhi_update(
+            package_config=package_config,
+            event=event_dict,
+            job_config=job_config,
+        )
+
+
+def test_bodhi_update_for_unknown_koji_build_failed_issue_created(
+    koji_build_completed_old_format,
+):
+
+    packit_yaml = (
+        "{'specfile_path': 'packit.spec',"
+        "'jobs': [{'trigger': 'commit', 'job': 'bodhi_update',"
+        "'metadata': {'dist_git_branches': ['rawhide']}}],"
+        "'downstream_package_name': 'packit',"
+        "'issue_repository': 'https://github.com/namespace/project'}"
+    )
+    pagure_project_mock = flexmock(
+        PagureProject,
+        full_repo_name="rpms/packit",
+        get_web_url=lambda: "https://src.fedoraproject.org/rpms/packit",
+        default_branch="main",
+    )
+    pagure_project_mock.should_receive("get_files").with_args(
+        ref="0eb3e12005cb18f15d3054020f7ac934c01eae08", filter_regex=r".+\.spec$"
+    ).and_return(["packit.spec"])
+    pagure_project_mock.should_receive("get_file_content").with_args(
+        path=".distro/source-git.yaml", ref="0eb3e12005cb18f15d3054020f7ac934c01eae08"
+    ).and_raise(FileNotFoundError, "Not found.")
+    pagure_project_mock.should_receive("get_file_content").with_args(
+        path=".packit.yaml", ref="0eb3e12005cb18f15d3054020f7ac934c01eae08"
+    ).and_return(packit_yaml)
+
+    flexmock(LocalProject, refresh_the_arguments=lambda: None)
+    # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
+    flexmock(Signature).should_receive("apply_async").times(2)
+    flexmock(PackitAPI).should_receive("create_update").with_args(
+        dist_git_branch="rawhide",
+        update_type="enhancement",
+        update_notes=DEFAULT_BODHI_NOTE,
+        koji_builds=["packit-0.43.0-1.fc36"],
+    ).and_raise(PackitException, "Failed to create an update")
+
+    issue_project_mock = flexmock(GithubProject)
+    issue_project_mock.should_receive("get_issue_list").and_return([]).once()
+    issue_project_mock.should_receive("create_issue").and_return(
+        flexmock(id=3, url="https://github.com/namespace/project/issues/3")
+    ).once()
+
+    # Database structure
+    run_model_flexmock = flexmock()
+    git_branch_model_flexmock = flexmock(
+        id=1, job_config_trigger_type=JobConfigTriggerType.commit
+    )
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+        build_id=1864700
+    ).and_return(None)
+    flexmock(GitBranchModel).should_receive("get_or_create").and_return(
+        git_branch_model_flexmock
+    )
+    flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
+    flexmock(KojiBuildTargetModel).should_receive("create").with_args(
+        build_id="1864700",
+        commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",
+        web_url="https://koji.fedoraproject.org/koji/taskinfo?taskID=79721403",
+        target="noarch",
+        status="COMPLETE",
+        run_model=run_model_flexmock,
+    ).and_return(flexmock(get_trigger_object=lambda: git_branch_model_flexmock))
+
+    processing_results = SteveJobs().process_message(koji_build_completed_old_format)
+    # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
+    assert len(processing_results) == 2
+    processing_results.pop()
+    event_dict, job, job_config, package_config = get_parameters_from_results(
+        processing_results
+    )
+    with pytest.raises(PackitException):
+        run_bodhi_update(
+            package_config=package_config,
+            event=event_dict,
+            job_config=job_config,
+        )
+
+
+def test_bodhi_update_for_unknown_koji_build_failed_issue_comment(
+    koji_build_completed_old_format,
+):
+
+    packit_yaml = (
+        "{'specfile_path': 'packit.spec',"
+        "'jobs': [{'trigger': 'commit', 'job': 'bodhi_update',"
+        "'metadata': {'dist_git_branches': ['rawhide']}}],"
+        "'downstream_package_name': 'packit',"
+        "'issue_repository': 'https://github.com/namespace/project'}"
+    )
+    pagure_project_mock = flexmock(
+        PagureProject,
+        full_repo_name="rpms/packit",
+        get_web_url=lambda: "https://src.fedoraproject.org/rpms/packit",
+        default_branch="main",
+    )
+    pagure_project_mock.should_receive("get_files").with_args(
+        ref="0eb3e12005cb18f15d3054020f7ac934c01eae08", filter_regex=r".+\.spec$"
+    ).and_return(["packit.spec"])
+    pagure_project_mock.should_receive("get_file_content").with_args(
+        path=".distro/source-git.yaml", ref="0eb3e12005cb18f15d3054020f7ac934c01eae08"
+    ).and_raise(FileNotFoundError, "Not found.")
+    pagure_project_mock.should_receive("get_file_content").with_args(
+        path=".packit.yaml", ref="0eb3e12005cb18f15d3054020f7ac934c01eae08"
+    ).and_return(packit_yaml)
+
+    flexmock(LocalProject, refresh_the_arguments=lambda: None)
+    # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
+    flexmock(Signature).should_receive("apply_async").times(2)
+    flexmock(PackitAPI).should_receive("create_update").with_args(
+        dist_git_branch="rawhide",
+        update_type="enhancement",
+        update_notes=DEFAULT_BODHI_NOTE,
+        koji_builds=["packit-0.43.0-1.fc36"],
+    ).and_raise(PackitException, "Failed to create an update")
+
+    issue_project_mock = flexmock(GithubProject)
+    issue_project_mock.should_receive("get_issue_list").and_return(
+        [
+            flexmock(
+                id=3,
+                title="[packit] Fedora Bodhi update failed to be created",
+                url="https://github.com/namespace/project/issues/3",
+            )
+            .should_receive("comment")
+            .once()
+            .mock()
+        ]
+    ).once()
+    issue_project_mock.should_receive("create_issue").times(0)
+
+    # Database structure
+    run_model_flexmock = flexmock()
+    git_branch_model_flexmock = flexmock(
+        id=1, job_config_trigger_type=JobConfigTriggerType.commit
+    )
+    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+        build_id=1864700
+    ).and_return(None)
+    flexmock(GitBranchModel).should_receive("get_or_create").and_return(
+        git_branch_model_flexmock
+    )
+    flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
+    flexmock(KojiBuildTargetModel).should_receive("create").with_args(
+        build_id="1864700",
+        commit_sha="0eb3e12005cb18f15d3054020f7ac934c01eae08",
+        web_url="https://koji.fedoraproject.org/koji/taskinfo?taskID=79721403",
+        target="noarch",
+        status="COMPLETE",
+        run_model=run_model_flexmock,
+    ).and_return(flexmock(get_trigger_object=lambda: git_branch_model_flexmock))
+
+    processing_results = SteveJobs().process_message(koji_build_completed_old_format)
+    # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
+    assert len(processing_results) == 2
+    processing_results.pop()
+    event_dict, job, job_config, package_config = get_parameters_from_results(
+        processing_results
+    )
+    with pytest.raises(PackitException):
+        run_bodhi_update(
+            package_config=package_config,
+            event=event_dict,
+            job_config=job_config,
+        )
 
 
 def test_bodhi_update_for_unknown_koji_build_not_for_unfinished(


### PR DESCRIPTION
Fixes: #1409

Requires: packit/packit#1536

---

RELEASE NOTES BEGIN
You can newly specify an `issue_repository` key in your config if you want to be
notified about errors of the downstream jobs (Koji build and Bodhi update).
This repository can be any GitHub/GitLab/Pagure repository
where issues are enabled and Packit has an identity on that instance.
(Let us know if you need some other instance to be supported.)
By default, no issue will be created and if the issue already exists,
a new comment will be added.
As usual, this new option works like other Packit options so you can set it
on the top level and/or (re)define on the job level.
RELEASE NOTES END
