### PR TITLE
Inform user about failure only on the last try

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -397,12 +397,14 @@ class DownstreamKojiBuildHandler(JobHandler):
         package_config: PackageConfig,
         job_config: JobConfig,
         event: dict,
+        task: Optional[Task] = None,
     ):
         super().__init__(
             package_config=package_config,
             job_config=job_config,
             event=event,
         )
+        self.task = task
         self.dg_branch = event.get("git_ref")
 
     def pre_check(self) -> bool:
@@ -449,6 +451,14 @@ class DownstreamKojiBuildHandler(JobHandler):
                 logger.debug(
                     "No issue repository configured. "
                     "User will not be notified about the failure."
+                )
+                raise ex
+
+            if self.task and self.task.request.retries < int(
+                getenv("CELERY_RETRY_LIMIT", DEFAULT_RETRY_LIMIT)
+            ):
+                logger.debug(
+                    "Celery task will be retried. User will not be notified about the failure."
                 )
                 raise ex
 

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -224,13 +224,19 @@ def run_sync_from_downstream_handler(
 
 
 @celery_app.task(
-    name=TaskName.downstream_koji_build, base=HandlerTaskWithRetry, queue="long-running"
+    bind=True,
+    name=TaskName.downstream_koji_build,
+    base=HandlerTaskWithRetry,
+    queue="long-running",
 )
-def run_downstream_koji_build(event: dict, package_config: dict, job_config: dict):
+def run_downstream_koji_build(
+    self, event: dict, package_config: dict, job_config: dict
+):
     handler = DownstreamKojiBuildHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,
+        task=self,
     )
     return get_handlers_task_results(handler.run_job(), event)
 
@@ -248,13 +254,17 @@ def run_downstream_koji_build_report(
 
 
 @celery_app.task(
-    name=TaskName.bodhi_update, base=HandlerTaskWithRetry, queue="long-running"
+    bind=True,
+    name=TaskName.bodhi_update,
+    base=HandlerTaskWithRetry,
+    queue="long-running",
 )
-def run_bodhi_update(event: dict, package_config: dict, job_config: dict):
+def run_bodhi_update(self, event: dict, package_config: dict, job_config: dict):
     handler = CreateBodhiUpdateHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,
+        task=self,
     )
     return get_handlers_task_results(handler.run_job(), event)
 


### PR DESCRIPTION
Signed-off-by: Frantisek Lachman <flachman@redhat.com>

Fixes: #1482

---

RELEASE NOTES BEGIN
Packit now correctly inform users about downstream errors only on the last try. (Previously, Packit informed for all tries even the last try succeded.)
RELEASE NOTES END
