### PR TITLE
Use packit_forge_project_allowed key from copr

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -246,11 +246,22 @@ CUSTOM_COPR_PROJECT_NOT_ALLOWED_STATUS = (
     "Not allowed to build in {copr_project} Copr project."
 )
 CUSTOM_COPR_PROJECT_NOT_ALLOWED_CONTENT = (
-    "Your git-forge project is not allowed to use the configured `{copr_project}` Copr project.\n\n"
-    f"Please, [let us know]({CONTACTS_URL}) "
-    "if you need this git project to be allowed. "
-    "We are working with the Copr team on a way "
-    "how to make this easily configurable in the Copr web interface.\n"
+    "Your git-forge project is not allowed to use "
+    "the configured `{copr_project}` Copr project.\n\n"
+    "Please, add this git-forge project `{forge_project}` "
+    "to `Packit allowed forge projects`"
+    "in the [Copr project settings](https://copr.fedorainfracloud.org/coprs/{copr_project}/edit/#packit_forge_projects_allowed). "  # noqa
+)
+
+CUSTOM_COPR_PROJECT_ALLOWED_IN_PACKIT_CONFIG = (
+    "Your git-forge project `{forge_project}` has permissions "
+    "to build in `{copr_project}` Copr project configured in Packit. "
+    "However, we migrated to the solution where you can configure"
+    "the allowed git-forge projects in Copr yourself and will remove the configuration"
+    "in Packit for the allowed projects soon. "
+    "Therefore, please, add this git-forge project `{forge_project}` "
+    "to `Packit allowed forge projects`"
+    "in the [Copr project settings](https://copr.fedorainfracloud.org/coprs/{copr_project}/edit/#packit_forge_projects_allowed). "  # noqa
 )
 
 FASJSON_URL = "https://fasjson.fedoraproject.org"
@@ -261,3 +272,4 @@ MISSING_PERMISSIONS_TO_BUILD_IN_COPR = (
     "You don't have permissions to build in this copr."
 )
 NOT_ALLOWED_TO_BUILD_IN_COPR = "is not allowed to build in the copr"
+GIT_FORGE_PROJECT_NOT_ALLOWED_TO_BUILD_IN_COPR = "can't build in this Copr via Packit."

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -152,9 +152,19 @@ def test_precheck_push(github_push_event):
         job_config=jc,
         event=github_push_event.get_dict(),
     )
-    copr_build_handler.service_config.allowed_forge_projects_for_copr_project = {
-        "@foo/bar": ["github.com/packit-service/hello-world"]
-    }
+    api = flexmock(
+        copr_helper=flexmock(
+            copr_client=flexmock(
+                config={"username": "nobody"},
+                project_proxy=flexmock(
+                    get=lambda owner, project: {
+                        "packit_forge_projects_allowed": "github.com/packit-service/hello-world"
+                    }
+                ),
+            )
+        )
+    )
+    flexmock(CoprBuildJobHelper).should_receive("api").and_return(api)
 
     assert copr_build_handler.pre_check()
 

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -2178,6 +2178,7 @@ def test_copr_build_targets_override(github_pr_event):
                 buildopts={
                     "chroots": ["bright-future-x86_64"],
                     "enable_net": True,
+                    "packit_forge_project": helper.forge_project,
                 },
             )
             .and_return(


### PR DESCRIPTION
Fixes packit/packit-service#1523

Merge before packit/packit.dev#520

---

RELEASE NOTES BEGIN
Users can now **allow and disallow** building in a custom `Copr` project from a `git-forge` project.
User has to add manually the `git-forge` project reference to the `Copr` project settings.
As an example, we should add *github.com/packit/ogr* to the list named *Packit forge project allowed* in our `packit-dev` Copr project settings: https://copr.fedorainfracloud.org/coprs/packit/packit-dev/edit#packit_forge_projects_allowed.
RELEASE NOTES END