### PR TITLE
Add a timestamp to the unique tag

### DIFF
--- a/.github/workflows/rebuild-and-push-images.yml
+++ b/.github/workflows/rebuild-and-push-images.yml
@@ -37,7 +37,7 @@ jobs:
                   ;;
           esac
           echo "::set-output name=branch::${branch}"
-          unique_tag="${branch}-${GITHUB_SHA::7}"
+          unique_tag="${branch}-${GITHUB_SHA::7}-$(date +%s)"
           echo "::set-output name=tag::${tag} ${unique_tag}"
         id: branch_tag
 


### PR DESCRIPTION
The `unique_tag` was introduced (355bd9eb92) to prevent older images from being garbage collected from the registry once a newer image with the same tag is pushed to the registry.

If a new image is built as a consequence of re-running the github action then the `GITHUB_SHA` (and so the `unique_tag`) stays the same and the previous image with this `unique_tag` is garbage collected once a new one is pushed to the registry.

Adding a timestamp to the `unique_tag` prevents this from happening.

(Tested in https://quay.io/repository/jpopelka/packit-worker?tab=tags)