### PR TITLE
feat(tf): pass Copr project and RPMs

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -219,6 +219,12 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             "PACKIT_SOURCE_URL": self.source_project_url,
             "PACKIT_TARGET_URL": self.target_project_url,
             "PACKIT_PR_ID": self.pr_id,
+            "PACKIT_COPR_PROJECT": f"{build.owner}/{build.project_name}"
+            if build
+            else None,
+            "PACKIT_COPR_RPMS": " ".join(artifact["packages"])
+            if artifact and artifact.get("packages")
+            else None,
         }
         predefined_environment = {
             k: v for k, v in predefined_environment.items() if v is not None

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -506,6 +506,8 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
                     "PACKIT_SOURCE_URL": "https://github.com/source/bar",
                     "PACKIT_TARGET_URL": "https://github.com/target/bar",
                     "PACKIT_PR_ID": 24,
+                    "PACKIT_COPR_PROJECT": "some-owner/some-project",
+                    "PACKIT_COPR_RPMS": "hello-world-0.1-1.noarch",
                 },
             }
         ],

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -499,6 +499,8 @@ def test_payload(
             }
         ],
         build_logs_url=log_url,
+        owner="builder",
+        project_name="some_package",
     )
     copr_build.should_receive("get_srpm_build").and_return(flexmock(url=srpm_url))
 
@@ -510,7 +512,7 @@ def test_payload(
         "ref": commit_sha,
     }
 
-    assert payload["environments"] == [
+    expected_environments = [
         {
             "arch": arch,
             "os": {"compose": compose},
@@ -529,9 +531,15 @@ def test_payload(
                 "PACKIT_TARGET_SHA": "abcdefgh",
                 "PACKIT_TARGET_URL": "https://github.com/packit/packit",
                 "PACKIT_PR_ID": 123,
+                "PACKIT_COPR_PROJECT": "builder/some_package",
             },
         }
     ]
+    if packages_to_send:
+        expected_environments[0]["variables"]["PACKIT_COPR_RPMS"] = " ".join(
+            packages_to_send
+        )
+    assert payload["environments"] == expected_environments
     assert payload["notification"]["webhook"]["url"].endswith("/testing-farm/results")
 
 
@@ -648,6 +656,8 @@ def test_test_repo(fmf_url, fmf_ref, result_url, result_ref):
             }
         ],
         build_logs_url=log_url,
+        owner="mf",
+        project_name="tree",
     )
     copr_build.should_receive("get_srpm_build").and_return(flexmock(url=srpm_url))
 


### PR DESCRIPTION
Fixes #1045

Signed-off-by: Matej Focko <mfocko@redhat.com>

---

RELEASE NOTES BEGIN
Packit now passes `PACKIT_COPR_PROJECT` and `PACKIT_COPR_RPMS` variables to the Testing Farm. `PACKIT_COPR_PROJECT` holds Copr project in format `owner/project` and `PACKIT_COPR_RPMS` space-separated RPMs that were built in Copr.
RELEASE NOTES END
