### PR TITLE
Filter most recent targets

### DIFF
--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -507,8 +507,9 @@ class AbstractForgeIndependentEvent(Event):
 
         return list(most_recent_models.values())
 
-    @staticmethod
+    @classmethod
     def _filter_most_recent_models_targets_by_status(
+        cls,
         models: Union[
             Optional[Iterable[CoprBuildTargetModel]],
             Optional[Iterable[TFTTestRunTargetModel]],
@@ -519,7 +520,7 @@ class AbstractForgeIndependentEvent(Event):
             f"Trying to filter targets with possible status: {statuses_to_filter_with} in {models}"
         )
         failed_models_targets = set()
-        for model in models:
+        for model in cls.get_most_recent_targets(models):
             if model.status in statuses_to_filter_with:
                 failed_models_targets.add(model.target)
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -1256,7 +1256,7 @@ def test_rebuild_failed(
         {"some_target"}
     )
     flexmock(AbstractForgeIndependentEvent).should_receive(
-        "_filter_failed_models_targets"
+        "_filter_most_recent_models_targets_by_status"
     ).with_args(
         models=[model], statuses_to_filter_with=[PG_BUILD_STATUS_FAILURE]
     ).and_return(
@@ -1344,7 +1344,7 @@ def test_retest_failed(
         {"some_tf_target"}
     )
     flexmock(AbstractForgeIndependentEvent).should_receive(
-        "_filter_failed_models_targets"
+        "_filter_most_recent_models_targets_by_status"
     ).with_args(
         models=[model],
         statuses_to_filter_with=[TestingFarmResult.failed, TestingFarmResult.error],

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1456,16 +1456,16 @@ class TestEvents:
         )
         assert len(latest_copr_models) == 1
         assert datetime.utcnow() - latest_copr_models[
-            "target"
+            0
         ].build_submitted_time < timedelta(seconds=2)
 
         latest_tf_models = AbstractForgeIndependentEvent.get_most_recent_targets(
             tf_models
         )
         assert len(latest_tf_models) == 1
-        assert datetime.utcnow() - latest_tf_models[
-            "target"
-        ].submitted_time < timedelta(seconds=2)
+        assert datetime.utcnow() - latest_tf_models[0].submitted_time < timedelta(
+            seconds=2
+        )
 
 
 class TestCentOSEventParser:

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -5,7 +5,7 @@
 Tests for events parsing
 """
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 import pytest
 from flexmock import flexmock
@@ -49,6 +49,7 @@ from packit_service.worker.events import (
     CheckRerunCommitEvent,
     CheckRerunPullRequestEvent,
     CheckRerunReleaseEvent,
+    AbstractForgeIndependentEvent,
 )
 from packit_service.worker.events.enums import (
     PullRequestAction,
@@ -197,6 +198,41 @@ class TestEvents:
             DATA_DIR / "webhooks" / "github" / "checkrun_rerequested.json"
         ) as outfile:
             return json.load(outfile)
+
+    @pytest.fixture()
+    def copr_models(self):
+        time = datetime(2000, 4, 28, 14, 9, 33, 860293)
+        latest_time = datetime.utcnow()
+        fake_copr = flexmock(build_id="1", build_submitted_time=time, target="target")
+        flexmock(CoprBuildTargetModel).new_instances(fake_copr)
+        copr = CoprBuildTargetModel()
+        copr.__class__ = CoprBuildTargetModel
+
+        another_fake_copr = flexmock(
+            build_id="2", build_submitted_time=latest_time, target="target"
+        )
+        flexmock(CoprBuildTargetModel).new_instances(another_fake_copr)
+        another_copr = CoprBuildTargetModel()
+        another_copr.__class__ = CoprBuildTargetModel
+
+        yield [copr, another_copr]
+
+    @pytest.fixture()
+    def tf_models(self):
+        time = datetime(2000, 4, 28, 14, 9, 33, 860293)
+        latest_time = datetime.utcnow()
+        fake_tf = flexmock(pipeline_id="1", submitted_time=time, target="target")
+        flexmock(TFTTestRunTargetModel).new_instances(fake_tf)
+        tf = TFTTestRunTargetModel()
+        tf.__class__ = TFTTestRunTargetModel
+
+        another_fake_tf = flexmock(
+            pipeline_id="2", submitted_time=latest_time, target="target"
+        )
+        flexmock(TFTTestRunTargetModel).new_instances(another_fake_tf)
+        another_tf = TFTTestRunTargetModel()
+        another_tf.__class__ = TFTTestRunTargetModel
+        yield [tf, another_tf]
 
     @pytest.fixture()
     def mock_config(self):
@@ -1394,6 +1430,42 @@ class TestEvents:
         assert event_object.build_targets_override is None
         assert event_object.tests_targets_override == {"fedora-rawhide-x86_64"}
         assert event_object.actor == "lbarcziova"
+
+    def test_get_submitted_time_from_model(self):
+        date = datetime.utcnow()
+
+        fake_tf = flexmock(submitted_time=date)
+        flexmock(TFTTestRunTargetModel).new_instances(fake_tf)
+        tf = TFTTestRunTargetModel()
+        tf.__class__ = TFTTestRunTargetModel
+        assert date == AbstractForgeIndependentEvent._get_submitted_time_from_model(tf)
+
+        fake_copr = flexmock(build_submitted_time=date)
+        flexmock(CoprBuildTargetModel).new_instances(fake_copr)
+        copr = CoprBuildTargetModel()
+        copr.__class__ = (
+            CoprBuildTargetModel  # to pass in isinstance(model, CoprBuildTargetModel)
+        )
+        assert date == AbstractForgeIndependentEvent._get_submitted_time_from_model(
+            copr
+        )
+
+    def test_get_most_recent_targets(self, copr_models, tf_models):
+        latest_copr_models = AbstractForgeIndependentEvent.get_most_recent_targets(
+            copr_models
+        )
+        assert len(latest_copr_models) == 1
+        assert datetime.utcnow() - latest_copr_models[
+            "target"
+        ].build_submitted_time < timedelta(seconds=2)
+
+        latest_tf_models = AbstractForgeIndependentEvent.get_most_recent_targets(
+            tf_models
+        )
+        assert len(latest_tf_models) == 1
+        assert datetime.utcnow() - latest_tf_models[
+            "target"
+        ].submitted_time < timedelta(seconds=2)
 
 
 class TestCentOSEventParser:

--- a/tests_openshift/database/test_events.py
+++ b/tests_openshift/database/test_events.py
@@ -463,7 +463,7 @@ def test_filter_failed_models_targets_copr(
 
     assert (
         len(
-            AbstractForgeIndependentEvent._filter_failed_models_targets(
+            AbstractForgeIndependentEvent._filter_most_recent_models_targets_by_status(
                 models=builds_list,
                 statuses_to_filter_with=[PG_BUILD_STATUS_FAILURE],
             )
@@ -488,7 +488,7 @@ def test_filter_failed_models_targets_tf(
 
     assert (
         len(
-            AbstractForgeIndependentEvent._filter_failed_models_targets(
+            AbstractForgeIndependentEvent._filter_most_recent_models_targets_by_status(
                 models=test_list,
                 statuses_to_filter_with=[
                     TestingFarmResult.failed,


### PR DESCRIPTION
for `/packit rebuild-retest-failed` we want to search for most recent copr/tf models in DB. Currently we search only for models which matches commit sha.
But what if some builds fails and after `/packit rebuild-failed` all builds succeeds? 
- we still have that failed model connected to commit sha so after another `rebuild-failed` we rebuild the previously failed build even if the latest build for corresponding target passed.

aditional functionality of filtering the most recent targets from iterable of models should solve this issue

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to #1375 and maybe finally closes it? :D

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
