### PR TITLE
Install the latest version of ogr, specfile and packit from copr

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -60,7 +60,10 @@
     - name: Check if all pip packages have all dependencies installed
       command: pip check
     - import_tasks: tasks/setup-copr-repos.yaml
-    - name: Install packit from copr
+    - name: Install ogr, specfile and packit from copr
       dnf:
-        name: packit
-        state: present
+        name:
+          - python3-ogr
+          - python3-specfile
+          - packit
+        state: latest

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -49,7 +49,10 @@
     - name: Check if all pip packages have all dependencies installed
       command: pip check
     - import_tasks: tasks/setup-copr-repos.yaml
-    - name: Install packit from copr
+    - name: Install ogr, specfile and packit from copr
       dnf:
-        name: packit
-        state: present
+        name:
+          - python3-ogr
+          - python3-specfile
+          - packit
+        state: latest


### PR DESCRIPTION
Before, if an older version of packit was already installed by a different task, it didn't get updated to the latest version
from copr. Make sure that happens now, not only with packit, but also with ogr and specfile.

Related to packit/packit#1686.

Merge before packit/packit#1686.