### PR TITLE
Add oldrev field to MergeRequestGitlabEvent

### DIFF
--- a/packit_service/worker/events/gitlab.py
+++ b/packit_service/worker/events/gitlab.py
@@ -58,6 +58,7 @@ class MergeRequestGitlabEvent(AddPullRequestDbTrigger, AbstractGitlabEvent):
         target_repo_branch: str,
         project_url: str,
         commit_sha: str,
+        oldrev: Optional[str],
         title: str,
         description: str,
         url: str,
@@ -79,6 +80,7 @@ class MergeRequestGitlabEvent(AddPullRequestDbTrigger, AbstractGitlabEvent):
         self.target_repo_branch = target_repo_branch
         self.project_url = project_url
         self.commit_sha = commit_sha
+        self.oldrev = oldrev
         self.title = title
         self.description = description
         self.url = url

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -201,6 +201,7 @@ class Parser:
         )
 
         commit_sha = nested_get(event, "object_attributes", "last_commit", "id")
+        oldrev = nested_get(event, "object_attributes", "oldrev")
 
         title = nested_get(event, "object_attributes", "title")
         description = nested_get(event, "object_attributes", "description")
@@ -220,6 +221,7 @@ class Parser:
             target_repo_branch=target_repo_branch,
             project_url=target_project_url,
             commit_sha=commit_sha,
+            oldrev=oldrev,
             title=title,
             description=description,
             url=url,

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -320,6 +320,7 @@ class TestEvents:
         assert isinstance(event_object, MergeRequestGitlabEvent)
         assert event_object.action == GitlabEventAction.update
         assert event_object.commit_sha == "45e272a57335e4e308f3176df6e9226a9e7805a9"
+        assert event_object.oldrev == "94ccba9f986629e24b432c11d9c7fd20bb2ea51d"
         assert event_object.identifier == "2"
 
         assert isinstance(event_object.project, GitlabProject)


### PR DESCRIPTION
Add the `oldrev` field from the GitLab webhook to the MergeRequestGitlabEvent.

This is needed to tell if code changes happened when there is an update of the merge request.

Also needed by my other pull request on Hardly https://github.com/packit/hardly/pull/76.

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
