### PR TITLE
Remove JobMetadataConfig class

### DIFF
--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -87,7 +87,7 @@ class CreateBodhiUpdateHandler(JobHandler):
 
         if self.koji_build_event.git_ref not in (
             configured_branches := get_branches(
-                *(self.job_config.metadata.dist_git_branches or {"fedora-stable"}),
+                *(self.job_config.dist_git_branches or {"fedora-stable"}),
                 default_dg_branch="rawhide",  # Koji calls it rawhide, not main
             )
         ):

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -117,7 +117,7 @@ class CoprBuildHandler(JobHandler):
         test_job = self.copr_build_helper.job_tests
         if (
             test_job
-            and test_job.metadata.use_internal_tf
+            and test_job.use_internal_tf
             and not self.project.can_merge_pr(actor)
         ):
             self.copr_build_helper.report_status_to_build(

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -411,7 +411,7 @@ class DownstreamKojiBuildHandler(JobHandler):
         if self.data.event_type in (PushPagureEvent.__name__,):
             if self.data.git_ref not in (
                 configured_branches := get_branches(
-                    *self.job_config.metadata.dist_git_branches,
+                    *self.job_config.dist_git_branches,
                     default="main",
                     with_aliases=True,
                 )
@@ -442,7 +442,7 @@ class DownstreamKojiBuildHandler(JobHandler):
         try:
             packit_api.build(
                 dist_git_branch=self.dg_branch,
-                scratch=self.job_config.metadata.scratch,
+                scratch=self.job_config.scratch,
                 nowait=True,
                 from_upstream=False,
             )

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -101,9 +101,7 @@ class TestingFarmHandler(JobHandler):
         """
         The job is not allowed for external contributors when using internal TF.
         """
-        if self.job_config.metadata.use_internal_tf and not self.project.can_merge_pr(
-            actor
-        ):
+        if self.job_config.use_internal_tf and not self.project.can_merge_pr(actor):
             message = (
                 INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED
                 if self.testing_farm_job_helper.job_build

--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -79,10 +79,10 @@ class BaseBuildJobHelper(BaseJobHelper):
         """
         targets = set()
         if self.job_build:
-            targets.update(self.job_build.metadata.targets)
+            targets.update(self.job_build.targets)
 
-        if self.job_tests and not self.job_tests.metadata.skip_build:
-            targets.update(self.job_tests.metadata.targets)
+        if self.job_tests and not self.job_tests.skip_build:
+            targets.update(self.job_tests.targets)
 
         return targets or {DEFAULT_VERSION}
 
@@ -101,10 +101,10 @@ class BaseBuildJobHelper(BaseJobHelper):
         if not self.job_tests:
             return set()
 
-        if not self.job_tests.metadata.targets and self.job_build:
+        if not self.job_tests.targets and self.job_build:
             return self.configured_build_targets
 
-        return self.job_tests.metadata.targets or {DEFAULT_VERSION}
+        return self.job_tests.targets or {DEFAULT_VERSION}
 
     @property
     def job_build(self) -> Optional[JobConfig]:
@@ -129,8 +129,8 @@ class BaseBuildJobHelper(BaseJobHelper):
         """
         Branch used for the build job or project's default branch.
         """
-        if self.job_build and self.job_build.metadata.branch:
-            return self.job_build.metadata.branch
+        if self.job_build and self.job_build.branch:
+            return self.job_build.branch
 
         return self.project.default_branch
 

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -120,11 +120,11 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         """
         The job definition from the config file.
         """
-        if self.job_build and self.job_build.metadata.project:
-            return self.job_build.metadata.project
+        if self.job_build and self.job_build.project:
+            return self.job_build.project
 
-        if self.job_tests and self.job_tests.metadata.project:
-            return self.job_tests.metadata.project
+        if self.job_tests and self.job_tests.project:
+            return self.job_tests.project
 
         return self.default_project_name
 
@@ -133,11 +133,11 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         """
         Owner used for the copr build -- search the config or use the copr's config.
         """
-        if self.job_build and self.job_build.metadata.owner:
-            return self.job_build.metadata.owner
+        if self.job_build and self.job_build.owner:
+            return self.job_build.owner
 
-        if self.job_tests and self.job_tests.metadata.owner:
-            return self.job_tests.metadata.owner
+        if self.job_tests and self.job_tests.owner:
+            return self.job_tests.owner
 
         return self.api.copr_helper.copr_client.config.get("username")
 
@@ -146,21 +146,21 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         """
         If the project will be preserved or can be removed after 60 days.
         """
-        return self.job_build.metadata.preserve_project if self.job_build else None
+        return self.job_build.preserve_project if self.job_build else None
 
     @property
     def list_on_homepage(self) -> Optional[bool]:
         """
         If the project will be shown on the copr home page.
         """
-        return self.job_build.metadata.list_on_homepage if self.job_build else None
+        return self.job_build.list_on_homepage if self.job_build else None
 
     @property
     def additional_repos(self) -> Optional[List[str]]:
         """
         Additional repos that will be enable for copr build.
         """
-        return self.job_build.metadata.additional_repos if self.job_build else None
+        return self.job_build.additional_repos if self.job_build else None
 
     @property
     def build_targets_all(self) -> Set[str]:
@@ -227,16 +227,16 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             return set()
 
         distro, arch = build_target.rsplit("-", 1)
-        configured_distros = self.job_tests.metadata.targets_dict.get(
-            build_target, {}
-        ).get("distros")
+        configured_distros = self.job_tests.targets_dict.get(build_target, {}).get(
+            "distros"
+        )
 
         if configured_distros:
             distro_arch_list = [(distro, arch) for distro in configured_distros]
         else:
             mapping = (
                 DEFAULT_MAPPING_INTERNAL_TF
-                if self.job_config.metadata.use_internal_tf
+                if self.job_config.use_internal_tf
                 else DEFAULT_MAPPING_TF
             )
             distro = mapping.get(distro, distro)
@@ -440,7 +440,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                     + self.package_config.srpm_build_deps,
                     buildopts={
                         "chroots": list(self.build_targets),
-                        "enable_net": self.job_config.metadata.enable_net,
+                        "enable_net": self.job_config.enable_net,
                     },
                 )
             else:
@@ -450,7 +450,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                     path=self.srpm_path,
                     buildopts={
                         "chroots": list(self.build_targets),
-                        "enable_net": self.job_config.metadata.enable_net,
+                        "enable_net": self.job_config.enable_net,
                     },
                 )
 

--- a/packit_service/worker/helpers/build/koji_build.py
+++ b/packit_service/worker/helpers/build/koji_build.py
@@ -65,7 +65,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
 
     @property
     def is_scratch(self) -> bool:
-        return self.job_build and self.job_build.metadata.scratch
+        return self.job_build and self.job_build.scratch
 
     @property
     def build_targets_all(self) -> Set[str]:

--- a/packit_service/worker/helpers/propose_downstream.py
+++ b/packit_service/worker/helpers/propose_downstream.py
@@ -122,7 +122,7 @@ class ProposeDownstreamJobHelper(BaseJobHelper):
         Return all valid branches from config.
         """
         branches = get_branches(
-            *self.job.metadata.dist_git_branches, default=self.default_dg_branch
+            *self.job.dist_git_branches, default=self.default_dg_branch
         )
         if self.branches_override:
             logger.debug(f"Branches override: {self.branches_override}")

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -86,19 +86,19 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             # This is checked in the run_testing_farm method.
             self._tft_token = (
                 self.service_config.internal_testing_farm_secret
-                if self.job_config.metadata.use_internal_tf
+                if self.job_config.use_internal_tf
                 else self.service_config.testing_farm_secret
             )
         return self._tft_token
 
     @property
     def skip_build(self) -> bool:
-        return self.job_config.metadata.skip_build
+        return self.job_config.skip_build
 
     @property
     def fmf_url(self) -> str:
         return (
-            self.job_config.metadata.fmf_url
+            self.job_config.fmf_url
             or (
                 self.metadata.pr_id
                 and self.project.get_pr(
@@ -110,8 +110,8 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
     @property
     def fmf_ref(self) -> str:
-        if self.job_config.metadata.fmf_url:
-            return self.job_config.metadata.fmf_ref
+        if self.job_config.fmf_url:
+            return self.job_config.fmf_ref
 
         return self.metadata.commit_sha
 
@@ -224,8 +224,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             k: v for k, v in predefined_environment.items() if v is not None
         }
         # User-defined variables have priority
-        metadata = self.job_config.metadata
-        env_variables = metadata.env if hasattr(metadata, "env") else {}
+        env_variables = self.job_config.env if hasattr(self.job_config, "env") else {}
         predefined_environment.update(env_variables)
 
         environment: Dict[str, Any] = {
@@ -292,7 +291,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
     def is_fmf_configured(self) -> bool:
 
-        if self.job_config.metadata.fmf_url is not None:
+        if self.job_config.fmf_url is not None:
             return True
 
         try:
@@ -327,7 +326,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             # TF has separate composes for aarch64 architecture
             compose += "-aarch64"
 
-        if self.job_config.metadata.use_internal_tf:
+        if self.job_config.use_internal_tf:
             # Internal TF does not have own endpoint for composes
             # This should be solved on the TF side.
             if compose == "Fedora-Rawhide":
@@ -413,7 +412,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             )
 
         if (
-            self.job_config.metadata.use_internal_tf
+            self.job_config.use_internal_tf
             and f"{self.project.service.hostname}/{self.project.full_repo_name}"
             not in self.service_config.enabled_projects_for_internal_tf
         ):

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -106,7 +106,7 @@ def test_bodhi_update_for_unknown_koji_build_failed(koji_build_completed_old_for
     packit_yaml = (
         "{'specfile_path': 'packit.spec',"
         "'jobs': [{'trigger': 'commit', 'job': 'bodhi_update',"
-        "'metadata': {'dist_git_branches': ['rawhide']}}],"
+        "'dist_git_branches': ['rawhide']}],"
         "'downstream_package_name': 'packit'}"
     )
     pagure_project_mock = flexmock(

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -432,7 +432,9 @@ def test_check_rerun_push_copr_build_handler(
                 {
                     "trigger": "commit",
                     "job": "tests",
-                    "metadata": {"targets": "fedora-all"},
+                    "targets": [
+                        "fedora-all",
+                    ],
                 }
             ]
         ]

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -535,16 +535,16 @@ def test_downstream_koji_build_where_multiple_branches_defined(jobs_config):
         pytest.param(
             "["
             "{'trigger': 'commit', 'job': 'koji_build', "
-            "'metadata': {'dist_git_branches': ['a-different-branch']}},"
+            "'dist_git_branches': ['a-different-branch']},"
             "{'trigger': 'commit', 'job': 'koji_build', "
-            "'metadata': {'dist_git_branches': ['other_branch']}}"
+            "'dist_git_branches': ['other_branch']}"
             "]",
             id="multiple_jobs",
         ),
         pytest.param(
             "["
             "{'trigger': 'commit', 'job': 'koji_build', "
-            "'metadata': {'dist_git_branches': ['a-different-branch', 'other_branch']}}"
+            "'dist_git_branches': ['a-different-branch', 'other_branch']}"
             "]",
             id="multiple_branches",
         ),

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -8,7 +8,6 @@ from flexmock import flexmock
 
 from ogr.services.github import GithubProject
 from packit.config import JobConfig, JobConfigTriggerType, JobType, PackageConfig
-from packit.config.job_config import JobMetadataConfig
 from packit_service.config import ServiceConfig
 from packit_service.constants import KOJI_PRODUCTION_BUILDS_ISSUE
 from packit_service.models import (
@@ -48,7 +47,6 @@ def test_handler_cleanup(tmp_path, trick_p_s_with_k8s):
     jc = JobConfig(
         type=JobType.copr_build,
         trigger=JobConfigTriggerType.pull_request,
-        metadata=JobMetadataConfig(),
     )
     j = JobHandler(
         package_config=pc,
@@ -106,14 +104,14 @@ def test_precheck_push(github_push_event):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(branch="build-branch"),
+                    branch="build-branch",
                 ),
             ]
         ),
         job_config=JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.commit,
-            metadata=JobMetadataConfig(branch="build-branch"),
+            branch="build-branch",
         ),
         event=github_push_event.get_dict(),
     )
@@ -132,14 +130,14 @@ def test_precheck_push_to_a_different_branch(github_push_event):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(branch="bad-branch"),
+                    branch="bad-branch",
                 ),
             ]
         ),
         job_config=JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.commit,
-            metadata=JobMetadataConfig(branch="bad-branch"),
+            branch="bad-branch",
         ),
         event=github_push_event.get_dict(),
     )
@@ -177,16 +175,16 @@ def test_precheck_koji_build_non_scratch(github_pr_event):
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        _targets=["bright-future"], scratch=False
-                    ),
+                    _targets=["bright-future"],
+                    scratch=False,
                 ),
             ]
         ),
         job_config=JobConfig(
             type=JobType.production_build,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(_targets=["bright-future"], scratch=False),
+            _targets=["bright-future"],
+            scratch=False,
         ),
         event=github_pr_event.get_dict(),
     )

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -15,7 +15,6 @@ import packit_service.service.urls as urls
 from ogr.services.github import GithubProject
 from ogr.utils import RequestResponse
 from packit.config import JobConfig, JobConfigTriggerType, JobType
-from packit.config.job_config import JobMetadataConfig
 from packit.config.package_config import PackageConfig
 from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
@@ -110,7 +109,7 @@ def pc_build_pr():
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                metadata=JobMetadataConfig(_targets=["fedora-all"]),
+                _targets=["fedora-all"],
             )
         ]
     )
@@ -123,7 +122,7 @@ def pc_koji_build_pr():
             JobConfig(
                 type=JobType.production_build,
                 trigger=JobConfigTriggerType.pull_request,
-                metadata=JobMetadataConfig(_targets=["fedora-all"]),
+                _targets=["fedora-all"],
             )
         ]
     )
@@ -136,7 +135,7 @@ def pc_build_push():
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.commit,
-                metadata=JobMetadataConfig(_targets=["fedora-all"]),
+                _targets=["fedora-all"],
             )
         ]
     )
@@ -149,7 +148,7 @@ def pc_build_release():
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.release,
-                metadata=JobMetadataConfig(_targets=["fedora-all"]),
+                _targets=["fedora-all"],
             )
         ]
     )
@@ -162,7 +161,7 @@ def pc_tests():
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
-                metadata=JobMetadataConfig(_targets=["fedora-all"]),
+                _targets=["fedora-all"],
             )
         ]
     )
@@ -423,14 +422,12 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                metadata=JobMetadataConfig(
-                    _targets=["fedora-rawhide"],
-                ),
+                _targets=["fedora-rawhide"],
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
-                metadata=JobMetadataConfig(_targets=["fedora-rawhide"]),
+                _targets=["fedora-rawhide"],
             ),
         ]
     )
@@ -630,14 +627,12 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                metadata=JobMetadataConfig(
-                    _targets=["fedora-rawhide"],
-                ),
+                _targets=["fedora-rawhide"],
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
-                metadata=JobMetadataConfig(_targets=["fedora-rawhide"]),
+                _targets=["fedora-rawhide"],
             ),
         ]
     )
@@ -769,14 +764,12 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                metadata=JobMetadataConfig(
-                    _targets=["fedora-rawhide"],
-                ),
+                _targets=["fedora-rawhide"],
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
-                metadata=JobMetadataConfig(_targets=["fedora-rawhide"]),
+                _targets=["fedora-rawhide"],
             ),
         ]
     )

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -663,7 +663,9 @@ def test_pr_comment_packit_only_handler(
                 {
                     "trigger": "pull_request",
                     "job": "copr_build",
-                    "metadata": {"targets": "fedora-rawhide-x86_64"},
+                    "targets": [
+                        "fedora-rawhide-x86_64",
+                    ],
                 }
             ]
         ]

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -299,7 +299,7 @@ def test_dist_git_push_release_handle_one_failed(
     packit_yaml = (
         "{'specfile_path': 'hello-world.spec', 'synced_files': []"
         ", jobs: [{trigger: release, job: propose_downstream, "
-        "metadata: {targets:[], dist-git-branch: fedora-all}}]}"
+        "targets:[], dist_git_branches: [fedora-all,]}]}"
     )
     flexmock(Github, get_repo=lambda full_name_or_id: None)
     project = (

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -15,7 +15,6 @@ import packit_service
 from packit.api import PackitAPI
 from packit.config import JobType, JobConfig, JobConfigTriggerType
 from packit.config.common_package_config import Deployment
-from packit.config.job_config import JobMetadataConfig
 from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
 from packit_service.constants import FAQ_URL
@@ -472,7 +471,7 @@ def test_check_and_report(
         JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(_targets=["fedora-rawhide"]),
+            _targets=["fedora-rawhide"],
         )
     ]
     flexmock(PullRequestGithubEvent).should_receive("get_package_config").and_return(

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -7,7 +7,6 @@ from flexmock import flexmock
 
 from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
 from packit.config.aliases import get_build_targets
-from packit.config.job_config import JobMetadataConfig
 from packit.local_project import LocalProject
 from packit.utils.repo import RepositoryCache
 from packit_service.config import ServiceConfig
@@ -38,7 +37,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -51,7 +50,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -64,7 +63,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             JobConfigTriggerType.release,
@@ -77,7 +76,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             JobConfigTriggerType.commit,
@@ -90,12 +89,12 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(_targets=["different", "os", "target"]),
+                    _targets=["different", "os", "target"],
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -108,12 +107,12 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(_targets=["different", "os", "target"]),
+                    _targets=["different", "os", "target"],
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -126,12 +125,12 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["different", "os", "target"]),
+                    _targets=["different", "os", "target"],
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 ),
             ],
             JobConfigTriggerType.commit,
@@ -168,7 +167,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -197,7 +196,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 ),
                 JobConfig(
                     type=JobType.tests,
@@ -218,7 +217,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -235,7 +234,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=list(ONE_CHROOT_SET)),
+                    _targets=list(ONE_CHROOT_SET),
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -349,7 +348,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=list(ONE_CHROOT_SET)),
+                    _targets=list(ONE_CHROOT_SET),
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -362,12 +361,12 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["fedora-rawhide"]),
+                    _targets=["fedora-rawhide"],
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -403,7 +402,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 ),
                 JobConfig(
                     type=JobType.tests,
@@ -422,7 +421,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -437,7 +436,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -452,9 +451,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}}
-                    ),
+                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -469,9 +466,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}}
-                    ),
+                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -486,7 +481,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["centos-stream-8"]),
+                    _targets=["centos-stream-8"],
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -501,7 +496,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["centos-stream-8"]),
+                    _targets=["centos-stream-8"],
                 ),
                 JobConfig(
                     type=JobType.tests,
@@ -520,7 +515,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["epel-7-x86_64"]),
+                    _targets=["epel-7-x86_64"],
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -535,7 +530,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["epel-7-x86_64"]),
+                    _targets=["epel-7-x86_64"],
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -550,7 +545,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["epel-7-ppc64le"]),
+                    _targets=["epel-7-ppc64le"],
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -565,7 +560,7 @@ def test_targets(jobs, job_config_trigger_type, build_chroots, test_chroots):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["epel-7-ppc64le"]),
+                    _targets=["epel-7-ppc64le"],
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -678,9 +673,8 @@ def test_copr_build_target2test_targets(
         JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(
-                _targets=configured_targets, use_internal_tf=use_internal_tf
-            ),
+            _targets=configured_targets,
+            use_internal_tf=use_internal_tf,
         )
     ]
     copr_build_helper = CoprBuildJobHelper(
@@ -700,17 +694,15 @@ def test_copr_build_and_test_targets_both_jobs_defined():
         JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(
-                _targets={
-                    "epel-8-x86_64": {},
-                    "fedora-35-x86_64": {"distros": ["fedora-35", "fedora-36"]},
-                },
-            ),
+            _targets={
+                "epel-8-x86_64": {},
+                "fedora-35-x86_64": {"distros": ["fedora-35", "fedora-36"]},
+            },
         ),
         JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(_targets=["fedora-35", "fedora-36", "epel-8"]),
+            _targets=["fedora-35", "fedora-36", "epel-8"],
         ),
     ]
     flexmock(copr_build, get_valid_build_targets=get_build_targets)
@@ -757,7 +749,7 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             "fedora-32-x86_64",
@@ -769,9 +761,7 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}}
-                    ),
+                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
                 )
             ],
             "centos-7-x86_64",
@@ -783,9 +773,7 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}}
-                    ),
+                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
                 )
             ],
             "rhel-7-x86_64",
@@ -797,9 +785,7 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}}
-                    ),
+                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
                 )
             ],
             "rhel-7-x86_64",
@@ -811,7 +797,7 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["epel-7-x86_64"]),
+                    _targets=["epel-7-x86_64"],
                 )
             ],
             "centos-7-x86_64",
@@ -823,9 +809,8 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        _targets=["epel-7-x86_64"], use_internal_tf=True
-                    ),
+                    _targets=["epel-7-x86_64"],
+                    use_internal_tf=True,
                 )
             ],
             "rhel-7-x86_64",
@@ -837,7 +822,7 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["centos-stream-9-x86_64"]),
+                    _targets=["centos-stream-9-x86_64"],
                 )
             ],
             "centos-stream-9-x86_64",
@@ -853,7 +838,7 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=["centos-stream-9-x86_64"]),
+                    _targets=["centos-stream-9-x86_64"],
                 ),
             ],
             "centos-stream-9-x86_64",
@@ -865,9 +850,8 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        _targets=["centos-stream-9-x86_64"], use_internal_tf=True
-                    ),
+                    _targets=["centos-stream-9-x86_64"],
+                    use_internal_tf=True,
                 )
             ],
             "centos-stream-9-x86_64",
@@ -909,7 +893,7 @@ def test_copr_test_target2build_target(job_config, test_target, build_target):
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -922,7 +906,7 @@ def test_copr_test_target2build_target(job_config, test_target, build_target):
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1306,7 +1290,6 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(),
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1320,7 +1303,7 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(owner="custom-owner"),
+                    owner="custom-owner",
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1334,7 +1317,7 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="custom-project"),
+                    project="custom-project",
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1348,9 +1331,8 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        owner="custom-owner", project="custom-project"
-                    ),
+                    owner="custom-owner",
+                    project="custom-project",
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1364,9 +1346,8 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        owner="custom-owner", project="custom-project"
-                    ),
+                    owner="custom-owner",
+                    project="custom-project",
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1380,7 +1361,6 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(),
                 )
             ],
             JobConfigTriggerType.commit,
@@ -1394,7 +1374,6 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(),
                 )
             ],
             JobConfigTriggerType.release,
@@ -1408,14 +1387,14 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(
-                        owner="commit-owner", project="commit-project"
-                    ),
+                    owner="commit-owner",
+                    project="commit-project",
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(owner="pr-owner", project="pr-project"),
+                    owner="pr-owner",
+                    project="pr-project",
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -1429,12 +1408,10 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(),
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(),
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -1448,14 +1425,12 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        owner="custom-owner", project="custom-project"
-                    ),
+                    owner="custom-owner",
+                    project="custom-project",
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(),
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -1469,14 +1444,12 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(),
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        owner="custom-owner", project="custom-project"
-                    ),
+                    owner="custom-owner",
+                    project="custom-project",
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -1490,19 +1463,18 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(owner="pr-owner", project="pr-project"),
+                    owner="pr-owner",
+                    project="pr-project",
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(),
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(
-                        owner="commit-owner", project="commit-project"
-                    ),
+                    owner="commit-owner",
+                    project="commit-project",
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -1516,19 +1488,18 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(owner="pr-owner", project="pr-project"),
+                    owner="pr-owner",
+                    project="pr-project",
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(),
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(
-                        owner="commit-owner", project="commit-project"
-                    ),
+                    owner="commit-owner",
+                    project="commit-project",
                 ),
             ],
             JobConfigTriggerType.commit,
@@ -1576,7 +1547,7 @@ def test_copr_project_and_namespace(
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1589,9 +1560,8 @@ def test_copr_project_and_namespace(
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(
-                        _targets=STABLE_VERSIONS, branch="build-branch"
-                    ),
+                    _targets=STABLE_VERSIONS,
+                    branch="build-branch",
                 )
             ],
             JobConfigTriggerType.commit,
@@ -1604,9 +1574,8 @@ def test_copr_project_and_namespace(
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(
-                        _targets=STABLE_VERSIONS, branch="build-branch"
-                    ),
+                    _targets=STABLE_VERSIONS,
+                    branch="build-branch",
                 )
             ],
             JobConfigTriggerType.release,
@@ -1649,14 +1618,14 @@ def test_repository_cache_invocation():
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+                    _targets=STABLE_VERSIONS,
                 )
             ],
         ),
         job_config=JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(_targets=STABLE_VERSIONS),
+            _targets=STABLE_VERSIONS,
         ),
         project=flexmock(
             service=flexmock(),
@@ -1688,7 +1657,6 @@ def test_local_project_not_called_when_initializing_api():
         JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(),
         )
     ]
     copr_build_helper = CoprBuildJobHelper(

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -7,7 +7,6 @@ import pytest
 from flexmock import flexmock
 
 from packit.config import JobConfig, JobConfigTriggerType, JobType
-from packit.config.job_config import JobMetadataConfig
 from packit_service.constants import COMMENT_REACTION
 from packit_service.worker.events import (
     CoprBuildEndEvent,
@@ -467,7 +466,7 @@ from packit_service.worker.jobs import (
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(skip_build=True),
+                    skip_build=True,
                 ),
             ],
             {TestingFarmHandler},
@@ -484,7 +483,7 @@ from packit_service.worker.jobs import (
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(skip_build=True),
+                    skip_build=True,
                 ),
             ],
             {CoprBuildHandler, TestingFarmHandler},
@@ -989,7 +988,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(skip_build=True),
+                    skip_build=True,
                 ),
             ],
             {TestingFarmHandler},
@@ -1005,7 +1004,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(skip_build=True),
+                    skip_build=True,
                 ),
             ],
             {TestingFarmHandler},
@@ -1355,24 +1354,24 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
             ],
             id="build_for_pr_twice&CoprBuildHandler&PullRequestGithubEvent",
@@ -1386,24 +1385,24 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 )
             ],
             id="build_for_pr+build_for_commit+build_for_release"
@@ -1417,24 +1416,24 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
             ],
             id="build_for_pr+build_for_commit+build_for_release"
@@ -1448,24 +1447,24 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             id="build_for_pr+build_for_commit+build_for_release"
@@ -1480,17 +1479,17 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [],
@@ -1505,24 +1504,24 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
@@ -1536,24 +1535,24 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
@@ -1567,24 +1566,24 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
@@ -1598,24 +1597,24 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
@@ -1629,24 +1628,24 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
@@ -1661,29 +1660,29 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project0"),
+                    project="project0",
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project0"),
+                    project="project0",
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1697,29 +1696,29 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project0"),
+                    project="project0",
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1733,29 +1732,29 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project0"),
+                    project="project0",
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1769,29 +1768,29 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project0"),
+                    project="project0",
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project0"),
+                    project="project0",
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1805,29 +1804,29 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project0"),
+                    project="project0",
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project0"),
+                    project="project0",
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1841,29 +1840,29 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project0"),
+                    project="project0",
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(project="project2"),
+                    project="project2",
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(project="project3"),
+                    project="project3",
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(project="project1"),
+                    project="project1",
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"

--- a/tests/unit/test_propose_downstream.py
+++ b/tests/unit/test_propose_downstream.py
@@ -5,7 +5,7 @@ import pytest
 from flexmock import flexmock
 
 from packit.config import PackageConfig, JobConfig, JobType
-from packit.config.job_config import JobMetadataConfig, JobConfigTriggerType
+from packit.config.job_config import JobConfigTriggerType
 from packit_service.config import ServiceConfig
 from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJobHelper
 
@@ -18,7 +18,7 @@ from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJo
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(dist_git_branches=["main", "f34"]),
+                    dist_git_branches=["main", "f34"],
                 ),
             ],
             JobConfigTriggerType.release,
@@ -30,7 +30,7 @@ from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJo
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(dist_git_branches=["f34", "main"]),
+                    dist_git_branches=["f34", "main"],
                 ),
             ],
             JobConfigTriggerType.release,
@@ -42,7 +42,7 @@ from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJo
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(dist_git_branches=["f35", "f34"]),
+                    dist_git_branches=["f35", "f34"],
                 ),
             ],
             JobConfigTriggerType.release,

--- a/tests/unit/test_srpm_logs.py
+++ b/tests/unit/test_srpm_logs.py
@@ -16,7 +16,6 @@ from packit.config import (
     JobType,
     JobConfigTriggerType,
 )
-from packit.config.job_config import JobMetadataConfig
 from packit_service.config import ServiceConfig
 from packit_service.models import SRPMBuildModel
 from packit_service.service.db_triggers import AddPullRequestDbTrigger
@@ -38,21 +37,20 @@ def build_helper(
         PushGitHubEvent,
         ReleaseEvent,
     ],
-    metadata=None,
+    _targets=None,
+    scratch=None,
     trigger=None,
     jobs=None,
     db_trigger=None,
 ):
-    if not metadata:
-        metadata = JobMetadataConfig(
-            owner="nobody",
-        )
     jobs = jobs or []
     jobs.append(
         JobConfig(
             type=JobType.production_build,
             trigger=trigger or JobConfigTriggerType.pull_request,
-            metadata=metadata,
+            _targets=_targets,
+            owner="nobody",
+            scratch=scratch,
         )
     )
 
@@ -106,7 +104,8 @@ def test_build_srpm_log_format(github_pr_event):
     flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(
         event=github_pr_event,
-        metadata=JobMetadataConfig(_targets=["bright-future"], scratch=True),
+        _targets=["bright-future"],
+        scratch=True,
         db_trigger=trigger,
     )
 

--- a/tests_openshift/database/test_tasks.py
+++ b/tests_openshift/database/test_tasks.py
@@ -9,7 +9,6 @@ from munch import Munch
 import packit_service
 from ogr.services.github import GithubProject
 from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
-from packit.config.job_config import JobMetadataConfig
 from packit_service.constants import PG_BUILD_STATUS_SUCCESS
 from packit_service.models import (
     CoprBuildTargetModel,
@@ -86,14 +85,12 @@ def test_check_copr_build(clean_before_and_after, packit_build_752):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(
-                        _targets=[
-                            "fedora-30-x86_64",
-                            "fedora-rawhide-x86_64",
-                            "fedora-31-x86_64",
-                            "fedora-32-x86_64",
-                        ]
-                    ),
+                    _targets=[
+                        "fedora-30-x86_64",
+                        "fedora-rawhide-x86_64",
+                        "fedora-31-x86_64",
+                        "fedora-32-x86_64",
+                    ],
                 )
             ]
         )


### PR DESCRIPTION
This PR removes also the support for the old osolete key dist-git-brach.

Usage of metadata key in the yaml files is still supported.
If the same key, let say branch, is used both netsted to job and
netsted to job -> metadata then the job -> metadata -> branch value
in the code.

Fixes https://github.com/packit/packit/issues/1515

Merge after packit/packit#1569

RELEASE NOTES BEGIN
Metadata dictionary is no longer required when specifying a job.
Keys which used to belong to the yaml metadata dictionary are now keys of the job dictionary itself.
RELEASE NOTES END