### PR TITLE
Record the task accepted time right before reporting the statuses

### DIFF
--- a/tests_openshift/database/test_tasks.py
+++ b/tests_openshift/database/test_tasks.py
@@ -77,7 +77,9 @@ def packit_build_752():
 
 
 def test_check_copr_build(clean_before_and_after, packit_build_752):
-    flexmock(Client).should_receive("create_from_config_file").and_return(Client(None))
+    flexmock(Client).should_receive("create_from_config_file").and_return(
+        Client(config={"copr_url": "https://copr.fedorainfracloud.org/"})
+    )
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
         PackageConfig(
             jobs=[


### PR DESCRIPTION
Related to #1364

Currently, we record the metrics about setting the initial status right after setting them. But in the case of many targets to report to, interaction with Github API can take some seconds. This way, we will record the time just before setting the status for the first target, which is probably more precise.

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
