### PR TITLE
Run pre_check for TestingFarmResultsHandler called from babysit task

### DIFF
--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -403,4 +403,11 @@ class TestingFarmResultsHandler(JobHandler):
         return TaskResults(success=True, details={})
 
     def pre_check(self) -> bool:
-        return self.data.identifier == self.job_config.identifier
+        if self.data.identifier != self.job_config.identifier:
+            logger.debug(
+                f"Skipping reporting, identifiers don't match "
+                f"(identifier of the test job to report: {self.data.identifier}, "
+                f"identifier from job config: {self.job_config.identifier})."
+            )
+            return False
+        return True

--- a/packit_service/worker/helpers/build/babysit.py
+++ b/packit_service/worker/helpers/build/babysit.py
@@ -110,11 +110,14 @@ def check_pending_testing_farm_runs() -> None:
         )
 
         for job_config in job_configs:
-            TestingFarmResultsHandler(
+            handler = TestingFarmResultsHandler(
                 package_config=event.package_config,
                 job_config=job_config,
                 event=event.get_dict(),
-            ).run()
+            )
+            # check for identifiers equality
+            if handler.pre_check():
+                handler.run()
 
 
 def check_pending_copr_builds() -> None:


### PR DESCRIPTION
In the pre_check, the equality of identifiers is checked. Without running it,
the reporting of the TF results can be incorrect.

Fixes #1630

---

RELEASE NOTES BEGIN
We have fixed the reporting when multiple Testing Farm jobs with identifiers are configured.
RELEASE NOTES END
