### PR TITLE
Correctly get 'action' from EventData

### DIFF
--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -140,7 +140,7 @@ class CoprBuildHandler(JobHandler):
     def pre_check(self) -> bool:
         if (
             self.data.event_type == MergeRequestGitlabEvent.__name__
-            and self.data.action == GitlabEventAction.closed.value
+            and self.data.event_dict["action"] == GitlabEventAction.closed.value
         ):
             # Not interested in closed merge requests
             return False

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -107,7 +107,7 @@ class KojiBuildHandler(JobHandler):
     def pre_check(self) -> bool:
         if (
             self.data.event_type == MergeRequestGitlabEvent.__name__
-            and self.data.action == GitlabEventAction.closed.value
+            and self.data.event_dict["action"] == GitlabEventAction.closed.value
         ):
             # Not interested in closed merge requests
             return False

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -120,7 +120,7 @@ class TestingFarmHandler(JobHandler):
     def pre_check(self) -> bool:
         if (
             self.data.event_type == MergeRequestGitlabEvent.__name__
-            and self.data.action == GitlabEventAction.closed.value
+            and self.data.event_dict["action"] == GitlabEventAction.closed.value
         ):
             # Not interested in closed merge requests
             return False

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -93,6 +93,37 @@ def test_precheck(github_pr_event):
     assert copr_build_handler.pre_check()
 
 
+def test_precheck_gitlab(gitlab_mr_event):
+    flexmock(PullRequestModel).should_receive("get_or_create").with_args(
+        pr_id=1,
+        namespace="testing/packit",
+        repo_name="hello-there",
+        project_url="https://gitlab.com/testing/packit/hello-there",
+    ).and_return(
+        flexmock(id=1, job_config_trigger_type=JobConfigTriggerType.pull_request)
+    )
+    copr_build_handler = CoprBuildHandler(
+        package_config=PackageConfig(
+            jobs=[
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                ),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                ),
+            ]
+        ),
+        job_config=JobConfig(
+            type=JobType.copr_build,
+            trigger=JobConfigTriggerType.pull_request,
+        ),
+        event=gitlab_mr_event.get_dict(),
+    )
+    assert copr_build_handler.pre_check()
+
+
 def test_precheck_push(github_push_event):
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         flexmock(id=1, job_config_trigger_type=JobConfigTriggerType.commit)

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1744,16 +1744,15 @@ class TestCentOSEventParser:
         )
         assert event_object.package_config
 
-
-def test_event_data_parse_pr(github_pr_event):
-    # A db_trigger would be created in the get_dict() call bellow.
-    # We don't need that in this test, so let's mock it out.
-    flexmock(PullRequestGithubEvent)
-    PullRequestGithubEvent.db_trigger = None
-    data = EventData.from_event_dict(github_pr_event.get_dict())
-    assert data.event_type == "PullRequestGithubEvent"
-    assert data.actor == "lbarcziova"
-    assert not data.git_ref
-    assert data.commit_sha == "528b803be6f93e19ca4130bf4976f2800a3004c4"
-    assert data.identifier == "342"
-    assert data.pr_id == 342
+    def test_event_data_parse_pr(self, github_pr_event):
+        # A db_trigger would be created in the get_dict() call bellow.
+        # We don't need that in this test, so let's mock it out.
+        flexmock(PullRequestGithubEvent)
+        PullRequestGithubEvent.db_trigger = None
+        data = EventData.from_event_dict(github_pr_event.get_dict())
+        assert data.event_type == "PullRequestGithubEvent"
+        assert data.actor == "lbarcziova"
+        assert not data.git_ref
+        assert data.commit_sha == "528b803be6f93e19ca4130bf4976f2800a3004c4"
+        assert data.identifier == "342"
+        assert data.pr_id == 342

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1756,3 +1756,14 @@ class TestCentOSEventParser:
         assert data.commit_sha == "528b803be6f93e19ca4130bf4976f2800a3004c4"
         assert data.identifier == "342"
         assert data.pr_id == 342
+        assert data.event_dict["action"] == "opened"
+
+    def test_event_data_parse_gitlab_mr(self, gitlab_mr_event):
+        data = EventData.from_event_dict(gitlab_mr_event.get_dict())
+        assert data.event_type == "MergeRequestGitlabEvent"
+        assert data.actor == "shreyaspapi"
+        assert not data.git_ref
+        assert data.commit_sha == "1f6a716aa7a618a9ffe56970d77177d99d100022"
+        assert data.identifier == "1"
+        assert data.pr_id == 1
+        assert data.event_dict["action"] == "opened"


### PR DESCRIPTION
[`EventData`](https://github.com/packit/packit-service/blob/aec21bf2007038402ec6c53bce0989a1f6aa55ca/packit_service/worker/events/event.py#L55) has no `'action'` attribute, it's in [`event_dict`](https://github.com/packit/packit-service/blob/aec21bf2007038402ec6c53bce0989a1f6aa55ca/packit_service/worker/events/event.py#L135).

Fixes #1516