### PR TITLE
Make service image build via Github workflow

### DIFF
--- a/alembic/versions/c6250555a36c_.py
+++ b/alembic/versions/c6250555a36c_.py
@@ -6,16 +6,15 @@ Create Date: 2020-04-06 09:34:50.929724
 
 """
 import enum
+import json
 import logging
 from datetime import datetime, timezone
-from json import loads
 from os import getenv
-from celery.backends.database import Task
-from redis import Redis
 from typing import TYPE_CHECKING, Union, List
-from persistentdict.dict_in_redis import PersistentDict
 
 from alembic import op
+from celery.backends.database import Task
+from redis import Redis
 from sqlalchemy import (
     Column,
     Integer,
@@ -29,8 +28,8 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, relationship
 from sqlalchemy.types import PickleType
 
-from packit_service.worker.events import InstallationEvent
 from packit_service.constants import ALLOWLIST_CONSTANTS
+from packit_service.worker.events import InstallationEvent
 
 # revision identifiers, used by Alembic.
 revision = "c6250555a36c"
@@ -44,6 +43,170 @@ else:
     Base = declarative_base()
 
 logger = logging.getLogger(__name__)
+
+
+class PersistentDict:
+    """
+    Dictionary backed by Redis DB.
+
+    We use Redis` 'hash' type [1] and store whole dictionary in one hash called self.hash.
+
+    Usage:
+    db = PersistentDict(hash_name="my-persistent-dict")
+    # add bug to the db with a value
+    db[key] = value
+    # show whole dictionary
+    print(db)
+    # iterate of bugs in db
+    for key, value in db.items():
+      do_something(key)
+    # do sth with key if it is in db
+    if key in db:
+      do_something(key)
+    # delete bug from db
+    del db[key]
+
+    [1] https://redis.io/topics/data-types-intro#hashes is basically Python's dict, but values
+        can be strings only, so we use json serialization
+    """
+
+    def __init__(
+        self,
+        hash_name="dict-in-redis",
+        redis_host=None,
+        redis_port=None,
+        redis_db=None,
+        redis_password=None,
+    ):
+        """
+
+        :param hash_name: name of the dictionary/hash [1] we store all the info in
+        """
+        self.db = Redis(
+            host=redis_host or getenv("REDIS_SERVICE_HOST", "localhost"),
+            port=redis_port or getenv("REDIS_SERVICE_PORT", "6379"),
+            db=redis_db or 1,  # 0 is used by Celery
+            password=redis_password or getenv("REDIS_PASSWORD"),
+            decode_responses=True,
+        )
+        self.hash = hash_name
+
+    def __contains__(self, key):
+        """
+        Is key in db ?
+
+        Usage:
+        if key in PersistentDict():
+
+        :param key: can be int or string
+        :return: bool
+        """
+        return self.db.hexists(self.hash, key)
+
+    def __getitem__(self, key):
+        """
+        Get info to key
+
+        Usage:
+        xyz = PersistentDict()[key]
+
+        :param key: can be int or string
+        :return: value assigned to the key or None if key not in db
+        """
+        value = self.db.hget(self.hash, key)
+        if value is None:
+            raise KeyError(f"Key '{key}' does not exist.")
+        return json.loads(value)
+
+    def __len__(self):
+        """
+
+        Number of items in db.
+
+        Usage:
+        len(PersistentDict())
+        """
+        return self.db.hlen(self.hash)
+
+    def __setitem__(self, key, value):
+        """
+        Store key in db along with a value.
+        Because values in a hash can be only strings, we first json serialize the value
+
+        Usage:
+        PersistentDict()[key] = value
+
+        :param key: can be int or string
+        :param value: additional info, can be any json serializable object
+        """
+        self.db.hset(self.hash, key, json.dumps(value))
+
+    def __delitem__(self, key):
+        """
+        Remove key from db
+
+        Usage:
+        del PersistentDict()[key]
+
+        :param key: can be int or string
+        """
+        self.db.hdel(self.hash, key)
+
+    def __repr__(self):
+        """
+        print(PersistentDict())
+
+        :return: string representation
+        """
+        return str(self.get_all())
+
+    def clear(self):
+        """
+        Remove all items from dictionary
+        """
+        for key in self.keys():
+            self.__delitem__(key)
+
+    def get(self, key, default=None):
+        """Get info to key or default, if key not present.
+
+        Usage:
+        xyz = PersistentDict().get(key, default)
+
+        :param key: can be int or string
+        :param default: can be anything, default is None
+        :return: value assigned to the key or default if key not in db
+        """
+        value = self.db.hget(self.hash, key)
+        return default if value is None else json.loads(value)
+
+    def get_all(self):
+        """
+        Return whole dictionary
+
+        Usage:
+        all_bugs_dict = PersistentDict().get_all()
+
+        :return: dictionary of {key: value}
+        """
+        return {k: json.loads(v) for k, v in self.db.hgetall(self.hash).items()}
+
+    def items(self):
+        """
+        Return iterator over the (key, value) pairs
+
+        Usage:
+        for key, value in PersistentDict().items():
+
+        :return: iterator over the (key, value) pairs
+        """
+        return self.get_all().items()
+
+    def keys(self):
+        """
+        :return: view object that displays a list of all the keys
+        """
+        return self.get_all().keys()
 
 
 # Redis models
@@ -294,7 +457,7 @@ def upgrade():
     # tasks
     keys = db.keys("celery-task-meta-*")
     for key in keys:
-        data = loads(db.get(key))
+        data = json.loads(db.get(key))
         task_id = data.get("task_id")
         status = data.get("status")
         result = data.get("result")

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -29,7 +29,6 @@
           - python3-flask-restx
           - python3-xmltodict # parse Testing Farm results
           - dnf-utils
-          - python3-pip
           - make
           # for pip-installing sandcastle from git repo
           - git-core

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -40,7 +40,6 @@
     - name: Install pip deps
       pip:
         name:
-          - persistentdict # still needed by one Alembic migration script
           - sentry-sdk[flask]
         executable: pip3
     - name: Check if all pip packages have all dependencies installed

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -17,8 +17,6 @@
           # httpd & deps
           - python3-mod_wsgi
           - mod_ssl
-          - python3-pip # not included in base fedora:31 image, needed for next task
-          # temporary dependencies
           - krb5-devel
           - gcc
           - python3-devel

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -17,9 +17,6 @@
           # httpd & deps
           - python3-mod_wsgi
           - mod_ssl
-          - krb5-devel
-          - gcc
-          - python3-devel
           - python3-alembic
           - python3-sqlalchemy+postgresql
           - python3-prometheus_client


### PR DESCRIPTION
```
TASK [Install pip deps] ********************************************************
task path: /src/files/install-deps.yaml:42
fatal: [localhost]: FAILED! => {
    "changed": false,
    "rc": 1
}

MSG:

MODULE FAILURE
See stdout/stderr for the exact error

MODULE_STDERR:

/tmp/ansible_pip_payload_uu1ijakg/ansible_pip_payload.zip/ansible/modules/packaging/language/pip.py:267: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
Traceback (most recent call last):
  File "/src/files/~packit/.ansible/tmp/ansible-tmp-1660903646.6798422-199-241924768958502/AnsiballZ_pip.py", line 102, in <module>
    _ansiballz_main()
  File "/src/files/~packit/.ansible/tmp/ansible-tmp-1660903646.6798422-199-241924768958502/AnsiballZ_pip.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/src/files/~packit/.ansible/tmp/ansible-tmp-1660903646.6798422-199-241924768958502/AnsiballZ_pip.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.packaging.language.pip', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib64/python3.10/runpy.py", line 224, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib64/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_pip_payload_uu1ijakg/ansible_pip_payload.zip/ansible/modules/packaging/language/pip.py", line 271, in <module>
  File "/usr/lib/python3.10/site-packages/pkg_resources/__init__.py", line 32, in <module>
    import plistlib
  File "/usr/lib64/python3.10/plistlib.py", line 61, in <module>
    from xml.parsers.expat import ParserCreate
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1016, in get_code
  File "<frozen importlib._bootstrap_external>", line 1073, in get_data
OSError: [Errno 40] Too many levels of symbolic links: '/usr/lib64/python3.10/xml/__init__.py'
```

First I thought the `persistentdict` module is to blame. It turned out to be false eventually, but the change is valid anyway, i.e. it'd be nice to drop [that module](https://github.com/user-cont/persistentdict) for good.

The real causes were the `-devel` packages and `gcc`. Once I removed those, it builds OK.

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
