### PR TITLE
fix(tf): provide project url if no PR is found

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -99,7 +99,13 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
     def fmf_url(self) -> str:
         return (
             self.job_config.metadata.fmf_url
-            or self.project.get_pr(self.metadata.pr_id).source_project.get_web_url()
+            or (
+                self.metadata.pr_id
+                and self.project.get_pr(
+                    self.metadata.pr_id
+                ).source_project.get_web_url()
+            )
+            or self.project.get_web_url()
         )
 
     @property


### PR DESCRIPTION
When providing FMF URL to the testing farm, consider also case when there
is no related PR and job is running on `commit` trigger, in such case,
provide URL of the project itself.

Fixes #1470

Signed-off-by: Matej Focko <mfocko@redhat.com>

---

RELEASE NOTES BEGIN
We have fixed a bug that caused Packit to fail when submitting Testing Farm on `commit` trigger.
RELEASE NOTES END
