### PR TITLE
Propose downstream improvements

### DIFF
--- a/packit_service/worker/events/comment.py
+++ b/packit_service/worker/events/comment.py
@@ -139,6 +139,7 @@ class AbstractIssueCommentEvent(AddIssueDbTrigger, AbstractCommentEvent):
 
         # Lazy properties
         self._tag_name = tag_name
+        self._commit_sha: Optional[str] = None
         self._comment_object = comment_object
 
     @property
@@ -150,8 +151,11 @@ class AbstractIssueCommentEvent(AddIssueDbTrigger, AbstractCommentEvent):
         return self._tag_name
 
     @property
-    def commit_sha(self):
-        return self.tag_name
+    def commit_sha(self) -> Optional[str]:  # type:ignore
+        # mypy does not like properties
+        if not self._commit_sha:
+            self._commit_sha = self.project.get_sha_from_tag(tag_name=self.tag_name)
+        return self._commit_sha
 
     @property
     def comment_object(self) -> Optional[Comment]:
@@ -164,5 +168,6 @@ class AbstractIssueCommentEvent(AddIssueDbTrigger, AbstractCommentEvent):
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
         result = super().get_dict()
         result["tag_name"] = self.tag_name
+        result["commit_sha"] = self.commit_sha
         result["issue_id"] = self.issue_id
         return result

--- a/packit_service/worker/helpers/propose_downstream.py
+++ b/packit_service/worker/helpers/propose_downstream.py
@@ -43,7 +43,7 @@ class ProposeDownstreamJobHelper(BaseJobHelper):
         self.branches_override = branches_override
         self.msg_retrigger: str = ""
         self._check_names: Optional[List[str]] = None
-        self._default_distgit_branch: Optional[str] = None
+        self._default_dg_branch: Optional[str] = None
         self._job: Optional[JobConfig] = None
 
     @classmethod
@@ -109,11 +109,12 @@ class ProposeDownstreamJobHelper(BaseJobHelper):
         """
         Get the default branch of the distgit project.
         """
-        if not self._default_distgit_branch:
-            self._default_distgit_branch = (
-                self.api.dg.local_project.git_project.default_branch
+        if not self._default_dg_branch:
+            git_project = self.service_config.get_project(
+                url=self.package_config.dist_git_package_url
             )
-        return self._default_distgit_branch
+            self._default_dg_branch = git_project.default_branch
+        return self._default_dg_branch
 
     @property
     def branches(self) -> Set[str]:

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -70,6 +70,7 @@ def mock_comment(request):
         full_repo_name="packit-service/packit",
         get_web_url=lambda: f"https://{forge}.com/packit-service/packit",
         default_branch="main",
+        get_sha_from_tag=lambda tag_name: "123456",
     )
     (
         flexmock(project_class)

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -462,13 +462,14 @@ class TestEvents:
         flexmock(event_object.project).should_receive("get_latest_release").and_return(
             flexmock(tag_name="0.5.0")
         )
+        flexmock(GithubProject, get_sha_from_tag=lambda tag_name: "123456")
         flexmock(PackageConfigGetter).should_receive(
             "get_package_config_from_repo"
         ).with_args(
             base_project=event_object.base_project,
             project=event_object.project,
             pr_id=None,
-            reference="0.5.0",
+            reference="123456",
             fail_when_missing=False,
         ).and_return(
             flexmock()
@@ -496,13 +497,14 @@ class TestEvents:
         flexmock(event_object.project).should_receive("get_latest_release").and_return(
             flexmock(tag_name="0.5.0")
         )
+        flexmock(event_object.project, get_sha_from_tag=lambda tag_name: "123456")
         flexmock(PackageConfigGetter).should_receive(
             "get_package_config_from_repo"
         ).with_args(
             base_project=event_object.base_project,
             project=event_object.project,
             pr_id=None,
-            reference="0.5.0",
+            reference="123456",
             fail_when_missing=False,
         ).and_return(
             flexmock()

--- a/tests/unit/test_propose_downstream.py
+++ b/tests/unit/test_propose_downstream.py
@@ -6,8 +6,6 @@ from flexmock import flexmock
 
 from packit.config import PackageConfig, JobConfig, JobType
 from packit.config.job_config import JobMetadataConfig, JobConfigTriggerType
-from packit.distgit import DistGit
-from packit.local_project import LocalProject
 from packit_service.config import ServiceConfig
 from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJobHelper
 
@@ -65,6 +63,10 @@ from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJo
     ],
 )
 def test_branches(jobs, job_config_trigger_type, branches_override, branches):
+    project = flexmock(
+        default_branch="main",
+    )
+    flexmock(ServiceConfig, get_project=lambda url: project)
     propose_downstream_helper = ProposeDownstreamJobHelper(
         service_config=ServiceConfig(),
         package_config=PackageConfig(jobs=jobs),
@@ -74,12 +76,4 @@ def test_branches(jobs, job_config_trigger_type, branches_override, branches):
         db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
         branches_override=branches_override,
     )
-
-    lp = flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    lp.git_project = flexmock(
-        default_branch="main",
-    )
-    lp.working_dir = ""
-    flexmock(DistGit).should_receive("local_project").and_return(lp)
-
     assert propose_downstream_helper.branches == branches

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -14,6 +14,7 @@ from flexmock import flexmock
 from github import Github
 
 from ogr.services.github import GithubProject
+from ogr.services.pagure import PagureProject
 from packit.api import PackitAPI
 from packit.config import JobConfigTriggerType
 from packit.distgit import DistGit
@@ -94,6 +95,9 @@ def test_process_message(event, private, enabled_private_namespaces, success):
 
     ServiceConfig().get_service_config().enabled_private_namespaces = (
         enabled_private_namespaces
+    )
+    flexmock(PagureProject).should_receive("_call_project_api").and_return(
+        {"default": "main"}
     )
 
     run_model = flexmock(PipelineModel)


### PR DESCRIPTION
Accessing `local_project` currently requires cloning of the repo and we can get the GitProject directly. It doesn't make much sense to clone the repo only for getting the `default_dg_branch` for the creation of the Github checks (we need the `default_dg_branch` when getting branches to report for).

The `AbstractIssueCommentEvent` is used only for propose-downstream, so get the `commit_sha` the same way as for the release event. This will be used for reporting.

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
