### PR TITLE
fix: Remove the option to override the specfile_path

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -303,7 +303,6 @@ class PackageConfigGetter:
         base_project: Optional[GitProject] = None,
         pr_id: int = None,
         fail_when_missing: bool = True,
-        spec_file_path: Optional[str] = None,
     ) -> Optional[PackageConfig]:
         """
         Get the package config and catch the invalid config scenario and possibly no-config scenario
@@ -317,7 +316,6 @@ class PackageConfigGetter:
             package_config: PackageConfig = get_package_config_from_repo(
                 project=project_to_search_in,
                 ref=reference,
-                spec_file_path=spec_file_path,
             )
             if not package_config and fail_when_missing:
                 raise PackitMissingConfigException(

--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -10,7 +10,6 @@ from logging import getLogger
 from typing import Dict, Iterable, Optional, Type, Union, Set, List
 
 from ogr.abstract import GitProject
-from ogr.parsing import RepoUrl
 from packit.config import JobConfigTriggerType, PackageConfig
 
 from packit_service.config import PackageConfigGetter, ServiceConfig
@@ -435,23 +434,12 @@ class AbstractForgeIndependentEvent(Event):
             f"\tpr_id: {self.pr_id}"
         )
 
-        spec_path = None
-        if self.project_url and RepoUrl.parse(self.project_url).hostname in [
-            "git.centos.org",
-            "git.stg.centos.org",
-        ]:
-            spec_path = f"SPECS/{self.project.repo}.spec"
-            logger.debug(
-                f"Getting package_config from CentOS dist-git. "
-                f"(Spec-file is expected to be in {spec_path}.)"
-            )
         package_config = PackageConfigGetter.get_package_config_from_repo(
             base_project=self.base_project,
             project=self.project,
             reference=self.commit_sha,
             pr_id=self.pr_id,
             fail_when_missing=self.fail_when_config_file_missing,
-            spec_file_path=spec_path,
         )
 
         # job config change note:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -162,7 +162,7 @@ def test_config_opts(sc):
 
 
 @pytest.mark.parametrize(
-    "content,project,mock_spec_search,spec_path_option,spec_path,reference",
+    "content,project,spec_path_option,spec_path,reference",
     [
         (
             "---\nspecfile_path: packit.spec\n"
@@ -171,7 +171,6 @@ def test_config_opts(sc):
             "  - src: .packit.yaml\n"
             "    dest: .packit2.yaml",
             GitProject(repo="", service=GitService(), namespace=""),
-            True,
             None,
             "packit.spec",
             None,
@@ -183,7 +182,6 @@ def test_config_opts(sc):
             "  - src: .packit.yaml\n"
             "    dest: .packit2.yaml",
             GitProject(repo="", service=GitService(), namespace=""),
-            True,
             None,
             "packit.spec",
             "some-branch",
@@ -194,7 +192,6 @@ def test_config_opts(sc):
             "  - src: .packit.yaml\n"
             "    dest: .packit2.yaml",
             GitProject(repo="", service=GitService(), namespace=""),
-            True,
             None,
             "packit.spec",
             None,
@@ -205,7 +202,6 @@ def test_config_opts(sc):
             "  - src: .packit.yaml\n"
             "    dest: .packit2.yaml",
             GitProject(repo="", service=GitService(), namespace=""),
-            False,
             "packit.spec",
             "packit.spec",
             None,
@@ -217,7 +213,6 @@ def test_config_opts(sc):
             "    dest: .packit2.yaml\n"
             "jobs: [{job: build, trigger: pull_request}]\n",
             GitProject(repo="", service=GitService(), namespace=""),
-            False,
             "packit.spec",
             "packit.spec",
             None,
@@ -227,7 +222,6 @@ def test_config_opts(sc):
 def test_get_package_config_from_repo(
     content,
     project: GitProject,
-    mock_spec_search: bool,
     spec_path: Optional[str],
     spec_path_option: Optional[str],
     reference: str,
@@ -240,10 +234,9 @@ def test_get_package_config_from_repo(
     gp.should_receive("get_file_content").with_args(
         path=".packit.yaml", ref=reference
     ).and_return(content)
-    if mock_spec_search:
-        gp.should_receive("get_files").and_return(["packit.spec"]).once()
+    gp.should_receive("get_files").and_return(["packit.spec"]).once()
     config = PackageConfigGetter.get_package_config_from_repo(
-        project=project, reference=reference, spec_file_path=spec_path_option
+        project=project, reference=reference
     )
     assert isinstance(config, PackageConfig)
     assert config.specfile_path == spec_path
@@ -275,10 +268,10 @@ def test_get_package_config_from_repo_alternative_config_name():
         "  - src: .packit.yaml\n"
         "    dest: .packit2.yaml"
     )
+    gp.should_receive("get_files").and_return(["packit.spec"]).once()
     config = PackageConfigGetter.get_package_config_from_repo(
         project=GitProject(repo="", service=GitService(), namespace=""),
         reference=None,
-        spec_file_path="packit.spec",
     )
     assert isinstance(config, PackageConfig)
     assert config.specfile_path == "packit.spec"

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -261,7 +261,6 @@ class TestEvents:
             pr_id=1,
             reference="1f6a716aa7a618a9ffe56970d77177d99d100022",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -286,7 +285,6 @@ class TestEvents:
             pr_id=2,
             reference="45e272a57335e4e308f3176df6e9226a9e7805a9",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -320,7 +318,6 @@ class TestEvents:
             pr_id=342,
             reference="528b803be6f93e19ca4130bf4976f2800a3004c4",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -360,7 +357,6 @@ class TestEvents:
             pr_id=9,
             reference="12345",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -397,7 +393,6 @@ class TestEvents:
             pr_id=2,
             reference="45e272a57335e4e308f3176df6e9226a9e7805a9",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -437,7 +432,6 @@ class TestEvents:
             pr_id=9,
             reference="12345",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -476,7 +470,6 @@ class TestEvents:
             pr_id=None,
             reference="0.5.0",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -511,7 +504,6 @@ class TestEvents:
             pr_id=None,
             reference="0.5.0",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -541,7 +533,6 @@ class TestEvents:
             pr_id=None,
             reference="04885ff850b0fa0e206cd09db73565703d48f99b",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -571,7 +562,6 @@ class TestEvents:
             pr_id=None,
             reference="cb2859505e101785097e082529dced35bbee0c8f",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -599,7 +589,6 @@ class TestEvents:
             pr_id=None,
             reference="da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -629,7 +618,6 @@ class TestEvents:
             pr_id=None,
             reference="04885ff850b0fa0e206cd09db73565703d48f99b",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -674,7 +662,6 @@ class TestEvents:
             pr_id=None,
             reference="ee58e259da263ecb4c1f0129be7aef8cfd4dedd6",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -808,7 +795,6 @@ class TestEvents:
             pr_id=24,
             reference="0011223344",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -852,7 +838,6 @@ class TestEvents:
             pr_id=24,
             reference="0011223344",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -1301,7 +1286,6 @@ class TestEvents:
             pr_id=None,
             reference="0e5d8b51fd5dfa460605e1497d22a76d65c6d7fd",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -1343,7 +1327,6 @@ class TestEvents:
             pr_id=12,
             reference="0e5d8b51fd5dfa460605e1497d22a76d65c6d7fd",
             fail_when_missing=False,
-            spec_file_path=None,
         ).and_return(
             flexmock()
         ).once()
@@ -1443,7 +1426,6 @@ class TestCentOSEventParser:
             pr_id=12,
             reference="bf9701dea5a167caa7a1afa0759342aa0bf0d8fd",
             fail_when_missing=False,
-            spec_file_path="SPECS/packit-hello-world.spec",
         ).and_return(
             flexmock()
         ).once()
@@ -1488,7 +1470,6 @@ class TestCentOSEventParser:
             pr_id=13,
             reference="b658af51df98c1cbf74a75095ced920bba2ef25e",
             fail_when_missing=False,
-            spec_file_path="SPECS/packit-hello-world.spec",
         ).and_return(
             flexmock()
         ).once()
@@ -1532,7 +1513,6 @@ class TestCentOSEventParser:
             pr_id=16,
             reference="dfe787d04101728c6ddc213d3f4bf39c969f194c",
             fail_when_missing=False,
-            spec_file_path="SPECS/packit-hello-world.spec",
         ).and_return(
             flexmock()
         ).once()
@@ -1584,7 +1564,6 @@ class TestCentOSEventParser:
             pr_id=24,
             reference="0011223344",
             fail_when_missing=False,
-            spec_file_path="SPECS/packit-hello-world.spec",
         ).and_return(
             flexmock()
         ).once()
@@ -1633,7 +1612,6 @@ class TestCentOSEventParser:
             pr_id=24,
             reference="0011223344",
             fail_when_missing=False,
-            spec_file_path="SPECS/packit-hello-world.spec",
         ).and_return(
             flexmock()
         ).once()


### PR DESCRIPTION
This possibility was added in order to support a different default
specfile_path in the v1 source-git repositories created for CentOS
Stream.

As those repositories are being decommissioned, this code can be
removed.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>