### PR TITLE
Don't require packit config when the command isn't supported by packit

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -290,14 +290,13 @@ class SteveJobs:
         Returns:
             Whether the Packit configuration is present in the repo.
         """
-        if isinstance(
-            self.event, AbstractCommentEvent
-        ) and get_packit_commands_from_comment(
+        if isinstance(self.event, AbstractCommentEvent) and get_handlers_for_comment(
             self.event.comment,
             packit_comment_command_prefix=self.service_config.comment_command_prefix,
         ):
             # we require packit config file when event is triggered by /packit command
             self.event.fail_when_config_file_missing = True
+
         if not self.event.package_config:
             # this happens when service receives events for repos which don't have packit config
             # success=True - it's not an error that people don't have packit.yaml in their repo


### PR DESCRIPTION
Don't require a packit config when we don't have matching handlers for it (non-existing commands - typos in commands etc.). With this, when user writes a typo,  `self.event.fail_when_config_file_missing` won't to False so `self.event.package_config` won't raise anything on a missing repo. The previous condition was checking for a `/packit whatever` commands :grin:  

With this we should hopefully ignore every non-existing packit commands (e.g. typos in them) but the issue that we firstly give them :eyes: even when we ignore them remains - #1448 (I was trying to do it since it's easy but... too much tests to fix :grinning: )

Fixes #1592 
