### PR TITLE
Fix the check of installation date for SRPM builds

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1769,20 +1769,6 @@ class GithubInstallationModel(Base):
         return sa_session().query(GithubInstallationModel).filter_by(id=id).first()
 
     @classmethod
-    def get_for_github_project(
-        cls, namespace: str, repo_name: str
-    ) -> Optional["GithubInstallationModel"]:
-        namespace_installation = cls.get_by_account_login(account_login=namespace)
-        if not namespace_installation:
-            return None
-
-        for project_id in namespace_installation.repositories:
-            project = GitProjectModel.get_by_id(project_id)
-            if project and project.repo_name == repo_name:
-                return namespace_installation
-        return None
-
-    @classmethod
     def get_by_account_login(
         cls, account_login: str
     ) -> Optional["GithubInstallationModel"]:

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -2208,6 +2208,11 @@ def test_copr_build_targets_override(github_pr_event):
             id="new_installation",
         ),
         pytest.param(
+            None,
+            DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR.replace(tzinfo=None) + timedelta(days=1),
+            id="new_installation_without_timezone",
+        ),
+        pytest.param(
             [], DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR, id="explicitly_defined_empty_key"
         ),  # user defines this key (it's None by default)
         pytest.param(


### PR DESCRIPTION
Transform timezone-naive datetime for installation comparison - if the datetime of installation.created_at is timezone-naive,
this causes a problem when comparing to timezone-aware datetime.
Get the installation only by a namespace since repositories can get outdated because we don't react
to installation updates (repositories additions/removal).


Fixes #1647 #1648

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
