### PR TITLE
fix(copr): do not bump version for release SRPM

### DIFF
--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -412,6 +412,7 @@ class BaseBuildJobHelper(BaseJobHelper):
                     srpm_dir=self.api.up.local_project.working_dir,
                     bump_version=self.job_config.trigger
                     != JobConfigTriggerType.release,
+                    release_suffix=self.job_config.release_suffix,
                 )
             )
         except SandcastleTimeoutReached as ex:

--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Set, Tuple
 
 from kubernetes.client.rest import ApiException
 from ogr.abstract import GitProject
-from packit.config import JobConfig, JobType
+from packit.config import JobConfig, JobType, JobConfigTriggerType
 from packit.config.aliases import DEFAULT_VERSION
 from packit.config.package_config import PackageConfig
 from packit.exceptions import PackitMergeException
@@ -408,7 +408,11 @@ class BaseBuildJobHelper(BaseJobHelper):
 
         try:
             self._srpm_path = Path(
-                self.api.create_srpm(srpm_dir=self.api.up.local_project.working_dir)
+                self.api.create_srpm(
+                    srpm_dir=self.api.up.local_project.working_dir,
+                    bump_version=self.job_config.trigger
+                    != JobConfigTriggerType.release,
+                )
             )
         except SandcastleTimeoutReached as ex:
             exception = ex

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -10,7 +10,7 @@ from copr.v3 import CoprAuthException, CoprRequestException
 from ogr.abstract import GitProject
 from ogr.parsing import parse_git_repo
 from ogr.services.github import GithubProject
-from packit.config import JobConfig, JobType
+from packit.config import JobConfig, JobType, JobConfigTriggerType
 from packit.config.aliases import get_aliases, get_valid_build_targets
 from packit.config.common_package_config import Deployment
 from packit.config.package_config import PackageConfig
@@ -382,6 +382,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 if pr_id
                 else None,
                 job_config_index=self.get_job_config_index(),
+                bump_version=self.job_config.trigger != JobConfigTriggerType.release,
             )
             build_id, web_url = self.submit_copr_build(script=script)
         except Exception as ex:

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -383,6 +383,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 else None,
                 job_config_index=self.get_job_config_index(),
                 bump_version=self.job_config.trigger != JobConfigTriggerType.release,
+                release_suffix=self.job_config.release_suffix,
             )
             build_id, web_url = self.submit_copr_build(script=script)
         except Exception as ex:

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -908,7 +908,10 @@ def test_copr_build_for_release(release_event):
     )
     flexmock(CoprBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
 
-    flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
+    flexmock(PackitAPI).should_receive("create_srpm").with_args(
+        srpm_dir=None,
+        bump_version=False,
+    ).and_return("my.srpm")
 
     # copr build
     flexmock(CoprHelper).should_receive("create_copr_project_if_not_exists").and_return(


### PR DESCRIPTION
When creating SRPM for Copr build on release event, do not change neither
release or version.

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
- [x] Support it with SRPM build in Copr too


Related to packit/packit#1181

Merge after packit/packit#1568

---

RELEASE NOTES BEGIN
Packit now builds RPMs in Copr triggered by `release` event with correct NVR (without the artificial release suffix). You can use it for distributing RPM packages via Copr. 
RELEASE NOTES END
