### PR TITLE
Remove usage of packit's git.Repo wrappers

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -183,7 +183,9 @@ class ProposeDownstreamHandler(JobHandler):
                     raise AbortProposeDownstream()
             raise ex
         finally:
-            self.api.up.local_project.reset("HEAD")
+            self.api.up.local_project.git_repo.head.reset(
+                "HEAD", index=True, working_tree=True
+            )
 
         return downstream_pr
 

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -140,7 +140,16 @@ def test_issue_comment_propose_downstream_handler(
         is_private=lambda: False,
     )
 
-    flexmock(LocalProject).should_receive("reset").with_args("HEAD").once()
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock(
+            head=flexmock()
+            .should_receive("reset")
+            .with_args("HEAD", index=True, working_tree=True)
+            .once()
+            .mock(),
+            git=flexmock(clear_cache=lambda: None),
+        )
+    )
 
     flexmock(IssueCommentGitlabEvent).should_receive("db_trigger").and_return(
         flexmock(id=123, job_config_trigger_type=JobConfigTriggerType.release)

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -93,7 +93,16 @@ def test_dist_git_push_release_handle(
     lp.git_project = project
     flexmock(DistGit).should_receive("local_project").and_return(lp)
     # reset of the upstream repo
-    flexmock(LocalProject).should_receive("reset").with_args("HEAD").once()
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock(
+            head=flexmock()
+            .should_receive("reset")
+            .with_args("HEAD", index=True, working_tree=True)
+            .once()
+            .mock(),
+            git=flexmock(clear_cache=lambda: None),
+        )
+    )
 
     flexmock(Allowlist, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url: project
@@ -164,8 +173,15 @@ def test_dist_git_push_release_handle_multiple_branches(
         default_branch="main",
     )
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(LocalProject).should_receive("reset").with_args("HEAD").times(
-        len(fedora_branches)
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock(
+            head=flexmock()
+            .should_receive("reset")
+            .with_args("HEAD", index=True, working_tree=True)
+            .times(len(fedora_branches))
+            .mock(),
+            git=flexmock(clear_cache=lambda: None),
+        )
     )
 
     flexmock(Allowlist, check_and_report=True)
@@ -245,8 +261,15 @@ def test_dist_git_push_release_handle_one_failed(
     )
     project.should_receive("get_issue_list").and_return([])
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(LocalProject).should_receive("reset").with_args("HEAD").times(
-        len(fedora_branches)
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock(
+            head=flexmock()
+            .should_receive("reset")
+            .with_args("HEAD", index=True, working_tree=True)
+            .times(len(fedora_branches))
+            .mock(),
+            git=flexmock(clear_cache=lambda: None),
+        )
     )
     flexmock(Allowlist, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url: project
@@ -356,8 +379,15 @@ def test_dist_git_push_release_handle_all_failed(
     lp.working_dir = ""
     flexmock(DistGit).should_receive("local_project").and_return(lp)
     # reset of the upstream repo
-    flexmock(LocalProject).should_receive("reset").with_args("HEAD").times(
-        len(fedora_branches)
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock(
+            head=flexmock()
+            .should_receive("reset")
+            .with_args("HEAD", index=True, working_tree=True)
+            .times(len(fedora_branches))
+            .mock(),
+            git=flexmock(clear_cache=lambda: None),
+        )
     )
 
     flexmock(Allowlist, check_and_report=True)
@@ -432,7 +462,16 @@ def test_retry_propose_downstream_task(
     lp.working_dir = ""
     flexmock(DistGit).should_receive("local_project").and_return(lp)
     # reset of the upstream repo
-    flexmock(LocalProject).should_receive("reset").with_args("HEAD").once()
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock(
+            head=flexmock()
+            .should_receive("reset")
+            .with_args("HEAD", index=True, working_tree=True)
+            .once()
+            .mock(),
+            git=flexmock(clear_cache=lambda: None),
+        )
+    )
 
     flexmock(Allowlist, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url: project
@@ -537,7 +576,16 @@ def test_dont_retry_propose_downstream_task(
         status=ProposeDownstreamStatus.error
     ).once()
 
-    flexmock(LocalProject).should_receive("reset").with_args("HEAD").once()
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock(
+            head=flexmock()
+            .should_receive("reset")
+            .with_args("HEAD", index=True, working_tree=True)
+            .once()
+            .mock(),
+            git=flexmock(clear_cache=lambda: None),
+        )
+    )
     flexmock(Context, retries=2)
     flexmock(shutil).should_receive("rmtree").with_args("")
     flexmock(Task).should_receive("retry").never()

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -77,8 +77,15 @@ def test_process_message(event, private, enabled_private_namespaces, success):
     lp.working_dir = ""
     flexmock(DistGit).should_receive("local_project").and_return(lp)
     # reset of the upstream repo
-    flexmock(LocalProject).should_receive("reset").with_args("HEAD").times(
-        1 if success else 0
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock(
+            head=flexmock()
+            .should_receive("reset")
+            .with_args("HEAD", index=True, working_tree=True)
+            .times(1 if success else 0)
+            .mock(),
+            git=flexmock(clear_cache=lambda: None),
+        )
     )
 
     ServiceConfig().get_service_config().enabled_private_namespaces = (


### PR DESCRIPTION
Related to: packit/packit#343

Prerequisite for removing the wrappers safely :) Hardly doesn't seem to have any usages and this was the only usage in p-s. So only packit now needs to be adjusted in this regard