### PR TITLE
Do not duplicate issue for failed propose downstream

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -218,9 +218,11 @@ class ProposeDownstreamHandler(JobHandler):
             f"{msg_retrigger}\n"
         )
 
-        self.project.create_issue(
-            title=f"[packit] Propose downstream failed for release {self.data.tag_name}",
-            body=body_msg,
+        PackageConfigGetter.create_issue_if_needed(
+            project=self.project,
+            title=f"Propose downstream failed for release {self.data.tag_name}",
+            message=body_msg,
+            comment_to_existing=body_msg,
         )
 
     def _get_or_create_propose_downstream_run(self) -> ProposeDownstreamModel:

--- a/tests/unit/test_distgit.py
+++ b/tests/unit/test_distgit.py
@@ -1,0 +1,50 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+from flexmock import flexmock
+
+from packit_service.worker.handlers.distgit import ProposeDownstreamHandler
+from packit_service.worker.events.event import EventData
+
+
+def test_create_one_issue_for_pr():
+    flexmock(EventData).should_receive("from_event_dict").and_return(
+        flexmock(
+            event_type="a type",
+            actor="an actor",
+            trigger_id=1,
+            project_url="a project url",
+            tag_name="056",
+        )
+    )
+    project = (
+        flexmock()
+        .should_receive("create_issue")
+        .once()
+        .and_return(flexmock(id="1", url="an url"))
+        .mock()
+    )
+    project.should_receive("get_issue_list").twice().and_return([]).and_return(
+        [
+            flexmock(
+                title="[packit] Propose downstream failed for release 056",
+                id=1,
+                url="a url",
+            )
+            .should_receive("comment")
+            .once.mock()
+        ]
+    )
+    flexmock(ProposeDownstreamHandler).should_receive("project").and_return(project)
+    handler = ProposeDownstreamHandler(None, None, {})
+    handler._report_errors_for_each_branch(
+        {
+            "f34": "Propose downstream failed for release 056",
+            "f35": "Propose downstream failed for release 056",
+        }
+    )
+    handler._report_errors_for_each_branch(
+        {
+            "f34": "Propose downstream failed for release 056",
+            "f35": "Propose downstream failed for release 056",
+        }
+    )


### PR DESCRIPTION
TODO:
If we want, we can enhance the create_issue_if_needed method and save the issue in the database
instead of trying to guess if it already exist using string matching.
I feel like that the `title in issue.title` check can lead to some errors (even if I think this are rare)

Should fix packit-service#1380

---

RELEASE NOTES BEGIN
When multiple propose downstream attempts for the same PR fail the error messages are sent to to the same issue, as comments, instead of creating multiple new issues.
RELEASE NOTES END
