### PR TITLE
Go through all PRs when getting distgit PR author for koji builds

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -409,9 +409,13 @@ class DownstreamKojiBuildHandler(JobHandler):
     @property
     def pull_request(self):
         if not self._pull_request and self.data.event_dict["committer"] == "pagure":
+            logger.debug(
+                f"Getting pull request with head commit {self.data.commit_sha}"
+                f"for repo {self.project.namespace}/{self.project.repo}"
+            )
             prs = [
                 pr
-                for pr in self.project.get_pr_list(status=PRStatus.merged)
+                for pr in self.project.get_pr_list(status=PRStatus.all)
                 if pr.head_commit == self.data.commit_sha
             ]
             if prs:


### PR DESCRIPTION
This should solve the problem when the fedmsg message about merged PR is created sooner than
the PR is acutally merged which may result in not being able to get the PR author from API
if we go only through the merged distgit PRs.

---

RELEASE NOTES BEGIN
We adjusted the way we check the author of the PR for PRs related to dist-git commits that trigger Koji build jobs. This should fix the race condition causing not creating Koji builds in some cases.
RELEASE NOTES END
