### PR TITLE
Koji allowlist

### DIFF
--- a/packit_service/worker/allowlist.py
+++ b/packit_service/worker/allowlist.py
@@ -35,6 +35,7 @@ from packit_service.worker.events import (
     CheckRerunEvent,
 )
 from packit_service.worker.events.koji import KojiBuildEvent
+from packit_service.worker.events.pagure import PullRequestMergedPagureEvent
 from packit_service.worker.helpers.build import CoprBuildJobHelper
 from packit_service.worker.reporting import BaseCommitStatus
 
@@ -50,6 +51,7 @@ UncheckedEvent = Union[
     KojiTaskEvent,
     KojiBuildEvent,
     CheckRerunEvent,
+    PullRequestMergedPagureEvent,
 ]
 
 
@@ -404,6 +406,7 @@ class Allowlist:
                 KojiTaskEvent,
                 KojiBuildEvent,
                 CheckRerunEvent,
+                PullRequestMergedPagureEvent,
             ): self._check_unchecked_event,
             (
                 ReleaseEvent,

--- a/packit_service/worker/events/pagure.py
+++ b/packit_service/worker/events/pagure.py
@@ -38,8 +38,7 @@ class PushPagureEvent(AddBranchPushDbTrigger, AbstractPagureEvent):
         git_ref: str,
         project_url: str,
         commit_sha: str,
-        name: str,
-        email: str,
+        committer: str,
     ):
         super().__init__(project_url=project_url)
         self.repo_namespace = repo_namespace
@@ -47,8 +46,7 @@ class PushPagureEvent(AddBranchPushDbTrigger, AbstractPagureEvent):
         self.git_ref = git_ref
         self.commit_sha = commit_sha
         self.identifier = git_ref
-        self.name = name
-        self.email = email
+        self.committer = committer
 
 
 class PullRequestCommentPagureEvent(AbstractPRCommentEvent, AbstractPagureEvent):

--- a/packit_service/worker/events/pagure.py
+++ b/packit_service/worker/events/pagure.py
@@ -145,6 +145,43 @@ class PullRequestPagureEvent(AddPullRequestDbTrigger, AbstractPagureEvent):
         return fork
 
 
+class PullRequestMergedPagureEvent(AddBranchPushDbTrigger, AbstractPagureEvent):
+    def __init__(
+        self,
+        pr_id: int,
+        repo_namespace: str,
+        repo_name: str,
+        base_repo_owner: str,
+        git_ref: str,
+        target_repo: str,
+        project_url: str,
+        commit_sha: str,
+        pr_author: str,
+        committer: str,
+    ):
+        super().__init__(project_url=project_url, pr_id=pr_id)
+        self.repo_namespace = repo_namespace
+        self.repo_name = repo_name
+        self.base_repo_owner = base_repo_owner
+        self.git_ref = git_ref
+        self.target_repo = target_repo
+        self.commit_sha = commit_sha
+        self.pr_author = pr_author
+        self.committer = committer
+        self.identifier = str(pr_id)
+        self.project_url = project_url
+
+    def get_base_project(self) -> GitProject:
+        fork = self.project.service.get_project(
+            namespace=self.repo_namespace,
+            repo=self.repo_name,
+            username=self.base_repo_owner,
+            is_fork=True,
+        )
+        logger.debug(f"Base project: {fork} owned by {self.base_repo_owner}")
+        return fork
+
+
 class PullRequestFlagPagureEvent(AbstractPagureEvent):
     def __init__(
         self,

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -887,8 +887,7 @@ class Parser:
             logger.warning("Target branch/rev for the new commits is not set.")
             return None
 
-        name = nested_get(event, "commit", "name")
-        email = nested_get(event, "commit", "email")
+        username = nested_get(event, "commit", "username")
 
         logger.info(
             f"New commits added to dist-git repo {dg_repo_namespace}/{dg_repo_name},"
@@ -904,8 +903,7 @@ class Parser:
             git_ref=dg_branch,
             project_url=dg_project_url,
             commit_sha=dg_commit,
-            name=name,
-            email=email,
+            committer=username,
         )
 
     @staticmethod
@@ -1417,6 +1415,5 @@ class CentosEventParser:
             git_ref=f"refs/head/{event['branch']}",
             project_url=f"https://{event['source']}/{event['repo']['url_path']}",
             commit_sha=event["end_commit"],
-            name=event["name"],
-            email=event["email"],
+            committer=event["commit"]["username"],
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from packit_service.worker.events import (
     MergeRequestGitlabEvent,
     PushPagureEvent,
 )
+from packit_service.worker.events.pagure import PullRequestMergedPagureEvent
 from packit_service.worker.parser import Parser
 from tests.spellbook import SAVED_HTTPD_REQS, DATA_DIR, load_the_message_from_file
 
@@ -327,6 +328,17 @@ def distgit_push_packit():
 @pytest.fixture(scope="module")
 def distgit_push_event(distgit_push_packit) -> PushPagureEvent:
     return Parser.parse_push_pagure_event(distgit_push_packit)
+
+
+@pytest.fixture(scope="module")
+def distgit_merged_pr():
+    with open(DATA_DIR / "fedmsg" / "distgit_merged_pr.json") as outfile:
+        return json.load(outfile)
+
+
+@pytest.fixture(scope="module")
+def distgit_merged_pr_event(distgit_merged_pr) -> PullRequestMergedPagureEvent:
+    return Parser.parse_pagure_pr_merged_event(distgit_merged_pr)
 
 
 @pytest.fixture(scope="module")

--- a/tests/data/fedmsg/distgit_merged_pr.json
+++ b/tests/data/fedmsg/distgit_merged_pr.json
@@ -1,0 +1,167 @@
+{
+  "topic": "org.fedoraproject.prod.pagure.pull-request.closed",
+  "agent": "nforro",
+  "merged": true,
+  "pullrequest": {
+    "assignee": null,
+    "branch": "epel8",
+    "branch_from": "0.3.0-epel8-update",
+    "cached_merge_status": "unknown",
+    "closed_at": "1652708223",
+    "closed_by": {
+      "full_url": "https://src.fedoraproject.org/user/nforro",
+      "fullname": "Nikola Forr\u00f3",
+      "name": "nforro",
+      "url_path": "user/nforro"
+    },
+    "comments": [
+      {
+        "comment": "Pull-Request has been merged by nforro",
+        "commit": null,
+        "date_created": "1652708223",
+        "edited_on": null,
+        "editor": null,
+        "filename": null,
+        "id": 105503,
+        "line": null,
+        "notification": true,
+        "parent": null,
+        "reactions": {},
+        "tree": null,
+        "user": {
+          "full_url": "https://src.fedoraproject.org/user/nforro",
+          "fullname": "Nikola Forr\u00f3",
+          "name": "nforro",
+          "url_path": "user/nforro"
+        }
+      }
+    ],
+    "commit_start": "0ba51c0f420befcd8fe76742fa3f2bd0e24b3740",
+    "commit_stop": "0ba51c0f420befcd8fe76742fa3f2bd0e24b3740",
+    "date_created": "1652703320",
+    "full_url": "https://src.fedoraproject.org/rpms/python-specfile/pull-request/11",
+    "id": 11,
+    "initial_comment": "Upstream tag: 0.3.0\nUpstream commit: df62e212",
+    "last_updated": "1652708223",
+    "project": {
+      "access_groups": {
+        "admin": [],
+        "collaborator": [],
+        "commit": [],
+        "ticket": []
+      },
+      "access_users": {
+        "admin": [],
+        "collaborator": [],
+        "commit": [],
+        "owner": ["nforro"],
+        "ticket": []
+      },
+      "close_status": [],
+      "custom_keys": [],
+      "date_created": "1645022033",
+      "date_modified": "1645022041",
+      "description": "A library for parsing and manipulating RPM spec files",
+      "full_url": "https://src.fedoraproject.org/rpms/python-specfile",
+      "fullname": "rpms/python-specfile",
+      "id": 55172,
+      "milestones": {},
+      "name": "python-specfile",
+      "namespace": "rpms",
+      "parent": null,
+      "priorities": {},
+      "tags": [""],
+      "url_path": "rpms/python-specfile",
+      "user": {
+        "full_url": "https://src.fedoraproject.org/user/nforro",
+        "fullname": "Nikola Forr\u00f3",
+        "name": "nforro",
+        "url_path": "user/nforro"
+      }
+    },
+    "remote_git": null,
+    "repo_from": {
+      "access_groups": {
+        "admin": [],
+        "collaborator": [],
+        "commit": [],
+        "ticket": []
+      },
+      "access_users": {
+        "admin": [],
+        "collaborator": [],
+        "commit": [],
+        "owner": ["packit-stg"],
+        "ticket": []
+      },
+      "close_status": [],
+      "custom_keys": [],
+      "date_created": "1652703212",
+      "date_modified": "1652703212",
+      "description": "A library for parsing and manipulating RPM spec files",
+      "full_url": "https://src.fedoraproject.org/fork/packit-stg/rpms/python-specfile",
+      "fullname": "forks/packit-stg/rpms/python-specfile",
+      "id": 56673,
+      "milestones": {},
+      "name": "python-specfile",
+      "namespace": "rpms",
+      "parent": {
+        "access_groups": {
+          "admin": [],
+          "collaborator": [],
+          "commit": [],
+          "ticket": []
+        },
+        "access_users": {
+          "admin": [],
+          "collaborator": [],
+          "commit": [],
+          "owner": ["nforro"],
+          "ticket": []
+        },
+        "close_status": [],
+        "custom_keys": [],
+        "date_created": "1645022033",
+        "date_modified": "1645022041",
+        "description": "A library for parsing and manipulating RPM spec files",
+        "full_url": "https://src.fedoraproject.org/rpms/python-specfile",
+        "fullname": "rpms/python-specfile",
+        "id": 55172,
+        "milestones": {},
+        "name": "python-specfile",
+        "namespace": "rpms",
+        "parent": null,
+        "priorities": {},
+        "tags": [""],
+        "url_path": "rpms/python-specfile",
+        "user": {
+          "full_url": "https://src.fedoraproject.org/user/nforro",
+          "fullname": "Nikola Forr\u00f3",
+          "name": "nforro",
+          "url_path": "user/nforro"
+        }
+      },
+      "priorities": {},
+      "tags": [],
+      "url_path": "fork/packit-stg/rpms/python-specfile",
+      "user": {
+        "full_url": "https://src.fedoraproject.org/user/packit-stg",
+        "fullname": "Packit Staging",
+        "name": "packit-stg",
+        "url_path": "user/packit-stg"
+      }
+    },
+    "status": "Merged",
+    "tags": [],
+    "threshold_reached": null,
+    "title": "Update to upstream release 0.3.0",
+    "uid": "c14ef1db56874a7087cd6b1cbdda913f",
+    "updated_on": "1652708223",
+    "user": {
+      "full_url": "https://src.fedoraproject.org/user/packit-stg",
+      "fullname": "Packit Staging",
+      "name": "packit-stg",
+      "url_path": "user/packit-stg"
+    }
+  }
+}

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -6,20 +6,23 @@ import json
 import pytest
 from celery.canvas import Signature
 from flexmock import flexmock
-
 from ogr.services.github import GithubProject
-from packit.exceptions import PackitException
-
 from ogr.services.pagure import PagureProject
+
 from packit.api import PackitAPI
 from packit.config import JobConfigTriggerType, PackageConfig, JobConfig, JobType
 from packit.config.common_package_config import Deployment
 from packit.constants import CONFIG_FILE_NAMES
+from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 from packit.utils.repo import RepositoryCache
 from packit_service.config import PackageConfigGetter, ProjectToSync, ServiceConfig
 from packit_service.constants import DEFAULT_RETRY_LIMIT, SANDCASTLE_WORK_DIR
-from packit_service.models import GitBranchModel, GitProjectModel, JobTriggerModelType
+from packit_service.models import (
+    GitBranchModel,
+    GitProjectModel,
+    JobTriggerModelType,
+)
 from packit_service.utils import load_job_config, load_package_config
 from packit_service.worker.handlers.distgit import DownstreamKojiBuildHandler
 from packit_service.worker.jobs import SteveJobs
@@ -163,7 +166,8 @@ def test_downstream_koji_build():
 
     packit_yaml = (
         "{'specfile_path': 'buildah.spec', 'synced_files': [],"
-        "'jobs': [{'trigger': 'commit', 'job': 'koji_build'}],"
+        "'jobs': [{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers':"
+        " ['rhcontainerbot']}],"
         "'downstream_package_name': 'buildah'}"
     )
     pagure_project = flexmock(
@@ -216,7 +220,8 @@ def test_downstream_koji_build_failure_no_issue():
 
     packit_yaml = (
         "{'specfile_path': 'buildah.spec',"
-        "'jobs': [{'trigger': 'commit', 'job': 'koji_build'}],"
+        "'jobs': [{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers': "
+        "['rhcontainerbot']}],"
         "'downstream_package_name': 'buildah'}"
     )
     pagure_project_mock = flexmock(
@@ -271,7 +276,8 @@ def test_downstream_koji_build_failure_issue_created():
 
     packit_yaml = (
         "{'specfile_path': 'buildah.spec',"
-        "'jobs': [{'trigger': 'commit', 'job': 'koji_build'}],"
+        "'jobs': [{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers': "
+        "['rhcontainerbot']}],"
         "'downstream_package_name': 'buildah',"
         "'issue_repository': 'https://github.com/namespace/project'}"
     )
@@ -332,7 +338,8 @@ def test_downstream_koji_build_failure_issue_comment():
 
     packit_yaml = (
         "{'specfile_path': 'buildah.spec',"
-        "'jobs': [{'trigger': 'commit', 'job': 'koji_build'}],"
+        "'jobs': [{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers': "
+        "['rhcontainerbot']}],"
         "'downstream_package_name': 'buildah',"
         "'issue_repository': 'https://github.com/namespace/project'}"
     )
@@ -441,80 +448,31 @@ def test_downstream_koji_build_no_config():
 
 
 @pytest.mark.parametrize(
-    "push_name, push_email, should_pass",
-    (("Sakamoto", "gyokuro@example.com", False), ("Packit", "hello@packit.dev", True)),
-)
-def test_precheck_koji_build_push_owner(
-    distgit_push_event, push_name, push_email, should_pass
-):
-    distgit_push_event.name = push_name
-    distgit_push_event.email = push_email
-
-    flexmock(GitProjectModel).should_receive("get_or_create").with_args(
-        namespace="rpms",
-        project_url="https://src.fedoraproject.org/rpms/packit",
-        repo_name="packit",
-    ).and_return(
-        flexmock(
-            id=342,
-        )
-    )
-    flexmock(GitBranchModel).should_receive("get_or_create").with_args(
-        branch_name="f36",
-        namespace="rpms",
-        project_url="https://src.fedoraproject.org/rpms/packit",
-        repo_name="packit",
-    ).and_return(
-        flexmock(
-            id=13,
-            job_config_trigger_type=JobConfigTriggerType.commit,
-            job_trigger_model_type=JobTriggerModelType.branch_push,
-        )
-    )
-
-    # flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
-    #     type=JobTriggerModelType.pull_request, trigger_id=342
-    # ).and_return(flexmock(id=2, type=JobTriggerModelType.pull_request))
-    # flexmock(GithubProject).should_receive("can_merge_pr").and_return(True)
-    jobs = [
-        JobConfig(
-            type=JobType.koji_build,
-            trigger=JobConfigTriggerType.pull_request,
-            dist_git_branches=["f36"],
-        ),
-    ]
-    koji_build_handler = DownstreamKojiBuildHandler(
-        package_config=PackageConfig(
-            jobs=jobs,
-        ),
-        job_config=jobs[0],
-        event=distgit_push_event.get_dict(),
-    )
-    assert koji_build_handler.pre_check() == should_pass
-
-
-@pytest.mark.parametrize(
     "jobs_config",
     [
         pytest.param(
             "["
-            "{'trigger': 'commit', 'job': 'koji_build', "
+            "{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers': "
+            "['rhcontainerbot'],"
             "'metadata': {'dist_git_branches': ['a-different-branch']}},"
-            "{'trigger': 'commit', 'job': 'koji_build', "
+            "{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers':"
+            " ['rhcontainerbot'], "
             "'metadata': {'dist_git_branches': ['main']}}"
             "]",
             id="multiple_jobs",
         ),
         pytest.param(
             "["
-            "{'trigger': 'commit', 'job': 'koji_build', "
+            "{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers': "
+            "['rhcontainerbot'], "
             "'metadata': {'dist_git_branches': ['a-different-branch', 'main', 'other_branch']}}"
             "]",
             id="multiple_branches",
         ),
         pytest.param(
             "["
-            "{'trigger': 'commit', 'job': 'koji_build', "
+            "{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers': "
+            "['rhcontainerbot'] ,"
             "'metadata': {'dist_git_branches': ['fedora-all']}}"
             "]",
             id="aliases",
@@ -587,7 +545,8 @@ def test_downstream_koji_build_where_multiple_branches_defined(jobs_config):
     [
         pytest.param(
             "["
-            "{'trigger': 'commit', 'job': 'koji_build', "
+            "{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers': "
+            "['rhcontainerbot'] ,"
             "'dist_git_branches': ['a-different-branch']},"
             "{'trigger': 'commit', 'job': 'koji_build', "
             "'dist_git_branches': ['other_branch']}"
@@ -596,14 +555,16 @@ def test_downstream_koji_build_where_multiple_branches_defined(jobs_config):
         ),
         pytest.param(
             "["
-            "{'trigger': 'commit', 'job': 'koji_build', "
+            "{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers': "
+            "['rhcontainerbot'],"
             "'dist_git_branches': ['a-different-branch', 'other_branch']}"
             "]",
             id="multiple_branches",
         ),
         pytest.param(
             "["
-            "{'trigger': 'commit', 'job': 'koji_build', "
+            "{'trigger': 'commit', 'job': 'koji_build', 'allowed_committers': "
+            "['rhcontainerbot'] ,"
             "'metadata': {'dist_git_branches': ['fedora-stable']}}"
             "]",
             id="aliases",
@@ -645,3 +606,60 @@ def test_do_not_run_downstream_koji_build_for_a_different_branch(jobs_config):
 
     processing_results = SteveJobs().process_message(distgit_commit_event())
     assert not processing_results
+
+
+@pytest.mark.parametrize(
+    "push_username, allowed_committers, should_pass",
+    (
+        ("sakamoto", [], False),
+        ("packit", ["packit"], True),
+        ("packit-stg", ["packit"], False),
+    ),
+)
+def test_precheck_koji_build_push(
+    distgit_push_event, push_username, allowed_committers, should_pass
+):
+    distgit_push_event.committer = push_username
+
+    flexmock(GitProjectModel).should_receive("get_or_create").with_args(
+        namespace="rpms",
+        project_url="https://src.fedoraproject.org/rpms/packit",
+        repo_name="packit",
+    ).and_return(
+        flexmock(
+            id=342,
+        )
+    )
+    flexmock(GitBranchModel).should_receive("get_or_create").with_args(
+        branch_name="f36",
+        namespace="rpms",
+        project_url="https://src.fedoraproject.org/rpms/packit",
+        repo_name="packit",
+    ).and_return(
+        flexmock(
+            id=13,
+            job_config_trigger_type=JobConfigTriggerType.commit,
+            job_trigger_model_type=JobTriggerModelType.branch_push,
+        )
+    )
+
+    # flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
+    #     type=JobTriggerModelType.pull_request, trigger_id=342
+    # ).and_return(flexmock(id=2, type=JobTriggerModelType.pull_request))
+    # flexmock(GithubProject).should_receive("can_merge_pr").and_return(True)
+    jobs = [
+        JobConfig(
+            type=JobType.koji_build,
+            trigger=JobConfigTriggerType.commit,
+            dist_git_branches=["f36"],
+            allowed_committers=allowed_committers,
+        ),
+    ]
+    koji_build_handler = DownstreamKojiBuildHandler(
+        package_config=PackageConfig(
+            jobs=jobs,
+        ),
+        job_config=jobs[0],
+        event=distgit_push_event.get_dict(),
+    )
+    assert koji_build_handler.pre_check() == should_pass

--- a/tests/integration/test_dg_merged_pr.py
+++ b/tests/integration/test_dg_merged_pr.py
@@ -1,0 +1,144 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import json
+import pytest
+
+from celery.canvas import Signature
+from flexmock import flexmock
+from ogr.services.pagure import PagureProject
+
+from packit.api import PackitAPI
+from packit.config import JobConfigTriggerType, JobConfig, PackageConfig, JobType
+from packit.local_project import LocalProject
+from packit_service.models import GitBranchModel, JobTriggerModelType, GitProjectModel
+from packit_service.worker.handlers.distgit import DownstreamKojiBuildHandler
+from packit_service.worker.jobs import SteveJobs
+from packit_service.worker.monitoring import Pushgateway
+from packit_service.worker.tasks import (
+    run_downstream_koji_build,
+)
+from tests.spellbook import DATA_DIR, first_dict_value, get_parameters_from_results
+
+
+def distgit_merged_pr_event():
+    return json.loads((DATA_DIR / "fedmsg" / "distgit_merged_pr.json").read_text())
+
+
+def test_downstream_koji_build_pull_request_merged_event():
+
+    packit_yaml = (
+        "{'specfile_path': 'buildah.spec', 'synced_files': [],"
+        "'jobs': [{'trigger': 'commit', 'job': 'koji_build', 'dist_git_branches': "
+        "['epel-8'], 'allowed_pr_authors': ['packit-stg']}],"
+        "'downstream_package_name': 'buildah'}"
+    )
+    pagure_project = flexmock(
+        PagureProject,
+        full_repo_name="rpms/python-specfile",
+        get_web_url=lambda: "https://src.fedoraproject.org/rpms/python-specfile",
+        default_branch="main",
+    )
+    pagure_project.should_receive("get_files").with_args(
+        ref="0ba51c0f420befcd8fe76742fa3f2bd0e24b3740", filter_regex=r".+\.spec$"
+    ).and_return(["buildah.spec"])
+    pagure_project.should_receive("get_file_content").with_args(
+        path=".distro/source-git.yaml", ref="0ba51c0f420befcd8fe76742fa3f2bd0e24b3740"
+    ).and_raise(FileNotFoundError, "Not found.")
+    pagure_project.should_receive("get_file_content").with_args(
+        path=".packit.yaml", ref="0ba51c0f420befcd8fe76742fa3f2bd0e24b3740"
+    ).and_return(packit_yaml)
+
+    flexmock(GitBranchModel).should_receive("get_or_create").with_args(
+        branch_name="epel8",
+        namespace="rpms",
+        repo_name="python-specfile",
+        project_url="https://src.fedoraproject.org/rpms/python-specfile",
+    ).and_return(flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.commit))
+
+    flexmock(LocalProject, refresh_the_arguments=lambda: None)
+    flexmock(Signature).should_receive("apply_async").once()
+    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(PackitAPI).should_receive("build").with_args(
+        dist_git_branch="epel8",
+        scratch=False,
+        nowait=True,
+        from_upstream=False,
+    )
+    processing_results = SteveJobs().process_message(distgit_merged_pr_event())
+    event_dict, job, job_config, package_config = get_parameters_from_results(
+        processing_results
+    )
+    assert json.dumps(event_dict)
+    results = run_downstream_koji_build(
+        package_config=package_config,
+        event=event_dict,
+        job_config=job_config,
+    )
+
+    assert first_dict_value(results["job"])["success"]
+
+
+@pytest.mark.parametrize(
+    "pr_author, committer, allowed_pr_authors, allowed_committers, should_pass",
+    (
+        ("packit", "sakamoto", ["packit"], [], True),
+        ("packit", "sakamoto", ["packit"], ["sakamoto"], True),
+        ("packit-stg", "sakamoto", [], ["sakamoto"], True),
+        ("packit-stg", "sakamoto", ["packit"], [], False),
+    ),
+)
+def test_precheck_koji_build_merged_pr(
+    distgit_merged_pr_event,
+    pr_author,
+    committer,
+    allowed_pr_authors,
+    allowed_committers,
+    should_pass,
+):
+    distgit_merged_pr_event.pr_author = pr_author
+    distgit_merged_pr_event.committer = committer
+
+    flexmock(GitProjectModel).should_receive("get_or_create").with_args(
+        namespace="rpms",
+        project_url="https://src.fedoraproject.org/rpms/packit",
+        repo_name="packit",
+    ).and_return(
+        flexmock(
+            id=342,
+        )
+    )
+    flexmock(GitBranchModel).should_receive("get_or_create").with_args(
+        branch_name="f36",
+        namespace="rpms",
+        project_url="https://src.fedoraproject.org/rpms/packit",
+        repo_name="packit",
+    ).and_return(
+        flexmock(
+            id=13,
+            job_config_trigger_type=JobConfigTriggerType.commit,
+            job_trigger_model_type=JobTriggerModelType.branch_push,
+        )
+    )
+
+    # flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
+    #     type=JobTriggerModelType.pull_request, trigger_id=342
+    # ).and_return(flexmock(id=2, type=JobTriggerModelType.pull_request))
+    # flexmock(GithubProject).should_receive("can_merge_pr").and_return(True)
+    jobs = [
+        JobConfig(
+            type=JobType.koji_build,
+            trigger=JobConfigTriggerType.commit,
+            dist_git_branches=["epel-8"],
+            allowed_pr_authors=allowed_pr_authors,
+            allowed_committers=allowed_committers,
+        ),
+    ]
+    koji_build_handler = DownstreamKojiBuildHandler(
+        package_config=PackageConfig(
+            jobs=jobs,
+        ),
+        job_config=jobs[0],
+        event=distgit_merged_pr_event.get_dict(),
+    )
+    assert koji_build_handler.pre_check() == should_pass


### PR DESCRIPTION
TODO:

- [x] Write more tests.
- [ ] enable the new topic in fedmsg configuration
- [x] Update or write new documentation in `packit/packit.dev`.


Fixes #1490 

For the merged PR pagure event, the db trigger model is currently GitBranchModel, since this is easier from the jobs mapping side for downstream koji build handler, although if we wanted to utilize this event for some other jobs, it could be a problem. Let me know what you think, should we use PRModel?

---

RELEASE NOTES BEGIN
TODO
RELEASE NOTES END
