### PR TITLE
SRPMs are built in Copr by default for installations since September 6

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
-
+import datetime
 from enum import Enum
 
 CONTACTS_URL = "https://packit.dev/#contact"
@@ -89,6 +89,16 @@ DEFAULT_JOB_TIMEOUT = 7 * 24 * 3600
 # SRPM builds older than this number of days are considered
 # outdated and their logs can be discarded.
 SRPMBUILDS_OUTDATED_AFTER_DAYS = 90
+
+DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR = datetime.datetime(
+    year=2022,
+    month=9,
+    day=6,
+    hour=6,
+    minute=0,
+    microsecond=0,
+    tzinfo=datetime.timezone.utc,
+)
 
 ALLOWLIST_CONSTANTS = {
     "approved_automatically": "approved_automatically",

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1765,6 +1765,19 @@ class GithubInstallationModel(Base):
         return sa_session().query(GithubInstallationModel).filter_by(id=id).first()
 
     @classmethod
+    def get_for_github_project(
+        cls, namespace: str, repo_name: str
+    ) -> Optional["GithubInstallationModel"]:
+        namespace_installation = cls.get_by_account_login(account_login=namespace)
+        if not namespace_installation:
+            return None
+
+        for project in namespace_installation.repositories:
+            if project.repo_name == repo_name:
+                return namespace_installation
+        return None
+
+    @classmethod
     def get_by_account_login(
         cls, account_login: str
     ) -> Optional["GithubInstallationModel"]:

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -489,7 +489,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                     # use the latest stable chroot
                     script_chroot=self.get_latest_fedora_stable_chroot(),
                     script_builddeps=self.get_packit_copr_download_urls()
-                    + self.package_config.srpm_build_deps,
+                    + (self.package_config.srpm_build_deps or []),
                     buildopts={
                         "chroots": list(self.build_targets),
                         "enable_net": self.job_config.enable_net,

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -11,9 +11,14 @@ from ogr.services.github import GithubProject
 
 from packit.config import JobConfigTriggerType
 from packit.local_project import LocalProject
-from packit_service.constants import PG_BUILD_STATUS_SUCCESS, TASK_ACCEPTED
+from packit_service.constants import (
+    DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,
+    PG_BUILD_STATUS_SUCCESS,
+    TASK_ACCEPTED,
+)
 from packit_service.models import (
     GitBranchModel,
+    GithubInstallationModel,
     JobTriggerModel,
     ProjectReleaseModel,
     PullRequestModel,
@@ -220,6 +225,14 @@ def mock_release_functionality(request):
 def test_check_rerun_pr_copr_build_handler(
     mock_pr_functionality, check_rerun_event_copr_build
 ):
+    flexmock(GithubInstallationModel).should_receive("get_by_account_login").with_args(
+        account_login="packit"
+    ).and_return(
+        flexmock(
+            created_at=DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,  # = old behaviour
+            repositories=[flexmock(repo_name="hello-world")],
+        )
+    )
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     ).once()
@@ -391,6 +404,14 @@ def test_check_rerun_pr_koji_build_handler(
 def test_check_rerun_push_copr_build_handler(
     mock_push_functionality, check_rerun_event_copr_build
 ):
+    flexmock(GithubInstallationModel).should_receive("get_by_account_login").with_args(
+        account_login="packit"
+    ).and_return(
+        flexmock(
+            created_at=DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,  # = old behaviour
+            repositories=[flexmock(repo_name="hello-world")],
+        )
+    )
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     ).once()
@@ -564,6 +585,14 @@ def test_check_rerun_push_koji_build_handler(
 def test_check_rerun_release_copr_build_handler(
     mock_release_functionality, check_rerun_event_copr_build
 ):
+    flexmock(GithubInstallationModel).should_receive("get_by_account_login").with_args(
+        account_login="packit"
+    ).and_return(
+        flexmock(
+            created_at=DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,  # = old behaviour
+            repositories=[flexmock(repo_name="hello-world")],
+        )
+    )
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     ).once()

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -19,6 +19,7 @@ from packit_service.config import ServiceConfig
 from packit_service.constants import (
     COMMENT_REACTION,
     CONTACTS_URL,
+    DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,
     DOCS_HOW_TO_CONFIGURE_URL,
     PG_BUILD_STATUS_SUCCESS,
     TASK_ACCEPTED,
@@ -26,6 +27,7 @@ from packit_service.constants import (
 )
 from packit_service.models import (
     CoprBuildTargetModel,
+    GithubInstallationModel,
     JobTriggerModel,
     JobTriggerModelType,
     PipelineModel,
@@ -174,6 +176,14 @@ def test_pr_comment_copr_build_handler(
     ).and_return(
         flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
     )
+    flexmock(GithubInstallationModel).should_receive("get_by_account_login").with_args(
+        account_login="packit-service"
+    ).and_return(
+        flexmock(
+            created_at=DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,  # = old behaviour
+            repositories=[flexmock(repo_name="hello-world")],
+        )
+    )
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
     ).once()
@@ -238,6 +248,14 @@ def test_pr_comment_build_handler(
         project_url="https://github.com/packit-service/hello-world",
     ).and_return(
         flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
+    )
+    flexmock(GithubInstallationModel).should_receive("get_by_account_login").with_args(
+        account_login="packit-service"
+    ).and_return(
+        flexmock(
+            created_at=DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,  # = old behaviour
+            repositories=[flexmock(repo_name="hello-world")],
+        )
     )
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         TaskResults(success=True, details={})
@@ -578,6 +596,14 @@ def test_pr_embedded_command_handler(
         project_url="https://github.com/packit-service/hello-world",
     ).and_return(
         flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
+    )
+    flexmock(GithubInstallationModel).should_receive("get_by_account_login").with_args(
+        account_login="packit-service"
+    ).and_return(
+        flexmock(
+            created_at=DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,  # = old behaviour
+            repositories=[flexmock(repo_name="hello-world")],
+        )
     )
     ServiceConfig.get_service_config().comment_command_prefix = command
     pr_embedded_command_comment_event["comment"]["body"] = comments_list
@@ -1770,6 +1796,14 @@ def test_rebuild_failed(
         project_url="https://github.com/packit-service/hello-world",
     ).and_return(
         flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
+    )
+    flexmock(GithubInstallationModel).should_receive("get_by_account_login").with_args(
+        account_login="packit-service"
+    ).and_return(
+        flexmock(
+            created_at=DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,  # = old behaviour
+            repositories=[flexmock(repo_name="hello-world")],
+        )
     )
 
     pr_embedded_command_comment_event["comment"]["body"] = "/packit rebuild-failed"


### PR DESCRIPTION
Signed-off-by: Frantisek Lachman <flachman@redhat.com>

TODO:

- [x] Write a new test.
- [x] Update the old tests.
- [x] Update documentation: packit/packit.dev#518

Fixes #1583

---

RELEASE NOTES BEGIN
SRPMs for Copr Builds are built in Copr by default for Packit GitHub app installations since September 6, 2022. For older installations, you can set the  `srpm_build_deps` config option to use Copr as a builder. Let us know if you hit any issue with the new implementation. We are going to slowly decommission the old implementation and are happy to help with the transition.
RELEASE NOTES END
