### PR TITLE
Fix a mocked call of 'get_aliases()'

### DIFF
--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -2122,9 +2122,9 @@ def test_run_copr_build_from_source_script(github_pr_event):
 
 
 def test_get_latest_fedora_stable_chroot(github_pr_event):
-    flexmock(packit.config.aliases).should_receive("get_aliases").and_return(
-        {"fedora-stable": ["fedora-34", "fedora-35"]}
-    )
+    flexmock(packit_service.worker.helpers.build.copr_build).should_receive(
+        "get_aliases"
+    ).and_return({"fedora-stable": ["fedora-34", "fedora-35"]})
     flexmock(packit_service.worker.helpers.build.copr_build).should_receive(
         "get_valid_build_targets"
     ).with_args("fedora-35").and_return({"fedora-35-x86_64"})


### PR DESCRIPTION
When creating an expectation for a function call with the help of
flexmock, the module mocked should be the one in which the function is
imported and used, in order to be properly replaced.

In this particular example although 'get_aliases()' is _defined_ in
'packit.config.aliases', when used, it's imported in
'packit_service.worker.helpers.build.copr_build' with

    from packit.config.aliases import get_aliases

and so it becomes a name in 'copr_build'. This is why it's 'copr_build'
that needs to be mocked, instead of 'packit.config.aliases'.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>