### PR TITLE
Allow specifying concurrency (autoscale & pool)

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -41,6 +41,9 @@
           - postgresql # pg_dump
           - python3-boto3 # AWS (S3)
           - python3-fasjson-client
+          # remove if we decide not to use concurrency
+          - python3-eventlet
+          - python3-gevent
         state: present
     - import_tasks: tasks/install-packit-deps.yaml
     - import_tasks: tasks/install-ogr-deps.yaml

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -22,7 +22,7 @@ CELERY_COMMAND="${CELERY_COMMAND:-$DEFAULT_CELERY_COMMAND}"
 
 if [[ "${CELERY_COMMAND}" == "beat" ]]; then
     # when using the database backend, celery beat must be running for the results to be expired.
-    # https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html#starting-the-scheduler
+    # https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html#starting-the-scheduler
     exec celery --app="${APP}" beat --loglevel="${LOGLEVEL:-DEBUG}" --pidfile=/tmp/celerybeat.pid --schedule=/tmp/celerybeat-schedule
 
 elif [[ "${CELERY_COMMAND}" == "worker" ]]; then

--- a/packit_service/celerizer.py
+++ b/packit_service/celerizer.py
@@ -23,13 +23,13 @@ class Celerizer:
             db = getenv("REDIS_SERVICE_DB", "0")
             broker_url = f"redis://:{password}@{host}:{port}/{db}"
 
-            # https://docs.celeryproject.org/en/stable/userguide/configuration.html#database-url-examples
+            # https://docs.celeryq.dev/en/stable/userguide/configuration.html#database-url-examples
             postgres_url = f"db+{get_pg_url()}"
 
-            # http://docs.celeryproject.org/en/latest/reference/celery.html#celery.Celery
+            # http://docs.celeryq.dev/en/stable/reference/celery.html#celery.Celery
             self._celery_app = Celery(backend=postgres_url, broker=broker_url)
 
-            # https://docs.celeryproject.org/en/stable/getting-started/first-steps-with-celery.html#configuration
+            # https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html#configuration
             self._celery_app.config_from_object("packit_service.celery_config")
 
         return self._celery_app

--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -4,13 +4,13 @@ from celery.schedules import crontab
 
 import packit_service.constants
 
-# https://docs.celeryproject.org/en/stable/userguide/tasks.html#ignore-results-you-don-t-want
+# https://docs.celeryq.dev/en/stable/userguide/tasks.html#ignore-results-you-don-t-want
 task_ignore_result = True
 
-# https://docs.celeryproject.org/en/latest/userguide/configuration.html#std-setting-task_default_queue
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_default_queue
 task_default_queue = packit_service.constants.CELERY_TASK_DEFAULT_QUEUE
 
-# https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html
+# https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html
 beat_schedule = {
     "update-pending-copr-builds": {
         "task": "packit_service.worker.tasks.babysit_pending_copr_builds",

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -432,7 +432,7 @@ class JobHandler(Handler):
     def get_signature(cls, event: Event, job: Optional[JobConfig]) -> Signature:
         """
         Get the signature of a Celery task which will run the handler.
-        https://docs.celeryproject.org/en/stable/userguide/canvas.html#signatures
+        https://docs.celeryq.dev/en/stable/userguide/canvas.html#signatures
         :param event: event which triggered the task
         :param job: job to process
         """

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -193,7 +193,7 @@ class ProposeDownstreamHandler(RetriableJobHandler):
                     # is not retried also automatically
                     kargs = self.celery_task.task.request.kwargs.copy()
                     kargs["propose_downstream_run_id"] = model.id
-                    # https://celeryproject.readthedocs.io/en/latest/userguide/tasks.html#retrying
+                    # https://docs.celeryq.dev/en/stable/userguide/tasks.html#retrying
                     self.celery_task.task.retry(
                         exc=ex, countdown=delay, throw=False, args=(), kwargs=kargs
                     )

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -389,7 +389,7 @@ class SteveJobs:
                         event=self.event,
                     )
                 )
-        # https://docs.celeryproject.org/en/stable/userguide/canvas.html#groups
+        # https://docs.celeryq.dev/en/stable/userguide/canvas.html#groups
         celery.group(signatures).apply_async()
         return processing_results
 


### PR DESCRIPTION
The default autoscale is 1,1 which is equal to `--concurrency=1`
The default pool is `prefork`, which also stays the same.

So nothing changes by default, but it allows us to experiment with concurrency as suggested in https://github.com/packit/research/pull/153