### PR TITLE
Do not use stage fedora instances from service

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -205,9 +205,6 @@ class ServiceConfig(Config):
             f"comment_command_prefix='{self.comment_command_prefix}')"
         )
 
-    def use_stage(self) -> bool:
-        return self.deployment != Deployment.prod
-
     @classmethod
     def get_from_dict(cls, raw_dict: dict) -> "ServiceConfig":
         # required to avoid circular imports

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -107,7 +107,6 @@ class CreateBodhiUpdateHandler(JobHandler):
             self.service_config,
             self.job_config,
             downstream_local_project=self.local_project,
-            stage=self.service_config.use_stage(),
         )
         try:
             packit_api.create_update(

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -112,7 +112,6 @@ class SyncFromDownstream(JobHandler):
             self.service_config,
             self.job_config,
             upstream_local_project=upstream_local_project,
-            stage=self.service_config.use_stage(),
         )
         # rev is a commit
         # we use branch on purpose so we get the latest thing
@@ -282,7 +281,6 @@ class ProposeDownstreamHandler(JobHandler):
             self.service_config,
             self.job_config,
             self.local_project,
-            stage=self.service_config.use_stage(),
         )
 
         errors = {}
@@ -439,7 +437,6 @@ class DownstreamKojiBuildHandler(JobHandler):
             self.service_config,
             self.job_config,
             downstream_local_project=self.local_project,
-            stage=self.service_config.use_stage(),
         )
         try:
             packit_api.build(

--- a/packit_service/worker/helpers/job_helper.py
+++ b/packit_service/worker/helpers/job_helper.py
@@ -120,7 +120,6 @@ class BaseJobHelper:
                 self.job_config,
                 # so that the local_project is evaluated only if needed
                 Proxy(partial(BaseJobHelper.local_project.__get__, self)),  # type: ignore
-                stage=self.service_config.use_stage(),
             )
         return self._api
 


### PR DESCRIPTION
Both Packit prod and stage work with prod instances
so we can use them for our projects
and to have the same environment for both of them.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>
