### PR TITLE
Revert to Bodhi 5 client

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -44,6 +44,11 @@
           # remove if we decide not to use concurrency
           - python3-eventlet
           - python3-gevent
+          # workaround for https://github.com/fedora-infra/bodhi/issues/4660
+          - https://kojipkgs.fedoraproject.org/packages/bodhi/5.7.5/1.fc35/noarch/python3-bodhi-5.7.5-1.fc35.noarch.rpm
+          - https://kojipkgs.fedoraproject.org/packages/bodhi/5.7.5/1.fc35/noarch/python3-bodhi-client-5.7.5-1.fc35.noarch.rpm
+        # needed when installing from koji - there are no GPG-signed packages
+        disable_gpg_check: true
         state: present
     - import_tasks: tasks/install-packit-deps.yaml
     - import_tasks: tasks/install-ogr-deps.yaml


### PR DESCRIPTION
Fixes: https://github.com/packit/packit-service/issues/1587
M0ar context: https://github.com/fedora-infra/bodhi/issues/4660

Just that I write this somewhere:
* Bodhi 5 is built from SRPM "bodhi" - everything
* Bodhi 6 was split into multiple packages, e.g. bodhi-client

RELEASE NOTES BEGIN
We have reverted to Bodhi 5 client since Packit couldn't create bodhi updates with the new version 6 client: https://github.com/fedora-infra/bodhi/issues/4660
RELEASE NOTES END