### PR TITLE
Make test_pr_comment runnable alone

### DIFF
--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -9,6 +9,7 @@ from celery.canvas import Signature
 from flexmock import flexmock
 from github import Github
 
+import packit_service.service.urls as urls
 from ogr.services.github import GithubProject
 from ogr.utils import RequestResponse
 from packit.config import JobConfigTriggerType
@@ -942,6 +943,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
         data={"base_project_url": "https://github.com/packit-service/hello-world"},
     ).and_return(tft_test_run_model)
 
+    urls.DASHBOARD_URL = "https://dashboard.localhost"
     flexmock(StatusReporter).should_receive("report").with_args(
         description="Tests have been submitted ...",
         state=BaseCommitStatus.running,


### PR DESCRIPTION
Found while working on group models but since it's unrelated and a simple fix, creating a simple PR.

Previously, the test only worked when run as a part of the whole suite
because other tests set the DASHBOARD_URL. Make the test self-contained
by mocking the dashboard url there as well.

Previously, `TEST_TARGET="tests/integration/test_pr_comment.py" make check-in-container` would result in a failed test (whereas `make check-in-container` passes).