### PR TITLE
Move the check for event and job identifiers equality

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -496,6 +496,10 @@ class SteveJobs:
         for job in self.event.package_config.jobs:
             if (
                 job.trigger == self.event.job_config_trigger_type
+                and (
+                    not isinstance(self.event, CheckRerunEvent)
+                    or self.event.job_identifier == job.identifier
+                )
                 and job not in jobs_matching_trigger
             ):
                 jobs_matching_trigger.append(job)
@@ -555,12 +559,6 @@ class SteveJobs:
 
         matching_handlers: Set[Type["JobHandler"]] = set()
         for job in jobs_matching_trigger:
-            if (
-                isinstance(self.event, CheckRerunEvent)
-                and self.event.job_identifier != job.identifier
-            ):
-                continue
-
             for handler in (
                 MAP_JOB_TYPE_TO_HANDLER[job.type]
                 | MAP_REQUIRED_JOB_TYPE_TO_HANDLER[job.type]

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2278,7 +2278,7 @@ def test_handler_doesnt_match_to_job(
 
 
 @pytest.mark.parametrize(
-    "event_kls,job_config_trigger_type,jobs,result",
+    "event_kls,job_config_trigger_type,jobs,result,kwargs",
     [
         pytest.param(
             PullRequestCommentGithubEvent,
@@ -2299,6 +2299,7 @@ def test_handler_doesnt_match_to_job(
                     trigger=JobConfigTriggerType.pull_request,
                 ),
             ],
+            {},
         ),
         pytest.param(
             PullRequestCommentGithubEvent,
@@ -2319,6 +2320,7 @@ def test_handler_doesnt_match_to_job(
                     trigger=JobConfigTriggerType.release,
                 ),
             ],
+            {},
         ),
         pytest.param(
             PullRequestCommentGithubEvent,
@@ -2343,6 +2345,7 @@ def test_handler_doesnt_match_to_job(
                     trigger=JobConfigTriggerType.release,
                 ),
             ],
+            {},
         ),
         pytest.param(
             PullRequestCommentGithubEvent,
@@ -2358,6 +2361,7 @@ def test_handler_doesnt_match_to_job(
                 ),
             ],
             [],
+            {},
         ),
         pytest.param(
             PullRequestCommentPagureEvent,
@@ -2374,6 +2378,7 @@ def test_handler_doesnt_match_to_job(
                     trigger=JobConfigTriggerType.commit,
                 ),
             ],
+            {},
         ),
         pytest.param(
             PullRequestCommentPagureEvent,
@@ -2398,13 +2403,40 @@ def test_handler_doesnt_match_to_job(
                     trigger=JobConfigTriggerType.commit,
                 ),
             ],
+            {},
+        ),
+        pytest.param(
+            CheckRerunPullRequestEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    identifier="first",
+                ),
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    identifier="second",
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    identifier="first",
+                ),
+            ],
+            {"job_identifier": "first"},
         ),
     ],
 )
-def test_get_jobs_matching_trigger(event_kls, job_config_trigger_type, jobs, result):
+def test_get_jobs_matching_trigger(
+    event_kls, job_config_trigger_type, jobs, result, kwargs
+):
     class Event(event_kls):
-        def __init__(self):
-            pass
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
 
         @property
         def job_config_trigger_type(self):
@@ -2414,7 +2446,7 @@ def test_get_jobs_matching_trigger(event_kls, job_config_trigger_type, jobs, res
         def package_config(self):
             return flexmock(jobs=jobs)
 
-    event = Event()
+    event = Event(**kwargs)
     assert result == SteveJobs(event).get_jobs_matching_event()
 
 


### PR DESCRIPTION
Move the check whether identifier of the event we are reacting to
 is equal to the identifier of the currently processed job
to get_jobs_matching_event method. Previously, the check was in the get_handlers_for_event method  which calls the get_jobs_matching_event. This was not enough, because get_jobs_matching_event is being called 2 times, once more after running get_handlers_for_event and therefore handler was triggered with more job configs than correct.

Fixes #1625

---

RELEASE NOTES BEGIN
Retriggering tasks via re-run button in Github commit checks when there are configured identifiers for jobs should now work correctly.
RELEASE NOTES END
