### PR TITLE
Retry Bodhi task on authentication error

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -72,6 +72,7 @@ PG_BUILD_STATUS_SUCCESS = "success"
 DEFAULT_RETRY_LIMIT = 2
 # retry in 3s, 6s
 DEFAULT_RETRY_BACKOFF = 3
+RETRY_INTERVAL_IN_MINUTES_WHEN_USER_ACTION_IS_NEEDED = 10
 
 # Time after which we no longer check the status of jobs and consider it as
 # timeout/internal error. Nothing should hopefully run for 7 days.

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -22,7 +22,12 @@ from packit.config import JobConfig, JobType, PackageConfig
 from packit.local_project import LocalProject
 from packit.utils.repo import RepositoryCache
 from packit_service.config import PackageConfigGetter
-from packit_service.constants import CONTACTS_URL, DEFAULT_RETRY_LIMIT, KojiBuildState
+from packit_service.constants import (
+    CONTACTS_URL,
+    DEFAULT_RETRY_LIMIT,
+    KojiBuildState,
+    RETRY_INTERVAL_IN_MINUTES_WHEN_USER_ACTION_IS_NEEDED,
+)
 from packit_service.worker.events.koji import KojiBuildEvent
 from packit_service.worker.handlers.abstract import (
     JobHandler,
@@ -125,20 +130,32 @@ class CreateBodhiUpdateHandler(JobHandler):
             )
         except PackitException as ex:
             logger.debug(f"Bodhi update failed to be created: {ex}")
-            if not self.job_config.issue_repository:
-                logger.debug(
-                    "No issue repository configured. User will not be notified about the failure."
-                )
-                raise ex
 
-            known_error = False
             if isinstance(ex.__cause__, AuthError):
                 body = (
                     f"Bodhi update creation failed for `{self.koji_build_event.nvr}` "
                     f"because of the missing permissions.\n\n"
                     f"Please, give {self.service_config.fas_user} user `commit` rights in the "
-                    f"[dist-git settings]({self.data.project_url}/adduser)."
+                    f"[dist-git settings]({self.data.project_url}/adduser).\n\n"
                 )
+
+                body += f"*Try {self.task.request.retries+1}/{self.get_retry_limit()+1}"
+
+                # Notify user on each task run and set a more generous retry interval
+                # to let the user fix this issue in the meantime.
+                if not self.is_last_try():
+                    body += (
+                        f": Task will be retried in "
+                        f"{RETRY_INTERVAL_IN_MINUTES_WHEN_USER_ACTION_IS_NEEDED} minutes.*"
+                    )
+                    self.retry(
+                        delay=RETRY_INTERVAL_IN_MINUTES_WHEN_USER_ACTION_IS_NEEDED * 60,
+                        ex=ex,
+                    )
+                else:
+                    body += "*"
+
+                notify = True
                 known_error = True
             else:
                 body = (
@@ -147,36 +164,89 @@ class CreateBodhiUpdateHandler(JobHandler):
                     f"{ex}\n"
                     "```"
                 )
+                # Notify user just on the last run.
+                notify = self.is_last_try()
+                known_error = False
 
-            if (
-                not known_error
-                and self.task
-                and self.task.request.retries
-                < int(getenv("CELERY_RETRY_LIMIT", DEFAULT_RETRY_LIMIT))
-            ):
-                logger.debug(
-                    "Celery task will be retried. User will not be notified about the failure."
-                )
-                raise ex
-
-            logger.debug(
-                f"Issue repository configured. We will create "
-                f"a new issue in {self.job_config.issue_repository}"
-                "or update the existing one."
-            )
-
-            issue_repo = self.service_config.get_project(
-                url=self.job_config.issue_repository
-            )
-
-            PackageConfigGetter.create_issue_if_needed(
-                project=issue_repo,
-                title="Fedora Bodhi update failed to be created",
-                message=body
-                + f"\n\n*Get in [touch with us]({CONTACTS_URL}) if you need some help.*",
-                comment_to_existing=body,
-            )
+            if notify:
+                self.notify_user_about_failure(body)
+            else:
+                logger.debug("User will not be notified about the failure.")
 
             if not known_error:
+                # This will cause `autoretry_for` mechanism to re-trigger the celery task.
                 raise ex
+
+        # `success=True` for all known errors
+        # (=The task was correctly processed.)
+        # Sentry issue will be created otherwise.
         return TaskResults(success=True, details={})
+
+    def notify_user_about_failure(self, body: str) -> None:
+        """
+        If user configures `issue_repository`,
+        Packit will create there an issue with the details.
+        If the issue already exists and is opened, comment will be added
+        instead of creating a new issue.
+
+        The issue will be a place where to re-trigger the job.
+
+        :param body: content sent to the user
+            (comment or issue description;
+             for issue description a contact footer is added)
+        """
+        if not self.job_config.issue_repository:
+            logger.debug(
+                "No issue repository configured. User will not be notified about the failure."
+            )
+            return
+
+        logger.debug(
+            f"Issue repository configured. We will create "
+            f"a new issue in {self.job_config.issue_repository}"
+            "or update the existing one."
+        )
+        issue_repo = self.service_config.get_project(
+            url=self.job_config.issue_repository
+        )
+        PackageConfigGetter.create_issue_if_needed(
+            project=issue_repo,
+            title="Fedora Bodhi update failed to be created",
+            message=body
+            + f"\n\n---\n\n*Get in [touch with us]({CONTACTS_URL}) if you need some help.*",
+            comment_to_existing=body,
+        )
+
+    def is_last_try(self) -> bool:
+        """
+        Returns True if the current celery task is run for the last try.
+        More info about retries can be found here:
+        https://celeryproject.readthedocs.io/en/latest/userguide/tasks.html#retrying
+        """
+        return self.task.request.retries == self.get_retry_limit()
+
+    def get_retry_limit(self) -> int:
+        """
+        Returns the limit of the celery task retries.
+        (Packit uses this env.var. in HandlerTaskWithRetry base class
+        to set `max_retries` in `retry_kwargs`.)
+        """
+        return int(getenv("CELERY_RETRY_LIMIT", DEFAULT_RETRY_LIMIT))
+
+    def retry(self, ex: Exception, delay: Optional[int] = None) -> None:
+        """
+        Retries the celery task.
+        Argument `throw` is set to False to not retry
+        the task also because of the `autoretry_for` mechanism.
+
+        More info about retries can be found here:
+        https://celeryproject.readthedocs.io/en/latest/userguide/tasks.html#retrying
+
+        :param ex: Exception needs to be specified.
+        :param delay: Number of seconds task waits before being available to workers
+        """
+        retries = self.task.request.retries
+        delay = delay if delay is not None else 60 * 2**retries
+        logger.info(f"Will retry for the {retries + 1}. time in {delay}s.")
+        kargs = self.task.request.kwargs.copy()
+        self.task.retry(exc=ex, countdown=delay, throw=False, args=(), kwargs=kargs)

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -194,7 +194,7 @@ class ProposeDownstreamHandler(JobHandler):
                     # is not retried also automatically
                     kargs = self.task.request.kwargs.copy()
                     kargs["propose_downstream_run_id"] = model.id
-                    # https://celeryproject.readthedocs.io/zh_CN/latest/userguide/tasks.html#retrying
+                    # https://celeryproject.readthedocs.io/en/latest/userguide/tasks.html#retrying
                     self.task.retry(
                         exc=ex, countdown=delay, throw=False, args=(), kwargs=kargs
                     )


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover the new functionality.
- [x] Update doc-strings where appropriate.
- [ ] ~~Update or write new documentation in `packit/packit.dev`.~~

Fixes: #1550 

The issue should look like this:
![Screenshot from 2022-06-27 15-42-11](https://user-images.githubusercontent.com/20214043/175955885-2651968e-0a47-4be9-a9b9-0868719bef88.png)


---

RELEASE NOTES BEGIN
On Bodhi authentication error, Packit will retry the task multiple times
in ten-minute intervals to be able to fix the issue in the meantime.
RELEASE NOTES END
