### PR TITLE
Allowlist automatic check

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -39,6 +39,7 @@
           - fedpkg-stage
           - postgresql # pg_dump
           - python3-boto3 # AWS (S3)
+          - python3-fasjson-client
         state: present
     - import_tasks: tasks/install-packit-deps.yaml
     - import_tasks: tasks/install-ogr-deps.yaml

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -16,7 +16,6 @@
           # changes b/w major versions and we want to pin to the specific
           # version to be sure it works well - it's 12.0.1 for now
           # - python3-kubernetes  # for sandcastle
-          - python3-fedora # to access FAS
           - python3-requests
           - python3-alembic
           - python3-prometheus_client
@@ -36,7 +35,6 @@
           - dnf-plugins-core
           # oc rsync /tmp/sandcastle -> sandcastle pod
           - rsync
-          - fedpkg-stage
           - postgresql # pg_dump
           - python3-boto3 # AWS (S3)
           - python3-fasjson-client

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -208,3 +208,5 @@ INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED = (
     "via `{packit_comment_command_prefix} build` comment "
     "or only test job via `{packit_comment_command_prefix} test` comment.*",
 )
+
+FASJSON_URL = "https://fasjson.fedoraproject.org"

--- a/packit_service/worker/handlers/forges.py
+++ b/packit_service/worker/handlers/forges.py
@@ -64,8 +64,10 @@ class GithubAppInstallationHandler(JobHandler):
         """
         GithubInstallationModel.create(event=self.installation_event)
         # try to add user to allowlist
-        allowlist = Allowlist()
-        if not allowlist.add_namespace(f"github.com/{self.account_login}"):
+        allowlist = Allowlist(self.service_config)
+        if not allowlist.add_namespace(
+            f"github.com/{self.account_login}", self.sender_login
+        ):
             # Create an issue in our repository, so we are notified when someone install the app
             self.project.create_issue(
                 title=f"{self.account_type} {self.account_login} needs to be approved.",

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -32,7 +32,7 @@ def test_installation():
 
     flexmock(GithubInstallationModel).should_receive("create").once()
     flexmock(Allowlist).should_receive("add_namespace").with_args(
-        "github.com/packit-service"
+        "github.com/packit-service", "jpopelka"
     ).and_return(False)
     flexmock(GithubProject).should_receive("create_issue").once()
 


### PR DESCRIPTION
I don't know how to make the testing nicer, since the [fasjson_client library](https://github.com/fedora-infra/fasjson-client) has  dynamic api methods so I can't mock the `get_user` directly, any suggestions are welcome :D (I tested the get_user locally and was following [their docs](https://github.com/fedora-infra/fasjson-client/blob/dev/docs/migration.rst#person_by_username))

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #1257 

---

RELEASE NOTES BEGIN
TODO
RELEASE NOTES END
