### PR TITLE
Don't add duplicated commit comments

### DIFF
--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -183,6 +183,15 @@ class StatusReporter:
             BaseCommitStatus.failure,
         }
 
+    def _commit_comment_already_added(self, comment: str) -> bool:
+        commit_comments = self.project.get_commit_comments(self.commit_sha)
+        if exists := any(c.comment == comment for c in commit_comments):
+            logger.debug(
+                "The following comment already exists for commit "
+                f"{self.commit_sha}\n{comment}"
+            )
+        return exists
+
     def _add_commit_comment_with_status(
         self, state: BaseCommitStatus, description: str, check_name: str, url: str = ""
     ):
@@ -196,8 +205,7 @@ class StatusReporter:
             )
             + f"\n\n{description}"
         )
-        if not self.is_final_state(state):
-            # To avoid multiple comments for non-final states
+        if not self.is_final_state(state) or self._commit_comment_already_added(body):
             logger.debug(f"Not adding a '{check_name} is {state.name}' comment.")
             return
 

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -1824,6 +1824,7 @@ def test_copr_build_success_gitlab_comment(gitlab_mr_event):
     exception.__cause__ = gitlab.GitlabError(response_code=403)
     flexmock(pr.source_project).should_receive("set_commit_status").and_raise(exception)
     flexmock(GitlabProject).should_receive("commit_comment").and_return()
+    flexmock(GitlabProject).should_receive("get_commit_comments").and_return([])
     flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
         (
             flexmock(status="success", id=42)

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -312,7 +312,7 @@ def test_commit_comment_instead_of_status(
         )
         + f"\n\n{description}",
     )
-
+    project.should_receive("get_commit_comments").and_return([])
     if has_pr_id:
         project.should_receive("get_pr").with_args(pr_id).and_return(pr_object)
 


### PR DESCRIPTION
The commit comments are added only as a fallback when adding a commit status fails
(because of permissions or forge issues).
It can happen that we want the set a status that a commit already has.
With commit statuses it's not a problem, but in the fallback mode
when we add comments instead, it results in duplicated comments.

Fixes https://github.com/packit/hardly/issues/29
Merge after https://github.com/packit/ogr/pull/717