### PR TITLE
feat(tf): export PR id to the testing farm env

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -212,6 +212,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             "PACKIT_TARGET_BRANCH": self.target_branch,
             "PACKIT_SOURCE_URL": self.source_project_url,
             "PACKIT_TARGET_URL": self.target_project_url,
+            "PACKIT_PR_ID": self.pr_id,
         }
         predefined_environment = {
             k: v for k, v in predefined_environment.items() if v is not None

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -508,6 +508,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
                     "PACKIT_TARGET_BRANCH": "the-target-branch",
                     "PACKIT_SOURCE_URL": "https://github.com/source/bar",
                     "PACKIT_TARGET_URL": "https://github.com/target/bar",
+                    "PACKIT_PR_ID": 24,
                 },
             }
         ],

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -871,6 +871,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
                     "PACKIT_TARGET_BRANCH": "the-target-branch",
                     "PACKIT_SOURCE_URL": "https://github.com/someone/hello-world",
                     "PACKIT_TARGET_URL": "https://github.com/packit-service/hello-world",
+                    "PACKIT_PR_ID": 9,
                 },
             }
         ],

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -529,6 +529,7 @@ def test_payload(
                 "PACKIT_TARGET_BRANCH": "the-target-branch",
                 "PACKIT_TARGET_SHA": "abcdefgh",
                 "PACKIT_TARGET_URL": "https://github.com/packit/packit",
+                "PACKIT_PR_ID": 123,
             },
         }
     ]


### PR DESCRIPTION
Fixes #1444

Signed-off-by: Matej Focko <mfocko@redhat.com>

---

RELEASE NOTES BEGIN
Packit now exports `PACKIT_PR_ID` environment variable to the Testing Farm.
RELEASE NOTES END
