### PR TITLE
Fix typo in setting ProposeDownstreamTargetModel retry status

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -333,7 +333,7 @@ class ProposeDownstreamHandler(JobHandler):
                         "Propose downstream is being retried because "
                         "we were not able yet to download the archive. "
                     )
-                    model.set_status(staus=ProposeDownstreamTargetStatus.retry)
+                    model.set_status(status=ProposeDownstreamTargetStatus.retry)
                     self.propose_downstream_helper.report_status_to_branch(
                         branch=branch,
                         description="Propose downstream is being retried because "

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -616,7 +616,7 @@ def test_retry_propose_downstream_task(
     ).once()
     flexmock(model).should_receive("set_branch").with_args(branch="main").once()
     flexmock(model).should_receive("set_status").with_args(
-        staus=ProposeDownstreamTargetStatus.retry
+        status=ProposeDownstreamTargetStatus.retry
     ).once()
     flexmock(model).should_receive("set_start_time").once()
     flexmock(model).should_receive("set_finished_time").once()


### PR DESCRIPTION
I was wondering why there are 2 comments on failure [here](https://github.com/packit/requre/issues/244) and checked the prod logs: `Task TaskName.propose_downstream[62bcae4c-8593-4cfe-870e-c00837080bab] retry: Retry in 3s: TypeError("ProposeDownstreamTargetModel.set_status() got an unexpected keyword argument 'staus'")`

 So fixed typos both in code and tests..

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
