### PR TITLE
submit koji builds and bodhi updates only for our own actions

### DIFF
--- a/packit_service/worker/events/pagure.py
+++ b/packit_service/worker/events/pagure.py
@@ -38,6 +38,8 @@ class PushPagureEvent(AddBranchPushDbTrigger, AbstractPagureEvent):
         git_ref: str,
         project_url: str,
         commit_sha: str,
+        name: str,
+        email: str,
     ):
         super().__init__(project_url=project_url)
         self.repo_namespace = repo_namespace
@@ -45,6 +47,8 @@ class PushPagureEvent(AddBranchPushDbTrigger, AbstractPagureEvent):
         self.git_ref = git_ref
         self.commit_sha = commit_sha
         self.identifier = git_ref
+        self.name = name
+        self.email = email
 
 
 class PullRequestCommentPagureEvent(AbstractPRCommentEvent, AbstractPagureEvent):

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -421,6 +421,20 @@ class DownstreamKojiBuildHandler(JobHandler):
                     f"Koji build configured only for '{configured_branches}'."
                 )
                 return False
+
+            # Packit should only build its own contributions
+            # We need to preserve the proven packager workflow - pushes not done by Packit
+            # should be built by those that do it, e.g. rebuilds in a side tag.
+            # prod/stg filtering happens in jobs.py -> packit_instances
+            if not (
+                self.data.event_dict["email"] == "hello@packit.dev"
+                and self.data.event_dict["name"] == "Packit"
+            ):
+                logger.info(
+                    f"Push event {self.data.identifier} ({self.data.event_dict['name']} "
+                    f"<{self.data.event_dict['email']}>) not done by us."
+                )
+                return False
         return True
 
     def run(self) -> TaskResults:

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -882,6 +882,9 @@ class Parser:
             logger.warning("Target branch/rev for the new commits is not set.")
             return None
 
+        name = nested_get(event, "commit", "name")
+        email = nested_get(event, "commit", "email")
+
         logger.info(
             f"New commits added to dist-git repo {dg_repo_namespace}/{dg_repo_name},"
             f"rev: {dg_commit}, branch: {dg_branch}"
@@ -896,6 +899,8 @@ class Parser:
             git_ref=dg_branch,
             project_url=dg_project_url,
             commit_sha=dg_commit,
+            name=name,
+            email=email,
         )
 
     @staticmethod
@@ -1375,4 +1380,6 @@ class CentosEventParser:
             git_ref=f"refs/head/{event['branch']}",
             project_url=f"https://{event['source']}/{event['repo']['url_path']}",
             commit_sha=event["end_commit"],
+            name=event["name"],
+            email=event["email"],
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from packit_service.worker.events import (
     PushGitHubEvent,
     ReleaseEvent,
     MergeRequestGitlabEvent,
+    PushPagureEvent,
 )
 from packit_service.worker.parser import Parser
 from tests.spellbook import SAVED_HTTPD_REQS, DATA_DIR, load_the_message_from_file
@@ -315,6 +316,17 @@ def github_push_event(github_push_webhook) -> PushGitHubEvent:
 def gitlab_mr_webhook():
     with open(DATA_DIR / "webhooks" / "gitlab" / "mr_event.json") as outfile:
         return json.load(outfile)
+
+
+@pytest.fixture(scope="module")
+def distgit_push_packit():
+    with open(DATA_DIR / "fedmsg" / "distgit_push_packit.json") as outfile:
+        return json.load(outfile)
+
+
+@pytest.fixture(scope="module")
+def distgit_push_event(distgit_push_packit) -> PushPagureEvent:
+    return Parser.parse_push_pagure_event(distgit_push_packit)
 
 
 @pytest.fixture(scope="module")

--- a/tests/data/fedmsg/distgit_commit.json
+++ b/tests/data/fedmsg/distgit_commit.json
@@ -3,9 +3,9 @@
   "commit": {
     "agent": "rhcontainerbot",
     "branch": "main",
-    "email": "rhcontainerbot@fedoraproject.org",
+    "email": "hello@packit.dev",
     "message": "buildah-1.12.0-0.73.dev.git1e6a70c\n\n- autobuilt 1e6a70c\n\nSigned-off-by: RH Container Bot <rhcontainerbot@fedoraproject.org>\n",
-    "name": "RH Container Bot",
+    "name": "Packit",
     "namespace": "rpms",
     "path": "/srv/git/repositories/rpms/buildah.git",
     "repo": "buildah",

--- a/tests/data/fedmsg/distgit_push_packit.json
+++ b/tests/data/fedmsg/distgit_push_packit.json
@@ -1,0 +1,52 @@
+{
+  "commit": {
+    "agent": "pagure",
+    "branch": "f36",
+    "email": "hello@packit.dev",
+    "message": "[packit] 0.50.0 upstream release\n\nUpstream tag: 0.50.0\nUpstream commit: c3667a91\n\nSigned-off-by: Packit <hello@packit.dev>\n",
+    "name": "Packit",
+    "namespace": "rpms",
+    "path": "/srv/git/repositories/rpms/packit.git",
+    "repo": "packit",
+    "rev": "ad0c308af91da45cf40b253cd82f07f63ea9cbbf",
+    "seen": false,
+    "stats": {
+      "files": {
+        ".gitignore": {
+          "additions": 1,
+          "deletions": 0,
+          "lines": 1
+        },
+        "README.packit": {
+          "additions": 1,
+          "deletions": 1,
+          "lines": 2
+        },
+        "packit.spec": {
+          "additions": 9,
+          "deletions": 1,
+          "lines": 10
+        },
+        "plans/main.fmf": {
+          "additions": 1,
+          "deletions": 1,
+          "lines": 2
+        },
+        "sources": {
+          "additions": 1,
+          "deletions": 1,
+          "lines": 2
+        }
+      },
+      "total": {
+        "additions": 13,
+        "deletions": 4,
+        "files": 5,
+        "lines": 17
+      }
+    },
+    "summary": "[packit] 0.50.0 upstream release",
+    "username": "pagure"
+  },
+  "topic": "org.fedoraproject.prod.git.receive"
+}

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1326,6 +1326,12 @@ class TestEvents:
         assert event_object.git_ref == "main"
         assert event_object.project_url == "https://src.fedoraproject.org/rpms/buildah"
 
+    def test_distgit_pagure_push_packit(self, distgit_push_packit):
+        event_object = Parser.parse_event(distgit_push_packit)
+        assert isinstance(event_object, PushPagureEvent)
+        assert event_object.name == "Packit"
+        assert event_object.email == "hello@packit.dev"
+
     def test_json_testing_farm_notification(
         self, testing_farm_notification, testing_farm_results
     ):


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] CI green (testing it out now)
- [x] Drop the bodhi commit that is not needed
- [x] Update release notes
- [x] Update or write new documentation in `packit/packit.dev`. https://github.com/packit/packit.dev/pull/455

Packit should only submit production koji builds for its own dist-git commits.
This plays nicely with the provenpackager workflow: their changes are not being
acted upon so they can safely build in sidetags or kick off builds as they
need.

This PR implements the first solution so the provenpackager workflow is possible. We should then continue with an actual allowlist.

Related: https://github.com/packit/packit-service/issues/1490

---

RELEASE NOTES BEGIN
Packit now builds only its own dist-git commits. Other commits are not being acted upon. For more info see https://github.com/packit/packit-service/issues/1490
RELEASE NOTES END