### PR TITLE
Users can set an explicit CentOS compose for internal TF

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -311,6 +311,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             .replace("Centos", "CentOS")
             .replace("Rhel", "RHEL")
             .replace("Oraclelinux", "Oracle-Linux")
+            .replace("Latest", "latest")
         )
         if compose == "CentOS-Stream":
             compose = "CentOS-Stream-8"
@@ -328,7 +329,12 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
                 return f"{compose}-Updated"
             if compose == "CentOS-Stream-8":
                 return "RHEL-8.5.0-Nightly"
-            if compose.startswith("CentOS"):
+            if compose.startswith("CentOS") and len(compose) == len("CentOS-7"):
+                # Attach latest suffix only to major versions:
+                # CentOS-7 -> CentOS-7-latest
+                # CentOS-8 -> CentOS-8-latest
+                # CentOS-8.4 -> CentOS-8.4
+                # CentOS-8-latest -> CentOS-8-latest
                 return f"{compose}-latest"
             if compose == "RHEL-6":
                 return "RHEL-6-LatestReleased"

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -166,6 +166,11 @@ def test_testing_farm_response(
         ("rhel-8", "RHEL-8.5.0-Nightly", True),
         ("oraclelinux-7", "Oracle-Linux-7.9", True),
         ("oraclelinux-8", "Oracle-Linux-8.5", True),
+        # Explicit compose name
+        ("centos-7-latest", "CentOS-7-latest", True),
+        ("centos-8-latest", "CentOS-8-latest", True),
+        ("centos-8-Latest", "CentOS-8-latest", True),
+        ("centos-8.4", "CentOS-8.4", True),
     ],
 )
 def test_distro2compose(distro, compose, use_internal_tf):


### PR DESCRIPTION
For example:
* CentOS-7 -> CentOS-7-latest
* CentOS-8 -> CentOS-8-latest
* CentOS-8.4 -> CentOS-8.4
* CentOS-8-latest -> CentOS-8-latest

(Just an internal TF => no release notes.)

Signed-off-by: Frantisek Lachman <flachman@redhat.com>