### PR TITLE
Fix the wording of a message for not allowed custom Copr projects

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -227,12 +227,11 @@ CUSTOM_COPR_PROJECT_NOT_ALLOWED_STATUS = (
     "Not allowed to build in {copr_project} Copr project."
 )
 CUSTOM_COPR_PROJECT_NOT_ALLOWED_CONTENT = (
-    "Your git-forge project is not allowed to use the configured {copr_project} Copr project.\n\n"
+    "Your git-forge project is not allowed to use the configured `{copr_project}` Copr project.\n\n"
     "Please, [let us know](https://packit.dev/#contact) "
     "if you need this git project to be allowed. "
     "We are working with the Copr team on a way "
-    "how to make this easily configurable in the Copr web interface."
-    "a list of projects that are allowed to use the Copr project."
+    "how to make this easily configurable in the Copr web interface.\n"
 )
 
 FASJSON_URL = "https://fasjson.fedoraproject.org"


### PR DESCRIPTION
and format the Copr project name in it.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>
