### PR TITLE
Express type as a string literal to avoid circular import

### DIFF
--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -50,7 +50,6 @@ from packit_service.service.urls import (
     get_srpm_build_info_url,
 )
 from packit_service.utils import get_package_nvrs
-from packit_service.worker.handlers.abstract import CeleryTask
 from packit_service.worker.helpers.build.build_helper import BaseBuildJobHelper
 from packit_service.worker.events import EventData
 from packit_service.worker.monitoring import Pushgateway, measure_time
@@ -77,7 +76,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         build_targets_override: Optional[Set[str]] = None,
         tests_targets_override: Optional[Set[str]] = None,
         pushgateway: Optional[Pushgateway] = None,
-        celery_task: Optional[CeleryTask] = None,
+        celery_task: Optional["CeleryTask"] = None,
     ):
         super().__init__(
             service_config=service_config,


### PR DESCRIPTION
Fixes #1618

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
