### PR TITLE
Improve configuration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,6 +286,20 @@ To run them you need docker-compose.
 Otherwise you can run the same using _Openshift_ and following
 the instructions below.
 
+### Running "reverse-dep" tests locally
+
+In order to use a locally checked out, development version of Packit in the
+test image, build a "reverse-dep" test image:
+
+    make build-revdep-test-image
+
+By default, 'packit' is expected to be found at `../packit`. Set `PACKIT_PATH`
+to customize this.
+
+Once the image is built, run the tests in a container as usual:
+
+    make check-in-container
+
 ### Openshift tests using requre
 
 This testsuite uses [requre project](https://github.com/packit/requre) project to

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PULL_BASE_IMAGE ?= true
 SERVICE_IMAGE ?= quay.io/packit/packit-service:dev
 WORKER_IMAGE ?= quay.io/packit/packit-worker:dev
 TEST_IMAGE ?= quay.io/packit/packit-service-tests:stg
+PACKIT_PATH ?= ../packit
 # missing|always|never
 PULL_TEST_IMAGE ?= missing
 TEST_TARGET ?= ./tests/unit ./tests/integration/
@@ -45,6 +46,13 @@ build-test-image: files/install-deps-worker.yaml files/install-deps.yaml files/r
 		-t $(TEST_IMAGE) \
 		-f files/docker/Dockerfile.tests \
 		--build-arg SOURCE_BRANCH=$(SOURCE_BRANCH) \
+		.
+
+build-revdep-test-image: build-test-image
+	$(CONTAINER_ENGINE) build \
+		-t $(TEST_IMAGE) \
+		-f files/docker/Containerfile.revdep \
+	    -v $(shell realpath $(PACKIT_PATH)):/var/packit:Z \
 		.
 
 # We use a test image pre-built (by Github action) from latest commit in main.
@@ -166,4 +174,6 @@ check-db: build-test-image compose-for-db-up
 		-w /src \
 		--network packit-service_default \
 		$(TEST_IMAGE) make check "TEST_TARGET=tests_openshift/database"
-		$(COMPOSE) down
+		$(COMPproject=OSE) down
+
+.PHONY: build-revdep-test-image

--- a/files/docker/Containerfile.revdep
+++ b/files/docker/Containerfile.revdep
@@ -1,0 +1,5 @@
+FROM quay.io/packit/packit-service-tests:stg
+
+WORKDIR /var/packit
+
+RUN pip3 install .

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -105,65 +105,70 @@ def koji_build_scratch_end():
 @pytest.fixture(scope="module")
 def pc_build_pr():
     return PackageConfig(
+        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
                 _targets=["fedora-all"],
             )
-        ]
+        ],
     )
 
 
 @pytest.fixture(scope="module")
 def pc_koji_build_pr():
     return PackageConfig(
+        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.production_build,
                 trigger=JobConfigTriggerType.pull_request,
                 _targets=["fedora-all"],
             )
-        ]
+        ],
     )
 
 
 @pytest.fixture(scope="module")
 def pc_build_push():
     return PackageConfig(
+        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.commit,
                 _targets=["fedora-all"],
             )
-        ]
+        ],
     )
 
 
 @pytest.fixture(scope="module")
 def pc_build_release():
     return PackageConfig(
+        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.release,
                 _targets=["fedora-all"],
             )
-        ]
+        ],
     )
 
 
 @pytest.fixture(scope="module")
 def pc_tests():
     return PackageConfig(
+        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
                 _targets=["fedora-all"],
             )
-        ]
+        ],
     )
 
 
@@ -418,6 +423,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     urls.DASHBOARD_URL = "https://dashboard.localhost"
 
     config = PackageConfig(
+        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
@@ -429,7 +435,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
                 trigger=JobConfigTriggerType.pull_request,
                 _targets=["fedora-rawhide"],
             ),
-        ]
+        ],
     )
 
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
@@ -626,6 +632,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     )
 
     config = PackageConfig(
+        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
@@ -637,7 +644,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
                 trigger=JobConfigTriggerType.pull_request,
                 _targets=["fedora-rawhide"],
             ),
-        ]
+        ],
     )
 
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
@@ -763,6 +770,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     )
 
     config = PackageConfig(
+        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
@@ -774,7 +782,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
                 trigger=JobConfigTriggerType.pull_request,
                 _targets=["fedora-rawhide"],
             ),
-        ]
+        ],
     )
 
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(


### PR DESCRIPTION
When trying to fix failures in packit/packit#1663, it turned out some configuration tests were overzealous, and were also testing functionality within _packit_. Re-factor these tests to limit their scope only to functionality in _packit_service_.

Other tests needed a 'specfile_path' to be explicitly defined in order to work with changes from the PR above.

Additionally, add a new Makefile-target to easily build a revdep-test-image for local testing. Document its usage.
