### PR TITLE
Always allow explicit job/event matching

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -500,8 +500,7 @@ class SteveJobs:
             ):
                 jobs_matching_trigger.append(job)
 
-        if not jobs_matching_trigger:
-            jobs_matching_trigger.extend(self.check_explicit_matching())
+        jobs_matching_trigger.extend(self.check_explicit_matching())
 
         return jobs_matching_trigger
 

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1261,12 +1261,13 @@ class Parser:
 
         action = PullRequestCommentAction.created.value
         pr_id = event["pullrequest"]["id"]
+        pagure_login = event["agent"]
         base_repo_namespace = event["pullrequest"]["project"]["namespace"]
         base_repo_name = event["pullrequest"]["project"]["name"]
-        base_repo_owner = event["pullrequest"]["repo_from"]["user"]["name"]
-        target_repo = event["pullrequest"]["repo_from"]["name"]
+        repo_from = event["pullrequest"]["repo_from"]
+        base_repo_owner = repo_from["user"]["name"] if repo_from else pagure_login
+        target_repo = repo_from["name"] if repo_from else base_repo_name
         https_url = event["pullrequest"]["project"]["full_url"]
-        pagure_login = event["agent"]
         commit_sha = event["pullrequest"]["commit_stop"]
 
         if "added" in event["topic"]:

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2375,6 +2375,30 @@ def test_handler_doesnt_match_to_job(
                 ),
             ],
         ),
+        pytest.param(
+            PullRequestCommentPagureEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                ),
+                JobConfig(
+                    type=JobType.koji_build,
+                    trigger=JobConfigTriggerType.commit,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                ),
+                JobConfig(
+                    type=JobType.koji_build,
+                    trigger=JobConfigTriggerType.commit,
+                ),
+            ],
+        ),
     ],
 )
 def test_get_jobs_matching_trigger(event_kls, job_config_trigger_type, jobs, result):


### PR DESCRIPTION
Packit config has many other matching jobs,
do not skip the koji-build job just because there are other matching jobs.

related to packit-service#1540