### PR TITLE
Improve the description for the not-allowed status

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -10,6 +10,11 @@ FAQ_URL_HOW_TO_RETRIGGER = (
     f"{DOCS_URL}/packit-as-a-service/"
     "#how-to-re-trigger-packit-service-actions-in-your-pull-request"
 )
+REQUIREMENTS_URL = (
+    "https://packit.dev/docs/packit-service/"
+    "#requirements-for-running-packit-service-jobs"
+)
+
 KOJI_PRODUCTION_BUILDS_ISSUE = "https://pagure.io/releng/issue/9801"
 
 SANDCASTLE_WORK_DIR = "/tmp/sandcastle"
@@ -35,6 +40,15 @@ COPR_CHROOT_CHANGE_MSG = (
     "This was the change Packit tried to do:\n\n"
     "{table}"
     "\n"
+)
+
+NAMESPACE_NOT_ALLOWED_MARKDOWN_DESCRIPTION = (
+    "In order to start using the service, "
+    "your repository or namespace needs to be allowed. "
+    "Just be aware that we are now onboarding Fedora contributors who have "
+    "a valid [Fedora Account System](https://fedoraproject.org/wiki/Account_System) account. "
+    "For more details on how to get allowed for our service, please read "
+    "the requirements [here](/docs/packit-service#requirements-for-running-packit-service-jobs)."
 )
 
 FILE_DOWNLOAD_FAILURE = "Failed to download file from URL"

--- a/packit_service/worker/allowlist.py
+++ b/packit_service/worker/allowlist.py
@@ -12,7 +12,11 @@ from packit.api import PackitAPI
 from packit.config.job_config import JobConfig
 from packit.exceptions import PackitException, PackitCommandFailedError
 from packit_service.config import ServiceConfig
-from packit_service.constants import FAQ_URL, FASJSON_URL
+from packit_service.constants import (
+    FASJSON_URL,
+    NAMESPACE_NOT_ALLOWED_MARKDOWN_DESCRIPTION,
+    REQUIREMENTS_URL,
+)
 from packit_service.models import AllowlistModel, AllowlistStatus
 from packit_service.worker.events import (
     EventData,
@@ -344,7 +348,10 @@ class Allowlist:
                     else "User cannot trigger!"
                 )
                 job_helper.report_status_to_all(
-                    description=msg, state=BaseCommitStatus.neutral, url=FAQ_URL
+                    description=msg,
+                    state=BaseCommitStatus.neutral,
+                    url=REQUIREMENTS_URL,
+                    markdown_content=NAMESPACE_NOT_ALLOWED_MARKDOWN_DESCRIPTION,
                 )
 
         return False

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -17,7 +17,10 @@ from packit.config import JobType, JobConfig, JobConfigTriggerType
 from packit.config.common_package_config import Deployment
 from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
-from packit_service.constants import FAQ_URL
+from packit_service.constants import (
+    NAMESPACE_NOT_ALLOWED_MARKDOWN_DESCRIPTION,
+    REQUIREMENTS_URL,
+)
 from packit_service.models import (
     AllowlistModel as DBAllowlist,
     AllowlistStatus,
@@ -520,9 +523,9 @@ def test_check_and_report(
             flexmock(StatusReporter).should_receive("report").with_args(
                 description="Namespace is not allowed!",
                 state=BaseCommitStatus.neutral,
-                url=FAQ_URL,
+                url=REQUIREMENTS_URL,
                 check_names=[EXPECTED_TESTING_FARM_CHECK_NAME],
-                markdown_content=None,
+                markdown_content=NAMESPACE_NOT_ALLOWED_MARKDOWN_DESCRIPTION,
             ).once()
         flexmock(packit_service.worker.helpers.build.copr_build).should_receive(
             "get_valid_build_targets"


### PR DESCRIPTION
Signed-off-by: Frantisek Lachman <flachman@redhat.com>

---

RELEASE NOTES BEGIN
Packit shows basic information about allowlisting in the status description when your namespace is not allowed.
RELEASE NOTES END
