### PR TITLE
Fix default Copr project name for releases

### DIFF
--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -34,6 +34,7 @@ from packit_service.models import (
     AbstractTriggerDbType,
     CoprBuildTargetModel,
     SRPMBuildModel,
+    JobTriggerModelType,
 )
 from packit_service.service.urls import (
     get_copr_build_info_url,
@@ -104,7 +105,9 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         # We want to share project between all releases.
         # More details: https://github.com/packit/packit-service/issues/1044
         ref_identifier = (
-            "releases" if self.metadata.tag_name else self.metadata.identifier
+            "releases"
+            if self.db_trigger.job_trigger_model_type == JobTriggerModelType.release
+            else self.metadata.identifier
         )
         configured_identifier = (
             f"-{self.job_config.identifier}" if self.job_config.identifier else ""

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -10,6 +10,7 @@ from packit.config.aliases import get_build_targets
 from packit.local_project import LocalProject
 from packit.utils.repo import RepositoryCache
 from packit_service.config import ServiceConfig
+from packit_service.models import JobTriggerModelType
 from packit_service.worker.helpers.build import copr_build
 from packit_service.worker.helpers.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.helpers.build.koji_build import KojiBuildJobHelper
@@ -1283,7 +1284,7 @@ def test_build_handler_job_and_test_properties(
 
 
 @pytest.mark.parametrize(
-    "jobs,job_config_trigger_type,tag_name,job_owner,job_project",
+    "jobs,job_config_trigger_type,job_trigger_model_type,tag_name,job_owner,job_project",
     [
         pytest.param(
             [
@@ -1293,6 +1294,7 @@ def test_build_handler_job_and_test_properties(
                 )
             ],
             JobConfigTriggerType.pull_request,
+            JobTriggerModelType.pull_request,
             None,
             "nobody",
             "git.instance.io-the-example-namespace-the-example-repo-the-event-identifier",
@@ -1307,6 +1309,7 @@ def test_build_handler_job_and_test_properties(
                 )
             ],
             JobConfigTriggerType.pull_request,
+            JobTriggerModelType.pull_request,
             None,
             "custom-owner",
             "git.instance.io-the-example-namespace-the-example-repo-the-event-identifier",
@@ -1321,6 +1324,7 @@ def test_build_handler_job_and_test_properties(
                 )
             ],
             JobConfigTriggerType.pull_request,
+            JobTriggerModelType.pull_request,
             None,
             "nobody",
             "custom-project",
@@ -1336,6 +1340,7 @@ def test_build_handler_job_and_test_properties(
                 )
             ],
             JobConfigTriggerType.pull_request,
+            JobTriggerModelType.pull_request,
             None,
             "custom-owner",
             "custom-project",
@@ -1351,6 +1356,7 @@ def test_build_handler_job_and_test_properties(
                 )
             ],
             JobConfigTriggerType.pull_request,
+            JobTriggerModelType.pull_request,
             None,
             "custom-owner",
             "custom-project",
@@ -1364,6 +1370,7 @@ def test_build_handler_job_and_test_properties(
                 )
             ],
             JobConfigTriggerType.commit,
+            JobTriggerModelType.branch_push,
             None,
             "nobody",
             "git.instance.io-the-example-namespace-the-example-repo-the-event-identifier",
@@ -1377,10 +1384,25 @@ def test_build_handler_job_and_test_properties(
                 )
             ],
             JobConfigTriggerType.release,
+            JobTriggerModelType.release,
             "v1.O.0",
             "nobody",
             "git.instance.io-the-example-namespace-the-example-repo-releases",
             id="release&default-owner&default-project",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.release,
+                )
+            ],
+            JobConfigTriggerType.release,
+            JobTriggerModelType.release,
+            None,
+            "nobody",
+            "git.instance.io-the-example-namespace-the-example-repo-releases",
+            id="release-without-tag&default-owner&default-project",
         ),
         pytest.param(
             [
@@ -1398,6 +1420,7 @@ def test_build_handler_job_and_test_properties(
                 ),
             ],
             JobConfigTriggerType.pull_request,
+            JobTriggerModelType.pull_request,
             None,
             "pr-owner",
             "pr-project",
@@ -1415,6 +1438,7 @@ def test_build_handler_job_and_test_properties(
                 ),
             ],
             JobConfigTriggerType.pull_request,
+            JobTriggerModelType.pull_request,
             None,
             "nobody",
             "git.instance.io-the-example-namespace-the-example-repo-the-event-identifier",
@@ -1434,6 +1458,7 @@ def test_build_handler_job_and_test_properties(
                 ),
             ],
             JobConfigTriggerType.pull_request,
+            JobTriggerModelType.pull_request,
             None,
             "custom-owner",
             "custom-project",
@@ -1453,6 +1478,7 @@ def test_build_handler_job_and_test_properties(
                 ),
             ],
             JobConfigTriggerType.pull_request,
+            JobTriggerModelType.pull_request,
             None,
             "custom-owner",
             "custom-project",
@@ -1478,6 +1504,7 @@ def test_build_handler_job_and_test_properties(
                 ),
             ],
             JobConfigTriggerType.pull_request,
+            JobTriggerModelType.pull_request,
             None,
             "pr-owner",
             "pr-project",
@@ -1503,6 +1530,7 @@ def test_build_handler_job_and_test_properties(
                 ),
             ],
             JobConfigTriggerType.commit,
+            JobTriggerModelType.branch_push,
             None,
             "commit-owner",
             "commit-project",
@@ -1513,6 +1541,7 @@ def test_build_handler_job_and_test_properties(
 def test_copr_project_and_namespace(
     jobs,
     job_config_trigger_type,
+    job_trigger_model_type,
     tag_name,
     job_owner,
     job_project,
@@ -1529,7 +1558,10 @@ def test_copr_project_and_namespace(
         metadata=flexmock(
             pr_id=None, identifier="the-event-identifier", tag_name=tag_name
         ),
-        db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
+        db_trigger=flexmock(
+            job_config_trigger_type=job_config_trigger_type,
+            job_trigger_model_type=job_trigger_model_type,
+        ),
     )
     copr_build_helper._api = flexmock(
         copr_helper=flexmock(copr_client=flexmock(config={"username": "nobody"}))


### PR DESCRIPTION
When processing the message from copr, we didn't have the `tag_name` in the `metadata`, therefore the `else` branch was executed. Checking directly the db trigger should be more straigtforward.

Fixes #1503


---

RELEASE NOTES BEGIN
The construction of the default Copr project name for releases which caused incorrect handling of the release Copr builds was fixed.
RELEASE NOTES END
