### PR TITLE
Send worker logs to syslog as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ check:
 # In most cases you don't need to build your test-image, the one in registry should be all you need.
 build-test-image: files/install-deps-worker.yaml files/install-deps.yaml files/recipe-tests.yaml
 	$(CONTAINER_ENGINE) build --rm \
+		--pull=$(PULL_BASE_IMAGE) \
 		-t $(TEST_IMAGE) \
 		-f files/docker/Dockerfile.tests \
 		--build-arg SOURCE_BRANCH=$(SOURCE_BRANCH) \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,18 @@ services:
       - ./secrets/packit/dev/fedora.keytab:/secrets/fedora.keytab:ro,z
     user: "1024"
 
+  fluentd:
+    container_name: fluentd
+    image: splunk/fluentd-hec
+    environment:
+      SPLUNK_HEC_URL: https://splunk-url
+      SPLUNK_HEC_TOKEN: "token"
+    ports:
+      - 5140:5140
+    volumes:
+      - ./secrets/packit/dev/fluentd-config:/fluentd/etc/fluent.conf:ro,Z
+    user: "1024"
+
   service:
     container_name: service
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       AWS_ACCESS_KEY_ID: ""
       AWS_SECRET_ACCESS_KEY: ""
     volumes:
+      - ../packit/packit:/usr/local/lib/python3.10/site-packages/packit:ro,z
       - ./packit_service:/usr/local/lib/python3.10/site-packages/packit_service:ro,z
       - ./secrets/packit/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
       - ./secrets/packit/dev/copr:/home/packit/.config/copr:ro,z

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -57,6 +57,7 @@
         name:
           - git+https://github.com/packit/sandcastle.git@{{ source_branch }}
           - sentry-sdk
+          - syslog-rfc5424-formatter
         executable: pip3
     # --no-deps: to fail instead of installing from PyPI when we forget to add some dependency to packit.spec
     - name: pip install packit & ogr with --no-deps

--- a/packit_service/log_versions.py
+++ b/packit_service/log_versions.py
@@ -25,8 +25,8 @@ def log_package_versions(package_versions: list):
     logger.info(log_string)
 
 
-def log_job_versions():
-    """Log essential package versions before running a job."""
+def log_worker_versions():
+    """Log essential package versions used in the worker."""
     package_versions = [
         ("OGR", ogr_version),
         ("Packit", packit_version),

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -19,7 +19,6 @@ from packit_service.constants import (
     COMMENT_REACTION,
     PACKIT_VERIFY_FAS_COMMAND,
 )
-from packit_service.log_versions import log_job_versions
 from packit_service.worker.allowlist import Allowlist
 from packit_service.worker.events import (
     Event,
@@ -110,7 +109,6 @@ class SteveJobs:
     def __init__(self, event: Optional[Event] = None):
         self.event = event
         self._service_config = None
-        log_job_versions()
 
     @property
     def service_config(self):

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -13,6 +13,7 @@ from packit_service.constants import (
     DEFAULT_RETRY_BACKOFF,
     CELERY_DEFAULT_MAIN_TASK_NAME,
 )
+from packit_service.log_versions import log_worker_versions
 from packit_service.utils import load_job_config, load_package_config
 from packit_service.worker.handlers.forges import GithubFasVerificationHandler
 from packit_service.worker.helpers.build.babysit import (
@@ -55,6 +56,8 @@ logging.getLogger("ogr").setLevel(logging.INFO)
 # easier debugging
 logging.getLogger("packit").setLevel(logging.DEBUG)
 logging.getLogger("sandcastle").setLevel(logging.DEBUG)
+
+log_worker_versions()
 
 
 class HandlerTaskWithRetry(Task):


### PR DESCRIPTION
The syslog part will be a [fluentd](https://docs.fluentd.org/input/syslog) container [running in the same pod](https://github.com/packit/deployment/pull/352) and listening on the specified TCP port.

https://github.com/packit/research/pull/152

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->