### PR TITLE
Comment command is configurable

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -108,6 +108,7 @@ class ServiceConfig(Config):
         koji_logs_url: str = "https://kojipkgs.fedoraproject.org",
         koji_web_url: str = "https://koji.fedoraproject.org",
         enabled_projects_for_srpm_in_copr: Union[Set[str], List[str]] = None,
+        comment_command_prefix: str = "/packit",
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -171,6 +172,7 @@ class ServiceConfig(Config):
         self.enabled_projects_for_srpm_in_copr: Set[str] = set(
             enabled_projects_for_srpm_in_copr or []
         )
+        self.comment_command_prefix = comment_command_prefix
 
     service_config = None
 
@@ -199,7 +201,8 @@ class ServiceConfig(Config):
             f"dashboard_url='{self.dashboard_url}', "
             f"koji_logs_url='{self.koji_logs_url}', "
             f"koji_web_url='{self.koji_web_url}', "
-            f"enabled_projects_for_srpm_in_copr= '{self.enabled_projects_for_srpm_in_copr}')"
+            f"enabled_projects_for_srpm_in_copr= '{self.enabled_projects_for_srpm_in_copr}', "
+            f"comment_command_prefix='{self.comment_command_prefix}')"
         )
 
     def use_stage(self) -> bool:

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -82,8 +82,6 @@ MSG_MORE_DETAILS = "You can find more details about the job [here]({url}).\n\n"
 
 MSG_TABLE_HEADER_WITH_DETAILS = "| Name/Job | URL |\n" "| --- | --- |\n"
 
-REQUESTED_PULL_REQUEST_COMMENT = "/packit"
-
 # https://github.com/packit/sandcastle/blob/3bd64e0812e3981b5462601e049471854eec433a/files/install-rpm-packages.yaml#L6
 SRPM_BUILD_DEPS = [
     "python3-pip",

--- a/packit_service/schema.py
+++ b/packit_service/schema.py
@@ -83,6 +83,7 @@ class ServiceConfigSchema(UserConfigSchema):
     koji_logs_url = fields.String()
     koji_web_url = fields.String()
     enabled_projects_for_srpm_in_copr = fields.List(fields.String())
+    comment_command_prefix = fields.String()
 
     @post_load
     def make_instance(self, data, **kwargs):

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -22,7 +22,6 @@ from packit.constants import DATETIME_FORMAT
 from packit.local_project import LocalProject
 
 from packit_service.config import ServiceConfig
-from packit_service.constants import REQUESTED_PULL_REQUEST_COMMENT
 from packit_service.models import (
     AbstractTriggerDbType,
 )
@@ -190,7 +189,9 @@ def run_for_check_rerun(prefix: str):
     return _add_to_mapping
 
 
-def get_packit_commands_from_comment(comment: str) -> List[str]:
+def get_packit_commands_from_comment(
+    comment: str, packit_comment_command_prefix: str
+) -> List[str]:
     comment_parts = comment.strip()
 
     if not comment_parts:
@@ -203,7 +204,7 @@ def get_packit_commands_from_comment(comment: str) -> List[str]:
         (packit_mark, *packit_command) = line.split(maxsplit=3)
         # packit_command[0] has the first cmd and [1] has the second, if needed.
 
-        if packit_mark == REQUESTED_PULL_REQUEST_COMMENT and packit_command:
+        if packit_mark == packit_comment_command_prefix and packit_command:
             return packit_command
 
     return []

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -170,7 +170,8 @@ class TestingFarmHandler(JobHandler):
 
     def is_copr_build_comment_event(self) -> bool:
         return self.is_comment_event() and get_packit_commands_from_comment(
-            self.data.event_dict.get("comment")
+            self.data.event_dict.get("comment"),
+            packit_comment_command_prefix=self.service_config.comment_command_prefix,
         )[0] in ("build", "copr-build")
 
     def run_copr_build_handler(self, event_data: dict, number_of_builds: int):


### PR DESCRIPTION
With this, we can set prefix to `/packit-stg` on the stage instance.

Fixes: #1271

---

RELEASE NOTES BEGIN
If you are using our stage instance, we make it listen only on `/packit-stg` comment commands so you can now differentiate
between the instances when commanding Packit via pull-request or issue comments.
For the production instance, you can continue using `/packit` prefix as you are used to.
RELEASE NOTES END
