### PR TITLE
Use the :Z suffix for volume mounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,9 @@ check-in-container:
 		--env COV_REPORT \
 		--env TEST_TARGET \
 		--env COLOR \
-		-v $(CURDIR):/src \
+		-v $(CURDIR):/src:Z \
 		-w /src \
-		--security-opt label=disable \
-		-v $(CURDIR)/files/packit-service.yaml:/root/.config/packit-service.yaml \
+		-v $(CURDIR)/files/packit-service.yaml:/root/.config/packit-service.yaml:Z \
 		$(TEST_IMAGE) make check "TEST_TARGET=$(TEST_TARGET)"
 
 # This is my target so don't touch it! :) How to:
@@ -140,12 +139,11 @@ check-db: build-test-image compose-for-db-up
 		--env COV_REPORT \
 		--env TEST_TARGET \
 		--env COLOR \
-		-v $(CURDIR):/src \
-		-v $(CURDIR)/files/packit-service.yaml:/root/.config/packit-service.yaml \
+		-v $(CURDIR):/src:z \
+		-v $(CURDIR)/files/packit-service.yaml:/root/.config/packit-service.yaml:z \
 		-v $(CURDIR)/secrets/packit/dev/fullchain.pem:/secrets/fullchain.pem:ro,z \
 		-v $(CURDIR)/secrets/packit/dev/privkey.pem:/secrets/privkey.pem:ro,z \
 		-w /src \
-		--security-opt label=disable \
 		--network packit-service_default \
 		$(TEST_IMAGE) make check "TEST_TARGET=tests_openshift/database"
 		$(COMPOSE) down

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -9,6 +9,13 @@
           - podman
         state: present
       become: true
+    # Fix the SELinux context for podman
+    - name: Create ~/.local/share/
+      file:
+        path: ~/.local/share/
+        state: directory
+        recurse: yes
+        setype: data_home_t
     - name: Run tests within a container
       command: "make check-in-container"
       args:


### PR DESCRIPTION
Instead of '--security-opt label=disable', which is an ancient way of
allowing container processes to write files in volume mounts.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>