### PR TITLE
Add more reasonable logs for searching copr/tf targers by status

### DIFF
--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -473,7 +473,7 @@ class AbstractForgeIndependentEvent(Event):
         statuses_to_filter_with: List[str],
     ) -> Optional[Set[str]]:
         logger.info(
-            f"Trying to filter targets with possible status in: {statuses_to_filter_with}"
+            f"Trying to filter targets with possible status: {statuses_to_filter_with} in {models}"
         )
         failed_models_targets = set()
         for model in models:
@@ -489,6 +489,10 @@ class AbstractForgeIndependentEvent(Event):
         if self.commit_sha is None:
             return None
 
+        logger.debug(
+            f"Getting failed Testing Farm targets for repo: {self.project.repo} and "
+            f"commit sha: {self.commit_sha}"
+        )
         return self._filter_failed_models_targets(
             models=TFTTestRunTargetModel.get_all_by_commit_target(
                 commit_sha=self.commit_sha
@@ -504,6 +508,10 @@ class AbstractForgeIndependentEvent(Event):
         if self.commit_sha is None or self.project.repo is None:
             return None
 
+        logger.debug(
+            f"Getting failed COPR build targets for repo: {self.project.repo} and "
+            f"commit sha: {self.commit_sha}"
+        )
         return self._filter_failed_models_targets(
             models=CoprBuildTargetModel.get_all_by(
                 project_name=self.project.repo, commit_sha=self.commit_sha


### PR DESCRIPTION
Adding more reasonable logs to this may finally tell what's wrong with `rebuild`/`retest` since regarding to current logs the bug will be 
- getting wrong commit sha or
-  getting wrong models according to commit sha or
-  wrong filtering of failed models

And ss you can see I cannot tell according to logs which of these three options works and which not and according to tests everything is working :D yes I should learn to write more reasonable logs

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
