### PR TITLE
Copr error retries

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -73,6 +73,7 @@ DEFAULT_RETRY_LIMIT = 2
 # retry in 3s, 6s
 DEFAULT_RETRY_BACKOFF = 3
 RETRY_INTERVAL_IN_MINUTES_WHEN_USER_ACTION_IS_NEEDED = 10
+BASE_RETRY_INTERVAL_IN_MINUTES_FOR_OUTAGES = 1
 
 # Time after which we no longer check the status of jobs and consider it as
 # timeout/internal error. Nothing should hopefully run for 7 days.
@@ -238,3 +239,8 @@ CUSTOM_COPR_PROJECT_NOT_ALLOWED_CONTENT = (
 FASJSON_URL = "https://fasjson.fedoraproject.org"
 
 PACKIT_VERIFY_FAS_COMMAND = "verify-fas"
+
+MISSING_PERMISSIONS_TO_BUILD_IN_COPR = (
+    "You don't have permissions to build in this copr."
+)
+NOT_ALLOWED_TO_BUILD_IN_COPR = "is not allowed to build in the copr"

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -34,7 +34,7 @@ from packit_service.worker.handlers import (
     TestingFarmHandler,
     TestingFarmResultsHandler,
 )
-from packit_service.worker.handlers.abstract import TaskName
+from packit_service.worker.handlers.abstract import TaskName, CeleryTask
 from packit_service.worker.handlers.bodhi import CreateBodhiUpdateHandler
 from packit_service.worker.handlers.distgit import DownstreamKojiBuildHandler
 from packit_service.worker.handlers.koji import KojiBuildReportHandler
@@ -193,7 +193,7 @@ def run_propose_downstream_handler(
         job_config=load_job_config(job_config),
         event=event,
         propose_downstream_run_id=propose_downstream_run_id,
-        task=self,
+        celery_task=self,
     )
     return get_handlers_task_results(handler.run_job(), event)
 
@@ -247,7 +247,7 @@ def run_downstream_koji_build(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,
-        task=self,
+        celery_task=self,
     )
     return get_handlers_task_results(handler.run_job(), event)
 
@@ -275,7 +275,7 @@ def run_bodhi_update(self, event: dict, package_config: dict, job_config: dict):
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,
-        task=self,
+        celery_task=self,
     )
     return get_handlers_task_results(handler.run_job(), event)
 

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -34,7 +34,7 @@ from packit_service.worker.handlers import (
     TestingFarmHandler,
     TestingFarmResultsHandler,
 )
-from packit_service.worker.handlers.abstract import TaskName, CeleryTask
+from packit_service.worker.handlers.abstract import TaskName
 from packit_service.worker.handlers.bodhi import CreateBodhiUpdateHandler
 from packit_service.worker.handlers.distgit import DownstreamKojiBuildHandler
 from packit_service.worker.handlers.koji import KojiBuildReportHandler
@@ -118,13 +118,14 @@ def run_copr_build_end_handler(event: dict, package_config: dict, job_config: di
 
 
 @celery_app.task(
-    name=TaskName.copr_build, base=HandlerTaskWithRetry, queue="long-running"
+    bind=True, name=TaskName.copr_build, base=HandlerTaskWithRetry, queue="long-running"
 )
-def run_copr_build_handler(event: dict, package_config: dict, job_config: dict):
+def run_copr_build_handler(self, event: dict, package_config: dict, job_config: dict):
     handler = CoprBuildHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,
+        celery_task=self,
     )
     return get_handlers_task_results(handler.run_job(), event)
 

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -20,6 +20,7 @@ from packit.local_project import LocalProject
 from packit_service.constants import DEFAULT_RETRY_LIMIT
 from packit_service.models import GitBranchModel, KojiBuildTargetModel, PipelineModel
 from packit_service.utils import load_job_config, load_package_config
+from packit_service.worker.handlers.abstract import CeleryTask
 from packit_service.worker.handlers.bodhi import CreateBodhiUpdateHandler
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.monitoring import Pushgateway
@@ -252,7 +253,7 @@ def test_bodhi_update_for_unknown_koji_build_failed_issue_created(
             job_config=load_job_config(job_config),
             event=event_dict,
             # Needs to be the last try to inform user
-            task=flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
+            celery_task=flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
         ).run_job()
 
 
@@ -342,7 +343,7 @@ def test_bodhi_update_for_unknown_koji_build_failed_issue_comment(
             job_config=load_job_config(job_config),
             event=event_dict,
             # Needs to be the last try to inform user
-            task=flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
+            celery_task=flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
         ).run_job()
 
 
@@ -424,7 +425,7 @@ def test_bodhi_update_auth_error(
     ).and_return(flexmock(get_trigger_object=lambda: git_branch_model_flexmock))
 
     flexmock(Task).should_receive("retry").and_return().once()
-    flexmock(CreateBodhiUpdateHandler).should_call("retry").with_args(
+    flexmock(CeleryTask).should_call("retry").with_args(
         ex=bodhi_exception, delay=600
     ).once()
 

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -330,7 +330,7 @@ def test_downstream_koji_build_failure_issue_created():
             job_config=load_job_config(job_config),
             event=event_dict,
             # Needs to be the last try to inform user
-            task=flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
+            celery_task=flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
         ).run_job()
 
 
@@ -401,7 +401,7 @@ def test_downstream_koji_build_failure_issue_comment():
             job_config=load_job_config(job_config),
             event=event_dict,
             # Needs to be the last try to inform user
-            task=flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
+            celery_task=flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
         ).run_job()
 
 

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -31,6 +31,7 @@ from packit.copr_helper import CoprHelper
 from packit.exceptions import FailedCreateSRPM, PackitCoprSettingsException
 from packit_service import sentry_integration
 from packit_service.config import ServiceConfig
+from packit_service.constants import DEFAULT_RETRY_LIMIT
 from packit_service.models import (
     CoprBuildTargetModel,
     JobTriggerModel,
@@ -42,6 +43,7 @@ from packit_service.service.db_triggers import (
     AddPullRequestDbTrigger,
     AddReleaseDbTrigger,
 )
+from packit_service.worker.handlers.abstract import CeleryTask
 
 from packit_service.worker.helpers.build import copr_build
 from packit_service.worker.helpers.build.copr_build import (
@@ -1096,6 +1098,9 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
             id=123,
             job_trigger_model_type=JobTriggerModelType.pull_request,
         ),
+    )
+    helper.celery_task = CeleryTask(
+        flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT))
     )
     flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
         type=JobTriggerModelType.pull_request, trigger_id=123


### PR DESCRIPTION
TODO:

- [x] agree on the interval (and create a constant for it) and types of exceptions

Fixes #1549 


---

RELEASE NOTES BEGIN
During creating Copr builds, on Copr errors, Packit will retry the task multiple times
in case there is a Copr outage.
RELEASE NOTES END
