### PR TITLE
Catch the new Copr exception that is newly raised by Copr

### DIFF
--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -5,7 +5,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Iterable, List, Optional, Set, Tuple
 
-from copr.v3 import CoprRequestException
+from copr.v3 import CoprAuthException, CoprRequestException
 
 from ogr.abstract import GitProject
 from ogr.parsing import parse_git_repo
@@ -452,7 +452,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                     },
                 )
 
-        except CoprRequestException as ex:
+        except (CoprRequestException, CoprAuthException) as ex:
             if "You don't have permissions to build in this copr." in str(
                 ex
             ) or "is not allowed to build in the copr" in str(ex):


### PR DESCRIPTION
Signed-off-by: Frantisek Lachman <flachman@redhat.com>
Fixes: #1471

---

RELEASE NOTES BEGIN
The bug in the Copr permission request is now fixed. (After the release of a new Copr client, Packit didn't catch that permission problem and didn't request the permissions to build in a custom Copr project.) You can wait for the fix to be deployed and retrigger the action or let the Packit team know to make the request manually.
RELEASE NOTES END
