### PR TITLE
Retrigger bodhi update via dist-git PR comment

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -467,7 +467,7 @@ class SteveJobs:
 
         return True
 
-    def check_explicit_matching(self):
+    def check_explicit_matching(self) -> List[JobConfig]:
         """Force explicit event/jobs matching for triggers
 
         Returns:
@@ -477,7 +477,7 @@ class SteveJobs:
         if isinstance(self.event, PullRequestCommentPagureEvent):
             for job in self.event.package_config.jobs:
                 if (
-                    job.type == JobType.koji_build
+                    job.type in [JobType.koji_build, JobType.bodhi_update]
                     and job.trigger == JobConfigTriggerType.commit
                     and self.event.job_config_trigger_type
                     == JobConfigTriggerType.pull_request

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -411,3 +411,9 @@ def koji_build_completed_f35():
 def koji_build_completed_epel8():
     with open(DATA_DIR / "fedmsg" / "koji_build_completed_epel8.json", "r") as outfile:
         return load_the_message_from_file(outfile)
+
+
+@pytest.fixture()
+def pagure_pr_comment_added():
+    with open(DATA_DIR / "fedmsg" / "pagure_pr_comment.json") as outfile:
+        return json.load(outfile)

--- a/tests/unit/test_bodhi_update.py
+++ b/tests/unit/test_bodhi_update.py
@@ -1,0 +1,48 @@
+import pytest
+
+from flexmock import flexmock
+
+from packit_service.worker.handlers.bodhi import CreateBodhiUpdateHandler
+
+
+class TestBodhiHandler:
+    @pytest.mark.parametrize(
+        "event_type, has_write_access, result",
+        [
+            pytest.param(
+                "PullRequestCommentPagureEvent",
+                True,
+                True,
+            ),
+            pytest.param(
+                "PullRequestCommentPagureEvent",
+                False,
+                False,
+            ),
+            pytest.param(
+                "TestingFarmHandler",
+                True,
+                True,
+            ),
+        ],
+    )
+    def test_write_access_to_dist_git_repo_is_not_needed_or_satisfied(
+        self, event_type: str, has_write_access: bool, result: bool
+    ):
+        mock_data = flexmock(
+            event_type=event_type,
+            actor="happy-packit-user",
+            pr_id=123,
+        )
+        mock_project = flexmock(
+            has_write_access=lambda user: has_write_access,
+            repo="playground-for-pencils",
+        )
+        mock_self = flexmock(data=mock_data, project=mock_project)
+
+        assert (
+            result
+            == CreateBodhiUpdateHandler._write_access_to_dist_git_repo_is_not_needed_or_satisfied(
+                mock_self
+            )
+        )

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -190,11 +190,6 @@ class TestEvents:
             return json.load(outfile)
 
     @pytest.fixture()
-    def pagure_pr_comment_added(self):
-        with open(DATA_DIR / "fedmsg" / "pagure_pr_comment.json") as outfile:
-            return json.load(outfile)
-
-    @pytest.fixture()
     def distgit_commit(self):
         with open(DATA_DIR / "fedmsg" / "distgit_commit.json") as outfile:
             return json.load(outfile)

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2399,6 +2399,22 @@ def test_handler_doesnt_match_to_job(
                 ),
             ],
         ),
+        pytest.param(
+            PullRequestCommentPagureEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.commit,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.commit,
+                ),
+            ],
+        ),
     ],
 )
 def test_get_jobs_matching_trigger(event_kls, job_config_trigger_type, jobs, result):


### PR DESCRIPTION
I'm sorry it took so long. I couldn't find the time to come back to this issue recently :disappointed: 

note: OGR doesn't have `has_write_access` method. Not yet. I am going to implement it :)

also help needed :grin::  `test_bodhi_update_retrigger_via_dist_git_pr_comment` won't pass because because the `CreateBodhiUpdateHandler.run` method is not called. Even though the `task.bodhi_update` task gets the signature of the Celery task. This means that the `JobHandler.get_signature` method is executed and according to its documentation the `run_bodhi_update` task should be run, but this obviously does not happen. Any idea why?

Fixes #1541

Merge after [org#742](https://github.com/packit/ogr/pull/742) [packit#1729](https://github.com/packit/packit/pull/1729)


---

RELEASE NOTES BEGIN
Packit now allows to re-trigger Bodhi update via dist-git PR comment `/packit create-update`.
RELEASE NOTES END
