### PR TITLE
fix SRPM build failures caused by new git

### DIFF
--- a/files/gitconfig
+++ b/files/gitconfig
@@ -3,3 +3,7 @@
     email = hello@packit.dev
 [push]
     default = current
+# https://github.com/packit/packit-service/issues/1496
+# git refuses to fetch: 'fatal: unsafe repository ('/tmp/sandcastle' is owned by someone else)'
+[safe]
+    directory = /tmp/sandcastle


### PR DESCRIPTION
git refuses to fetch: 'fatal: unsafe repository ('/tmp/sandcastle' is owned by someone else)'

Fixes https://github.com/packit/packit-service/issues/1496

---

RELEASE NOTES BEGIN

Resolved an SRPM build problem caused by a new version of git that refuses to fetch in a git repo when it's owned on the OS level by someone else.
￼
RELEASE NOTES END