### PR TITLE
Handle ProjectAndTriggersConnector.get_project() returning None

### DIFF
--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -101,12 +101,12 @@ class TestingFarmResults(Resource):
     @ns.expect(pagination_arguments)
     @ns.response(HTTPStatus.PARTIAL_CONTENT.value, "Testing Farm Results follow")
     def get(self):
-        """List all Testing Farm  results."""
+        """List all Testing Farm results."""
 
         result = []
 
         first, last = indices()
-        # results have nothing other than ref in common, so it doesnt make sense to
+        # results have nothing other than ref in common, so it doesn't make sense to
         # merge them like copr builds
         for tf_result in TFTTestRunTargetModel.get_range(first, last):
             result_dict = {
@@ -121,9 +121,9 @@ class TestingFarmResults(Resource):
             }
 
             project = tf_result.get_project()
-            result_dict["repo_namespace"] = project.namespace
-            result_dict["repo_name"] = project.repo_name
-            result_dict["project_url"] = project.project_url
+            result_dict["repo_namespace"] = project.namespace if project else None
+            result_dict["repo_name"] = project.repo_name if project else None
+            result_dict["project_url"] = project.project_url if project else None
 
             result.append(result_dict)
 


### PR DESCRIPTION
[The Sentry issue](https://sentry.io/organizations/red-hat-0p/issues/3311412610) looks like a flake, but easy to sanitize.

We put `None` in those fields instead of omitting them to not break [dashboard](https://github.com/packit/dashboard/blob/33e4e89f3ffaf542d2cafb6dcd234b99b3517401/frontend/src/components/tables/testing_farm.js#L62).