### PR TITLE
Retry the task on TF submit failure

### DIFF
--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -241,7 +241,7 @@ class CeleryTask:
 
     def retry(
         self,
-        ex: Exception,
+        ex: Optional[Exception] = None,
         delay: Optional[int] = None,
         max_retries: Optional[int] = None,
     ) -> None:

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -176,8 +176,9 @@ def run_github_fas_verification_handler(
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name=TaskName.testing_farm, base=HandlerTaskWithRetry)
+@celery_app.task(bind=True, name=TaskName.testing_farm, base=HandlerTaskWithRetry)
 def run_testing_farm_handler(
+    self,
     event: dict,
     package_config: dict,
     job_config: dict,
@@ -188,6 +189,7 @@ def run_testing_farm_handler(
         job_config=load_job_config(job_config),
         event=event,
         build_id=build_id,
+        celery_task=self,
     )
     return get_handlers_task_results(handler.run_job(), event)
 

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -19,7 +19,7 @@ from packit.config.package_config import PackageConfig
 from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
 from packit_service.config import PackageConfigGetter, ServiceConfig
-from packit_service.constants import COPR_API_FAIL_STATE
+from packit_service.constants import COPR_API_FAIL_STATE, DEFAULT_RETRY_LIMIT
 from packit_service.models import (
     CoprBuildTargetModel,
     JobTriggerModelType,
@@ -855,7 +855,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     ).once()
     flexmock(StatusReporter).should_receive("report").with_args(
         state=BaseCommitStatus.failure,
-        description="Failed to submit tests: some text error",
+        description="Failed to submit tests: some text error.",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
         url="",
         markdown_content=None,
@@ -885,7 +885,9 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         copr_build_pr.get_trigger_object()
     )
     event_dict["tests_targets_override"] = ["fedora-rawhide-x86_64"]
-    run_testing_farm_handler(
+    task = run_testing_farm_handler.__wrapped__.__func__
+    task(
+        flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
         package_config=package_config,
         event=event_dict,
         job_config=job_config,

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -788,7 +788,12 @@ def test_trigger_build(copr_build, run_new_build):
         {"target-x86_64", "another-target-x86_64"}
     )
 
-    tf_handler = TestingFarmHandler(package_config, job_config, event)
+    tf_handler = TestingFarmHandler(
+        package_config,
+        job_config,
+        event,
+        celery_task=flexmock(request=flexmock(retries=0)),
+    )
     tf_handler._db_trigger = flexmock(
         job_config_trigger_type=JobConfigTriggerType.pull_request
     )


### PR DESCRIPTION
Retry the TFHandler task if there was no response or failure in response when
submitting the payload to TF. Fixes #1551.

---

RELEASE NOTES BEGIN
When submitting Testing Farm tests, Packit will now retry multiple times in case there is a failure.
RELEASE NOTES END
