### PR TITLE
CI: install-deps: explicitly install bodhi 5

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -34,7 +34,13 @@
           # (see d90948124e46_add_tables_for_triggers_koji_and_tests.py )
           - dnf-plugins-core
           - python-jwt
+          # workaround for https://github.com/fedora-infra/bodhi/issues/4660
+          # we need to explicitly install here so that `tasks/install-packit-deps.yaml` doesn't pick up bodhi-client 6
+          - https://kojipkgs.fedoraproject.org/packages/bodhi/5.7.5/1.fc35/noarch/python3-bodhi-5.7.5-1.fc35.noarch.rpm
+          - https://kojipkgs.fedoraproject.org/packages/bodhi/5.7.5/1.fc35/noarch/python3-bodhi-client-5.7.5-1.fc35.noarch.rpm
         state: present
+        # needed when installing from koji - there are no GPG-signed packages
+        disable_gpg_check: true
     - import_tasks: tasks/install-ogr-deps.yaml
     - import_tasks: tasks/install-packit-deps.yaml
     - name: Install pip deps


### PR DESCRIPTION
otherwise tasks/install-packit-deps.yaml picks up bodhi 6 and then the
playbook install-deps-worker.yaml fails as bodhi 5 client is explicitly
mentioned there

should resolve: https://softwarefactory-project.io/zuul/t/packit-service/build/b6b910658162418983feb7c855cd0c2e/console

Extra commit that increases scope of a allowed_forge_projects_for_copr_project test:

```
test: actually check that a forge project is approved

in the `allowed_forge_projects_for_copr_project` setting

The test case written like this helped me diagnose a related issue.
```