### PR TITLE
Don't configure Celery result backend

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -22,8 +22,7 @@
           - python3-requests
           - python3-alembic
           - python3-prometheus_client
-          - python3-sqlalchemy
-          - python3-psycopg2
+          - python3-sqlalchemy+postgresql
           - python3-celery # unfortunately, the probes don't work with this
           - python3-redis # celery[redis]
           - python3-lazy-object-proxy

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -23,9 +23,8 @@
           - gcc
           - python3-devel
           - python3-alembic
-          - python3-sqlalchemy
+          - python3-sqlalchemy+postgresql
           - python3-prometheus_client
-          - python3-psycopg2
           - python3-celery
           - python3-redis # celery[redis]
           - python3-lazy-object-proxy

--- a/packit_service/celerizer.py
+++ b/packit_service/celerizer.py
@@ -6,7 +6,6 @@ from os import getenv
 from celery import Celery
 from lazy_object_proxy import Proxy
 
-from packit_service.models import get_pg_url
 from packit_service.sentry_integration import configure_sentry
 
 
@@ -23,11 +22,8 @@ class Celerizer:
             db = getenv("REDIS_SERVICE_DB", "0")
             broker_url = f"redis://:{password}@{host}:{port}/{db}"
 
-            # https://docs.celeryq.dev/en/stable/userguide/configuration.html#database-url-examples
-            postgres_url = f"db+{get_pg_url()}"
-
             # http://docs.celeryq.dev/en/stable/reference/celery.html#celery.Celery
-            self._celery_app = Celery(backend=postgres_url, broker=broker_url)
+            self._celery_app = Celery(broker=broker_url)
 
             # https://docs.celeryq.dev/en/stable/getting-started/first-steps-with-celery.html#configuration
             self._celery_app.config_from_object("packit_service.celery_config")

--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -4,9 +4,6 @@ from celery.schedules import crontab
 
 import packit_service.constants
 
-# https://docs.celeryq.dev/en/stable/userguide/tasks.html#ignore-results-you-don-t-want
-task_ignore_result = True
-
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_default_queue
 task_default_queue = packit_service.constants.CELERY_TASK_DEFAULT_QUEUE
 


### PR DESCRIPTION
Since #1242 we've been ignoring task results, i.e. haven't stored them in the DB.
It, however, makes more sense not to specify the backend to store task results at all than specify it and don't use it.