### PR TITLE
make Copr build logs available when a build starts

### DIFF
--- a/packit_service/worker/events/copr.py
+++ b/packit_service/worker/events/copr.py
@@ -147,9 +147,10 @@ class AbstractCoprBuildEvent(AbstractForgeIndependentEvent):
 
     def get_copr_build_logs_url(self) -> str:
         pkg = "" if self.chroot == COPR_SRPM_CHROOT else f"-{self.pkg}"
+        # https://github.com/packit/packit-service/issues/1387
         return (
-            f"https://copr-be.cloud.fedoraproject.org/results/{self.owner}/"
-            f"{self.project_name}/{self.chroot}/"
+            "https://download.copr.fedorainfracloud.org/"
+            f"results/{self.owner}/{self.project_name}/{self.chroot}/"
             f"{self.build_id:08d}{pkg}/builder-live.log.gz"
         )
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -870,6 +870,11 @@ class TestEvents:
             not event_object.base_project  # With Github app, we cannot work with fork repo
         )
 
+        assert event_object.get_copr_build_logs_url() == (
+            "https://download.copr.fedorainfracloud.org/results/packit/"
+            "packit-service-hello-world-24/fedora-rawhide-x86_64/01044215-hello/builder-live.log.gz"
+        )
+
         flexmock(PackageConfigGetter).should_receive(
             "get_package_config_from_repo"
         ).with_args(


### PR DESCRIPTION
As copr-be.cloud.fp.o/.../builder-live.log.gz is 404 when a build starts
and only has the logs once a build is done, we should instead use
download.copr.fedorainfracloud.org that has them available when a build
starts

Fixes #1387

TODO:

- [x] Write new tests or update the old ones to cover new functionality.

---

RELEASE NOTES BEGIN
A link to Copr build logs was updated: it now points to a place where logs are available once a build starts.
RELEASE NOTES END