### PR TITLE
Check project configuring custom copr project

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -4,7 +4,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import List, NamedTuple, Optional, Set, Union
+from typing import Dict, List, NamedTuple, Optional, Set, Union
 
 from yaml import safe_load
 
@@ -109,6 +109,7 @@ class ServiceConfig(Config):
         koji_web_url: str = "https://koji.fedoraproject.org",
         enabled_projects_for_srpm_in_copr: Union[Set[str], List[str]] = None,
         comment_command_prefix: str = "/packit",
+        allowed_forge_projects_for_copr_project: Dict[str, List[str]] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -174,6 +175,14 @@ class ServiceConfig(Config):
         )
         self.comment_command_prefix = comment_command_prefix
 
+        # e.g. {
+        # "copr_owner/copr_project": ["github.com/namespace/repo", "github.com/namespace/repo-2"],
+        # "@copr_group/copr_project": ["github.com/namespace/repo"],
+        # }
+        self.allowed_forge_projects_for_copr_project = (
+            allowed_forge_projects_for_copr_project or {}
+        )
+
     service_config = None
 
     def __repr__(self):
@@ -202,6 +211,7 @@ class ServiceConfig(Config):
             f"koji_logs_url='{self.koji_logs_url}', "
             f"koji_web_url='{self.koji_web_url}', "
             f"enabled_projects_for_srpm_in_copr= '{self.enabled_projects_for_srpm_in_copr}', "
+            f"forge_projects_for_copr_project={self.allowed_forge_projects_for_copr_project}"
             f"comment_command_prefix='{self.comment_command_prefix}')"
         )
 

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -223,6 +223,18 @@ INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED = (
     "or only test job via `{packit_comment_command_prefix} test` comment.*",
 )
 
+CUSTOM_COPR_PROJECT_NOT_ALLOWED_STATUS = (
+    "Not allowed to build in {copr_project} Copr project."
+)
+CUSTOM_COPR_PROJECT_NOT_ALLOWED_CONTENT = (
+    "Your git-forge project is not allowed to use the configured {copr_project} Copr project.\n\n"
+    "Please, [let us know](https://packit.dev/#contact) "
+    "if you need this git project to be allowed. "
+    "We are working with the Copr team on a way "
+    "how to make this easily configurable in the Copr web interface."
+    "a list of projects that are allowed to use the Copr project."
+)
+
 FASJSON_URL = "https://fasjson.fedoraproject.org"
 
 PACKIT_VERIFY_FAS_COMMAND = "verify-fas"

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -163,6 +163,14 @@ class CoprBuildHandler(JobHandler):
             # we can't report it to end-user at this stage
             return False
 
+        if self.copr_build_helper.is_custom_copr_project_defined():
+            logger.debug(
+                "Custom Copr owner/project set. "
+                "Checking if this GitHub project can use this Copr project."
+            )
+            if not self.copr_build_helper.check_if_custom_copr_can_be_used_and_report():
+                return False
+
         return True
 
 

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -223,6 +223,9 @@ def test_check_rerun_pr_copr_build_handler(
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     ).once()
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
     flexmock(GithubProject).should_receive("get_files").and_return(["foo.spec"])
     flexmock(GithubProject).should_receive("get_web_url").and_return(
         "https://github.com/the-namespace/the-repo"
@@ -391,6 +394,9 @@ def test_check_rerun_push_copr_build_handler(
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     ).once()
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
     flexmock(GithubProject).should_receive("get_files").and_return(["foo.spec"])
     flexmock(GithubProject).should_receive("get_web_url").and_return(
         "https://github.com/the-namespace/the-repo"
@@ -561,6 +567,9 @@ def test_check_rerun_release_copr_build_handler(
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     ).once()
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
     flexmock(GithubProject).should_receive("get_files").and_return(["foo.spec"])
     flexmock(GithubProject).should_receive("get_web_url").and_return(
         "https://github.com/the-namespace/the-repo"

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -21,6 +21,7 @@ from packit_service.worker.handlers import (
     CoprBuildHandler,
     KojiBuildHandler,
 )
+from packit_service.worker.helpers.build import CoprBuildJobHelper
 from packit_service.worker.reporting import StatusReporterGithubChecks, BaseCommitStatus
 
 
@@ -90,6 +91,9 @@ def test_precheck(github_pr_event):
         ),
         event=github_pr_event.get_dict(),
     )
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
     assert copr_build_handler.pre_check()
 
 
@@ -121,6 +125,9 @@ def test_precheck_gitlab(gitlab_mr_event):
         ),
         event=gitlab_mr_event.get_dict(),
     )
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
     assert copr_build_handler.pre_check()
 
 
@@ -146,6 +153,9 @@ def test_precheck_push(github_push_event):
         ),
         event=github_push_event.get_dict(),
     )
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
 
     assert copr_build_handler.pre_check()
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -173,6 +173,9 @@ def test_pr_comment_copr_build_handler(
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     ).once()
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
     flexmock(GithubProject).should_receive("get_files").and_return(["foo.spec"])
     flexmock(GithubProject).should_receive("get_web_url").and_return(
         "https://github.com/the-namespace/the-repo"
@@ -235,6 +238,9 @@ def test_pr_comment_build_handler(
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     )
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(copr_build).should_receive("get_valid_build_targets").and_return(set())
@@ -371,6 +377,9 @@ def test_pr_comment_build_build_and_test_handler(
         state=BaseCommitStatus.pending,
         url="",
     ).once()
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
     flexmock(Signature).should_receive("apply_async").twice()
     flexmock(Pushgateway).should_receive("push").times(3).and_return()
     pr = flexmock(head_commit="12345")
@@ -571,6 +580,9 @@ def test_pr_embedded_command_handler(
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     )
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     pr = flexmock(head_commit="12345")
@@ -1164,6 +1176,9 @@ def test_pr_build_command_handler_not_allowed_external_contributor_on_internal_T
         "you can trigger the build and test jobs manually via `/packit build` comment "
         "or only test job via `/packit test` comment.*",
     ).once()
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
 
     processing_results = SteveJobs().process_message(pr_embedded_command_comment_event)
     assert not processing_results
@@ -1237,6 +1252,9 @@ def test_rebuild_failed(
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     )
+    flexmock(CoprBuildJobHelper).should_receive(
+        "is_custom_copr_project_defined"
+    ).and_return(False).once()
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     pr = flexmock(head_commit="12345")


### PR DESCRIPTION
Short-term solution for: #1523

---

RELEASE NOTES BEGIN
There is a new check for git projects that are allowed to use a custom Copr project. There will be a better integration in the form of a new config field in Copr settings that Packit can use. In the meantime, the mapping is defined and maintained by the Packit team. Let us know if you need a project to be allowed.
RELEASE NOTES END
