### PR TITLE
Retrigger downstream koji builds

### DIFF
--- a/packit_service/worker/events/pagure.py
+++ b/packit_service/worker/events/pagure.py
@@ -90,14 +90,14 @@ class PullRequestCommentPagureEvent(AbstractPRCommentEvent, AbstractPagureEvent)
         return result
 
     def get_base_project(self) -> GitProject:
-        fork = self.project.service.get_project(
+        project = self.project.service.get_project(
             namespace=self.base_repo_namespace,
             repo=self.base_repo_name,
             username=self.base_repo_owner,
-            is_fork=True,
+            is_fork=False,
         )
-        logger.debug(f"Base project: {fork} owned by {self.base_repo_owner}")
-        return fork
+        logger.debug(f"Base project: {project} owned by {self.base_repo_owner}")
+        return project
 
 
 class PullRequestPagureEvent(AddPullRequestDbTrigger, AbstractPagureEvent):

--- a/tests/data/fedmsg/pagure_pr_comment.json
+++ b/tests/data/fedmsg/pagure_pr_comment.json
@@ -1,0 +1,127 @@
+{
+  "agent": "mmassari",
+  "pullrequest": {
+    "assignee": null,
+    "branch": "test-koji-downstream",
+    "branch_from": "test-koji-downstream-2",
+    "cached_merge_status": "FFORWARD",
+    "closed_at": null,
+    "closed_by": null,
+    "comments": [
+      {
+        "comment": "/packit koji-build",
+        "commit": null,
+        "date_created": "1657783448",
+        "edited_on": null,
+        "editor": null,
+        "filename": null,
+        "id": 110401,
+        "line": null,
+        "notification": false,
+        "parent": null,
+        "reactions": {},
+        "tree": null,
+        "user": {
+          "full_url": "https://src.fedoraproject.org/user/mmassari",
+          "fullname": "Maja Massarini",
+          "name": "mmassari",
+          "url_path": "user/mmassari"
+        }
+      }
+    ],
+    "commit_start": "beaf90bcecc51968a46663f8d6f092bfdc92e682",
+    "commit_stop": "beaf90bcecc51968a46663f8d6f092bfdc92e682",
+    "date_created": "1657783415",
+    "full_url": "https://src.fedoraproject.org/rpms/python-teamcity-messages/pull-request/36",
+    "id": 36,
+    "initial_comment": null,
+    "last_updated": "1657783448",
+    "project": {
+      "access_groups": {
+        "admin": [],
+        "collaborator": [],
+        "commit": [],
+        "ticket": []
+      },
+      "access_users": {
+        "admin": ["limb"],
+        "collaborator": [],
+        "commit": [],
+        "owner": ["mmassari"],
+        "ticket": []
+      },
+      "close_status": [],
+      "custom_keys": [],
+      "date_created": "1643654065",
+      "date_modified": "1650542166",
+      "description": "The python-teamcity-messages package\\n",
+      "full_url": "https://src.fedoraproject.org/rpms/python-teamcity-messages",
+      "fullname": "rpms/python-teamcity-messages",
+      "id": 54766,
+      "milestones": {},
+      "name": "python-teamcity-messages",
+      "namespace": "rpms",
+      "parent": null,
+      "priorities": {},
+      "tags": [],
+      "url_path": "rpms/python-teamcity-messages",
+      "user": {
+        "full_url": "https://src.fedoraproject.org/user/mmassari",
+        "fullname": "Maja Massarini",
+        "name": "mmassari",
+        "url_path": "user/mmassari"
+      }
+    },
+    "remote_git": null,
+    "repo_from": {
+      "access_groups": {
+        "admin": [],
+        "collaborator": [],
+        "commit": [],
+        "ticket": []
+      },
+      "access_users": {
+        "admin": ["limb"],
+        "collaborator": [],
+        "commit": [],
+        "owner": ["mmassari"],
+        "ticket": []
+      },
+      "close_status": [],
+      "custom_keys": [],
+      "date_created": "1643654065",
+      "date_modified": "1650542166",
+      "description": "The python-teamcity-messages package\\n",
+      "full_url": "https://src.fedoraproject.org/rpms/python-teamcity-messages",
+      "fullname": "rpms/python-teamcity-messages",
+      "id": 54766,
+      "milestones": {},
+      "name": "python-teamcity-messages",
+      "namespace": "rpms",
+      "parent": null,
+      "priorities": {},
+      "tags": [],
+      "url_path": "rpms/python-teamcity-messages",
+      "user": {
+        "full_url": "https://src.fedoraproject.org/user/mmassari",
+        "fullname": "Maja Massarini",
+        "name": "mmassari",
+        "url_path": "user/mmassari"
+      }
+    },
+    "status": "Open",
+    "tags": [],
+    "threshold_reached": null,
+    "title": "Not usefull commit",
+    "uid": "d8b1dd625c674cb9ad8010985bd98351",
+    "updated_on": "1657783448",
+    "user": {
+      "full_url": "https://src.fedoraproject.org/user/mmassari",
+      "fullname": "Maja Massarini",
+      "name": "mmassari",
+      "url_path": "user/mmassari"
+    }
+  },
+  "topic": "org.fedoraproject.prod.pagure.pull-request.comment.added",
+  "timestamp": 1657776351.055628
+}

--- a/tests/unit/test_distgit.py
+++ b/tests/unit/test_distgit.py
@@ -1,8 +1,16 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
-from flexmock import flexmock
+import json
+import pytest
 
-from packit_service.worker.handlers.distgit import ProposeDownstreamHandler
+from flexmock import flexmock
+from fasjson_client import Client
+
+from packit.api import PackitAPI
+from packit_service.worker.handlers.distgit import (
+    ProposeDownstreamHandler,
+    DownstreamKojiBuildHandler,
+)
 from packit_service.worker.events.event import EventData
 
 
@@ -31,7 +39,8 @@ def test_create_one_issue_for_pr():
                 url="a url",
             )
             .should_receive("comment")
-            .once.mock()
+            .once()
+            .mock()
         ]
     )
     flexmock(ProposeDownstreamHandler).should_receive("project").and_return(project)
@@ -48,3 +57,33 @@ def test_create_one_issue_for_pr():
             "f35": "Propose downstream failed for release 056",
         }
     )
+
+
+PAGURE_PULL_REQUEST_COMMENT_PROCESSED = '{"created_at": 1658228337, "project_url": "https://src.fedoraproject.org/rpms/python-teamcity-messages", "_pr_id": 36, "fail_when_config_file_missing": true, "actor": null, "_package_config_searched": true, "git_ref": null, "identifier": "36", "comment": "/packit koji-build", "comment_id": 110401, "_commit_sha": "beaf90bcecc51968a46663f8d6f092bfdc92e682", "action": "created", "base_repo_namespace": "rpms", "base_repo_name": "python-teamcity-messages", "base_repo_owner": "mmassari", "base_ref": null, "target_repo": "python-teamcity-messages", "user_login": "mmassari", "event_type": "PullRequestCommentPagureEvent", "trigger_id": null, "task_accepted_time": null, "commit_sha": "beaf90bcecc51968a46663f8d6f092bfdc92e682"}'  # noqa
+
+
+@pytest.mark.parametrize(
+    "user_groups,data,check_passed",
+    [
+        pytest.param(
+            flexmock(result=[{"groupname": "somegroup"}, {"groupname": "packager"}]),
+            PAGURE_PULL_REQUEST_COMMENT_PROCESSED,
+            True,
+        ),
+        pytest.param(
+            flexmock(result=[{"groupname": "somegroup"}]),
+            PAGURE_PULL_REQUEST_COMMENT_PROCESSED,
+            False,
+        ),
+    ],
+)
+def test_retrigger_downstream_koji_build_pre_check(user_groups, data, check_passed):
+    data_dict = json.loads(data)
+    handler = DownstreamKojiBuildHandler(None, None, data_dict)
+    flexmock(PackitAPI).should_receive("init_kerberos_ticket").and_return(None)
+    flexmock(Client).should_receive("__getattr__").with_args(
+        "list_user_groups"
+    ).and_return(lambda username: user_groups)
+
+    result = handler.pre_check()
+    assert result == check_passed

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2359,6 +2359,22 @@ def test_handler_doesnt_match_to_job(
             ],
             [],
         ),
+        pytest.param(
+            PullRequestCommentPagureEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.koji_build,
+                    trigger=JobConfigTriggerType.commit,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.koji_build,
+                    trigger=JobConfigTriggerType.commit,
+                ),
+            ],
+        ),
     ],
 )
 def test_get_jobs_matching_trigger(event_kls, job_config_trigger_type, jobs, result):


### PR DESCRIPTION
Through a Pagure comment in a PR

Fixes #1540

Merge after packit/packit-service-fedmsg#70

---

RELEASE NOTES BEGIN
A downstream *koji-build* can now be re-triggered commenting in a PR like this: `/packit koji-build`.
RELEASE NOTES END
