### PR TITLE
Move job handler's pre-checks in a new class

### DIFF
--- a/packit_service/worker/checker/abstract.py
+++ b/packit_service/worker/checker/abstract.py
@@ -34,7 +34,6 @@ class ActorChecker(Checker):
         ...
 
     def pre_check(self) -> bool:
-        if self.actor:
-            return self._pre_check()
-        else:
+        if not self.actor:
             return False
+        return self._pre_check()

--- a/packit_service/worker/checker/abstract.py
+++ b/packit_service/worker/checker/abstract.py
@@ -1,0 +1,40 @@
+from abc import abstractmethod
+from typing import Optional
+
+from packit.config import JobConfig
+from packit.config.package_config import PackageConfig
+
+from packit_service.worker.events import EventData
+from packit_service.worker.mixin import ConfigMixin, PackitAPIWithDownstreamMixin
+
+
+class Checker(ConfigMixin, PackitAPIWithDownstreamMixin):
+    def __init__(
+        self,
+        package_config: PackageConfig,
+        job_config: JobConfig,
+        event: dict,
+    ):
+        self.package_config = package_config
+        self.job_config = job_config
+        self.data = EventData.from_event_dict(event)
+
+    @abstractmethod
+    def pre_check(self) -> bool:
+        ...
+
+
+class ActorChecker(Checker):
+    @property
+    def actor(self) -> Optional[str]:
+        return self.data.actor
+
+    @abstractmethod
+    def _pre_check(self) -> bool:
+        ...
+
+    def pre_check(self) -> bool:
+        if self.actor:
+            return self._pre_check()
+        else:
+            return False

--- a/packit_service/worker/checker/bodhi.py
+++ b/packit_service/worker/checker/bodhi.py
@@ -13,7 +13,7 @@ from packit_service.worker.handlers.mixin import GetKojiBuildEventMixin
 logger = logging.getLogger(__name__)
 
 
-class IsKojiBuildComplete(Checker, GetKojiBuildEventMixin):
+class IsKojiBuildCompleteAndBranchConfigured(Checker, GetKojiBuildEventMixin):
     def pre_check(self) -> bool:
         """Check if builds are finished (=KojiBuildState.complete)
         and branches are configured.

--- a/packit_service/worker/checker/bodhi.py
+++ b/packit_service/worker/checker/bodhi.py
@@ -1,0 +1,42 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+
+from packit.config.aliases import get_branches
+
+from packit_service.constants import KojiBuildState
+
+from packit_service.worker.checker.abstract import Checker
+from packit_service.worker.handlers.mixin import GetKojiBuildEventMixin
+
+logger = logging.getLogger(__name__)
+
+
+class IsKojiBuildComplete(Checker, GetKojiBuildEventMixin):
+    def pre_check(self) -> bool:
+        """Check if builds are finished (=KojiBuildState.complete)
+        and branches are configured.
+        By default, we use `fedora-stable` alias.
+        (Rawhide updates are already created automatically.)
+        """
+        if self.koji_build_event.state != KojiBuildState.complete:
+            logger.debug(
+                f"Skipping build '{self.koji_build_event.build_id}' "
+                f"on '{self.koji_build_event.git_ref}'. "
+                f"Build not finished yet."
+            )
+            return False
+
+        if self.koji_build_event.git_ref not in (
+            configured_branches := get_branches(
+                *(self.job_config.dist_git_branches or {"fedora-stable"}),
+                default_dg_branch="rawhide",  # Koji calls it rawhide, not main
+            )
+        ):
+            logger.info(
+                f"Skipping build on '{self.data.git_ref}'. "
+                f"Bodhi update configured only for '{configured_branches}'."
+            )
+            return False
+        return True

--- a/packit_service/worker/checker/copr.py
+++ b/packit_service/worker/checker/copr.py
@@ -80,8 +80,7 @@ class CoprBuildPermission(Checker, GetCoprBuildJobHelperForIdMixin):
 
 
 class CanActorRunJob(ActorChecker, GetCoprBuildJobHelperMixin):
-    """
-    For external contributors, we need to be more careful when running jobs.
+    """For external contributors, we need to be more careful when running jobs.
     This is a handler-specific permission check
     for a user who trigger the action on a PR.
     """

--- a/packit_service/worker/checker/copr.py
+++ b/packit_service/worker/checker/copr.py
@@ -1,0 +1,106 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+
+from packit_service.worker.checker.abstract import ActorChecker, Checker
+from packit_service.worker.events.enums import GitlabEventAction
+from packit_service.worker.events import (
+    MergeRequestGitlabEvent,
+    PushGitHubEvent,
+    PushGitlabEvent,
+    PushPagureEvent,
+)
+from packit_service.worker.handlers.mixin import (
+    GetCoprBuildJobHelperForIdMixin,
+    GetCoprBuildJobHelperMixin,
+)
+from packit_service.constants import (
+    INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED,
+)
+from packit_service.worker.reporting import BaseCommitStatus
+
+logger = logging.getLogger(__name__)
+
+
+class Permission(Checker, GetCoprBuildJobHelperMixin):
+    def pre_check(
+        self,
+    ) -> bool:
+        if (
+            self.data.event_type == MergeRequestGitlabEvent.__name__
+            and self.data.event_dict["action"] == GitlabEventAction.closed.value
+        ):
+            # Not interested in closed merge requests
+            return False
+
+        if self.data.event_type in (
+            PushGitHubEvent.__name__,
+            PushGitlabEvent.__name__,
+            PushPagureEvent.__name__,
+        ):
+            configured_branch = self.copr_build_helper.job_build_branch
+            if self.data.git_ref != configured_branch:
+                logger.info(
+                    f"Skipping build on '{self.data.git_ref}'. "
+                    f"Push configured only for '{configured_branch}'."
+                )
+                return False
+
+        if not (self.copr_build_helper.job_build or self.copr_build_helper.job_tests):
+            logger.info("No copr_build or tests job defined.")
+            # we can't report it to end-user at this stage
+            return False
+
+        if self.copr_build_helper.is_custom_copr_project_defined():
+            logger.debug(
+                "Custom Copr owner/project set. "
+                "Checking if this GitHub project can use this Copr project."
+            )
+            if not self.copr_build_helper.check_if_custom_copr_can_be_used_and_report():
+                return False
+
+        return True
+
+
+class CoprBuildPermission(Checker, GetCoprBuildJobHelperForIdMixin):
+    def pre_check(self) -> bool:
+        if (
+            self.copr_event.owner == self.copr_build_helper.job_owner
+            and self.copr_event.project_name == self.copr_build_helper.job_project
+        ):
+            return True
+
+        logger.debug(
+            f"The Copr project {self.copr_event.owner}/{self.copr_event.project_name} "
+            f"does not match the configuration "
+            f"({self.copr_build_helper.job_owner}/{self.copr_build_helper.job_project} expected)."
+        )
+        return False
+
+
+class CanActorRunJob(ActorChecker, GetCoprBuildJobHelperMixin):
+    """
+    For external contributors, we need to be more careful when running jobs.
+    This is a handler-specific permission check
+    for a user who trigger the action on a PR.
+    """
+
+    def _pre_check(self) -> bool:
+        test_job = self.copr_build_helper.job_tests
+        if (
+            test_job
+            and test_job.use_internal_tf
+            and not self.project.can_merge_pr(self.actor)
+        ):
+            self.copr_build_helper.report_status_to_build(
+                description=INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED[0].format(
+                    actor=self.actor
+                ),
+                state=BaseCommitStatus.neutral,
+                markdown_content=INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED[1].format(
+                    packit_comment_command_prefix=self.service_config.comment_command_prefix
+                ),
+            )
+            return False
+        return True

--- a/packit_service/worker/checker/copr.py
+++ b/packit_service/worker/checker/copr.py
@@ -91,6 +91,7 @@ class CanActorRunTestsJob(ActorChecker, GetCoprBuildJobHelperMixin):
             test_job
             and test_job.use_internal_tf
             and not self.project.can_merge_pr(self.actor)
+            and self.actor not in self.service_config.admins
         ):
             self.copr_build_helper.report_status_to_build(
                 description=INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED[0].format(

--- a/packit_service/worker/checker/copr.py
+++ b/packit_service/worker/checker/copr.py
@@ -23,7 +23,7 @@ from packit_service.worker.reporting import BaseCommitStatus
 logger = logging.getLogger(__name__)
 
 
-class Permission(Checker, GetCoprBuildJobHelperMixin):
+class PermissionOnCopr(Checker, GetCoprBuildJobHelperMixin):
     def pre_check(
         self,
     ) -> bool:

--- a/packit_service/worker/checker/copr.py
+++ b/packit_service/worker/checker/copr.py
@@ -23,7 +23,7 @@ from packit_service.worker.reporting import BaseCommitStatus
 logger = logging.getLogger(__name__)
 
 
-class PermissionOnCopr(Checker, GetCoprBuildJobHelperMixin):
+class IsGitForgeProjectAndEventOk(Checker, GetCoprBuildJobHelperMixin):
     def pre_check(
         self,
     ) -> bool:
@@ -63,7 +63,7 @@ class PermissionOnCopr(Checker, GetCoprBuildJobHelperMixin):
         return True
 
 
-class CoprBuildPermission(Checker, GetCoprBuildJobHelperForIdMixin):
+class AreOwnerAndProjectMatchingJob(Checker, GetCoprBuildJobHelperForIdMixin):
     def pre_check(self) -> bool:
         if (
             self.copr_event.owner == self.copr_build_helper.job_owner
@@ -79,7 +79,7 @@ class CoprBuildPermission(Checker, GetCoprBuildJobHelperForIdMixin):
         return False
 
 
-class CanActorRunJob(ActorChecker, GetCoprBuildJobHelperMixin):
+class CanActorRunTestsJob(ActorChecker, GetCoprBuildJobHelperMixin):
     """For external contributors, we need to be more careful when running jobs.
     This is a handler-specific permission check
     for a user who trigger the action on a PR.

--- a/packit_service/worker/checker/distgit.py
+++ b/packit_service/worker/checker/distgit.py
@@ -1,0 +1,75 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+
+from packit.config.aliases import get_branches
+
+from packit_service.worker.checker.abstract import Checker
+from packit_service.worker.events import (
+    PushPagureEvent,
+)
+from packit_service.worker.events.pagure import PullRequestCommentPagureEvent
+from packit_service.worker.handlers.mixin import GetProjectToSyncMixin
+from packit_service.worker.mixin import (
+    GetPagurePullRequestMixin,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class Permission(Checker, GetPagurePullRequestMixin):
+    def pre_check(self) -> bool:
+        if self.data.event_type in (PushPagureEvent.__name__,):
+            if self.data.git_ref not in (
+                configured_branches := get_branches(
+                    *self.job_config.dist_git_branches,
+                    default="main",
+                    with_aliases=True,
+                )
+            ):
+                logger.info(
+                    f"Skipping build on '{self.data.git_ref}'. "
+                    f"Koji build configured only for '{configured_branches}'."
+                )
+                return False
+
+            if self.data.event_dict["committer"] == "pagure":
+                pr_author = self.get_pr_author()
+                logger.debug(f"PR author: {pr_author}")
+                if pr_author not in self.job_config.allowed_pr_authors:
+                    logger.info(
+                        f"Push event {self.data.identifier} with corresponding PR created by"
+                        f" {pr_author} that is not allowed in project "
+                        f"configuration: {self.job_config.allowed_pr_authors}."
+                    )
+                    return False
+            else:
+                committer = self.data.event_dict["committer"]
+                logger.debug(f"Committer: {committer}")
+                if committer not in self.job_config.allowed_committers:
+                    logger.info(
+                        f"Push event {self.data.identifier} done by "
+                        f"{committer} that is not allowed in project "
+                        f"configuration: {self.job_config.allowed_committers}."
+                    )
+                    return False
+        elif self.data.event_type in (PullRequestCommentPagureEvent.__name__,):
+            commenter = self.data.actor
+            logger.debug(
+                f"Triggering downstream koji build through comment by: {commenter}"
+            )
+            if not self.is_packager(commenter):
+                logger.info(
+                    f"koji-build retrigger comment event on PR identifier {self.data.pr_id} "
+                    f"done by {commenter} which is not a packager."
+                )
+                return False
+
+        return True
+
+
+class IsProjectOk(Checker, GetProjectToSyncMixin):
+    def pre_check(self) -> bool:
+        return self.project_to_sync is not None

--- a/packit_service/worker/checker/distgit.py
+++ b/packit_service/worker/checker/distgit.py
@@ -19,7 +19,7 @@ from packit_service.worker.mixin import (
 logger = logging.getLogger(__name__)
 
 
-class Permission(Checker, GetPagurePullRequestMixin):
+class PermissionOnDistgit(Checker, GetPagurePullRequestMixin):
     def pre_check(self) -> bool:
         if self.data.event_type in (PushPagureEvent.__name__,):
             if self.data.git_ref not in (

--- a/packit_service/worker/checker/forges.py
+++ b/packit_service/worker/checker/forges.py
@@ -1,0 +1,34 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+
+from packit_service.worker.checker.abstract import Checker
+from packit_service.worker.mixin import GetIssueMixin
+
+logger = logging.getLogger(__name__)
+
+
+class Permission(Checker, GetIssueMixin):
+    def pre_check(self) -> bool:
+        """
+        Checks whether the Packit verification command is placed in
+        packit/notifications repository in the issue our service created.
+        """
+        if not (
+            self.project.namespace == "packit" and self.project.repo == "notifications"
+        ):
+            logger.debug(
+                "Packit verification comment command not placed in packit/notifications repository."
+            )
+            return False
+
+        issue_author = self.issue.author
+        if issue_author != self.service_config.get_github_account_name():
+            logger.debug(
+                f"Packit verification comment command placed on issue with author "
+                f"other than our app: {issue_author}"
+            )
+            return False
+
+        return True

--- a/packit_service/worker/checker/forges.py
+++ b/packit_service/worker/checker/forges.py
@@ -11,8 +11,7 @@ logger = logging.getLogger(__name__)
 
 class PermissionOnForge(Checker, GetIssueMixin):
     def pre_check(self) -> bool:
-        """
-        Checks whether the Packit verification command is placed in
+        """Checks whether the Packit verification command is placed in
         packit/notifications repository in the issue our service created.
         """
         if not (

--- a/packit_service/worker/checker/forges.py
+++ b/packit_service/worker/checker/forges.py
@@ -9,7 +9,7 @@ from packit_service.worker.mixin import GetIssueMixin
 logger = logging.getLogger(__name__)
 
 
-class PermissionOnForge(Checker, GetIssueMixin):
+class IsIssueInNotificationRepoChecker(Checker, GetIssueMixin):
     def pre_check(self) -> bool:
         """Checks whether the Packit verification command is placed in
         packit/notifications repository in the issue our service created.

--- a/packit_service/worker/checker/forges.py
+++ b/packit_service/worker/checker/forges.py
@@ -9,7 +9,7 @@ from packit_service.worker.mixin import GetIssueMixin
 logger = logging.getLogger(__name__)
 
 
-class Permission(Checker, GetIssueMixin):
+class PermissionOnForge(Checker, GetIssueMixin):
     def pre_check(self) -> bool:
         """
         Checks whether the Packit verification command is placed in

--- a/packit_service/worker/checker/koji.py
+++ b/packit_service/worker/checker/koji.py
@@ -1,0 +1,65 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+
+from packit_service.worker.checker.abstract import Checker
+from packit_service.worker.events.enums import GitlabEventAction
+from packit_service.worker.events import (
+    MergeRequestGitlabEvent,
+    PullRequestGithubEvent,
+    PushGitHubEvent,
+    PushGitlabEvent,
+    PushPagureEvent,
+)
+from packit_service.constants import (
+    KOJI_PRODUCTION_BUILDS_ISSUE,
+    PERMISSIONS_ERROR_WRITE_OR_ADMIN,
+)
+from packit_service.worker.reporting import BaseCommitStatus
+from packit_service.worker.handlers.mixin import GetKojiBuildJobHelperMixin
+
+logger = logging.getLogger(__name__)
+
+
+class Permission(Checker, GetKojiBuildJobHelperMixin):
+    def pre_check(self) -> bool:
+        if (
+            self.data.event_type == MergeRequestGitlabEvent.__name__
+            and self.data.event_dict["action"] == GitlabEventAction.closed.value
+        ):
+            # Not interested in closed merge requests
+            return False
+
+        if self.data.event_type in (
+            PushGitHubEvent.__name__,
+            PushGitlabEvent.__name__,
+            PushPagureEvent.__name__,
+        ):
+            configured_branch = self.koji_build_helper.job_build_branch
+            if self.data.git_ref != configured_branch:
+                logger.info(
+                    f"Skipping build on '{self.data.git_ref}'. "
+                    f"Push configured only for '{configured_branch}'."
+                )
+                return False
+
+        if self.data.event_type == PullRequestGithubEvent.__name__:
+            user_can_merge_pr = self.project.can_merge_pr(self.data.actor)
+            if not (user_can_merge_pr or self.data.actor in self.service_config.admins):
+                self.koji_build_helper.report_status_to_all(
+                    description=PERMISSIONS_ERROR_WRITE_OR_ADMIN,
+                    state=BaseCommitStatus.neutral,
+                )
+                return False
+
+        if not self.koji_build_helper.is_scratch:
+            msg = "Non-scratch builds not possible from upstream."
+            self.koji_build_helper.report_status_to_all(
+                description=msg,
+                state=BaseCommitStatus.neutral,
+                url=KOJI_PRODUCTION_BUILDS_ISSUE,
+            )
+            return False
+
+        return True

--- a/packit_service/worker/checker/koji.py
+++ b/packit_service/worker/checker/koji.py
@@ -22,7 +22,7 @@ from packit_service.worker.handlers.mixin import GetKojiBuildJobHelperMixin
 logger = logging.getLogger(__name__)
 
 
-class Permission(Checker, GetKojiBuildJobHelperMixin):
+class PermissionOnKoji(Checker, GetKojiBuildJobHelperMixin):
     def pre_check(self) -> bool:
         if (
             self.data.event_type == MergeRequestGitlabEvent.__name__

--- a/packit_service/worker/checker/testing_farm.py
+++ b/packit_service/worker/checker/testing_farm.py
@@ -1,0 +1,81 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+from packit_service.constants import (
+    INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED,
+    INTERNAL_TF_TESTS_NOT_ALLOWED,
+)
+
+from packit_service.worker.checker.abstract import ActorChecker, Checker
+from packit_service.worker.events.gitlab import MergeRequestGitlabEvent
+from packit_service.worker.events.enums import GitlabEventAction
+from packit_service.worker.handlers.mixin import (
+    GetTestingFarmJobHelperMixin,
+    GetCoprBuildMixin,
+    GetGithubCommentEventMixin,
+)
+from packit_service.worker.reporting import BaseCommitStatus
+
+logger = logging.getLogger(__name__)
+
+
+class IsEventOk(
+    Checker, GetTestingFarmJobHelperMixin, GetCoprBuildMixin, GetGithubCommentEventMixin
+):
+    def pre_check(self) -> bool:
+        if (
+            self.data.event_type == MergeRequestGitlabEvent.__name__
+            and self.data.event_dict["action"] == GitlabEventAction.closed.value
+        ):
+            # Not interested in closed merge requests
+            return False
+
+        if self.testing_farm_job_helper.is_test_comment_pr_argument_present():
+            return self.testing_farm_job_helper.check_comment_pr_argument_and_report()
+
+        return not (
+            self.testing_farm_job_helper.skip_build
+            and self.testing_farm_job_helper.is_copr_build_comment_event()
+        )
+
+
+class IsEventForJob(Checker):
+    def pre_check(self) -> bool:
+        if self.data.identifier != self.job_config.identifier:
+            logger.debug(
+                f"Skipping reporting, identifiers don't match "
+                f"(identifier of the test job to report: {self.data.identifier}, "
+                f"identifier from job config: {self.job_config.identifier})."
+            )
+            return False
+        return True
+
+
+class CanActorRunJob(ActorChecker, GetTestingFarmJobHelperMixin):
+    """
+    For external contributors, we need to be more careful when running jobs.
+    This is a handler-specific permission check
+    for a user who trigger the action on a PR.
+
+    The job is not allowed for external contributors when using internal TF.
+    """
+
+    def _pre_check(self) -> bool:
+        if self.job_config.use_internal_tf and not self.project.can_merge_pr(
+            self.actor
+        ):
+            message = (
+                INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED
+                if self.testing_farm_job_helper.job_build
+                else INTERNAL_TF_TESTS_NOT_ALLOWED
+            )
+            self.testing_farm_job_helper.report_status_to_tests(
+                description=message[0].format(actor=self.actor),
+                state=BaseCommitStatus.neutral,
+                markdown_content=message[1].format(
+                    packit_comment_command_prefix=self.service_config.comment_command_prefix
+                ),
+            )
+            return False
+        return True

--- a/packit_service/worker/checker/testing_farm.py
+++ b/packit_service/worker/checker/testing_farm.py
@@ -53,8 +53,7 @@ class IsEventForJob(Checker):
 
 
 class CanActorRunJob(ActorChecker, GetTestingFarmJobHelperMixin):
-    """
-    For external contributors, we need to be more careful when running jobs.
+    """For external contributors, we need to be more careful when running jobs.
     This is a handler-specific permission check
     for a user who trigger the action on a PR.
 

--- a/packit_service/worker/checker/testing_farm.py
+++ b/packit_service/worker/checker/testing_farm.py
@@ -61,8 +61,10 @@ class CanActorRunJob(ActorChecker, GetTestingFarmJobHelperMixin):
     """
 
     def _pre_check(self) -> bool:
-        if self.job_config.use_internal_tf and not self.project.can_merge_pr(
-            self.actor
+        if (
+            self.job_config.use_internal_tf
+            and not self.project.can_merge_pr(self.actor)
+            and self.actor not in self.service_config.admins
         ):
             message = (
                 INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -275,7 +275,8 @@ class Handler(ConfigMixin, PackitAPIWithDownstreamMixin):
         event: dict,
     ) -> bool:
         """
-        :return: False if we have to skip the job execution.
+        Returns
+            bool: False if we have to skip the job execution.
         """
         checks_pass = True
         for checker_cls in cls.get_checkers():

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -29,6 +29,7 @@ from packit_service.worker.celery_task import CeleryTask
 from packit_service.worker.events import Event, EventData
 from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.result import TaskResults
+from packit_service.worker.checker.abstract import Checker
 
 from packit_service.worker.mixin import (
     ConfigMixin,
@@ -264,7 +265,7 @@ class Handler(ConfigMixin, PackitAPIWithDownstreamMixin):
                 shutil.rmtree(item)
 
     @staticmethod
-    def get_checkers() -> Tuple:
+    def get_checkers() -> Tuple[Type[Checker], ...]:
         return ()
 
     @classmethod

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -382,7 +382,7 @@ class RetriableJobHandler(JobHandler):
         super().__init__(
             package_config=package_config, job_config=job_config, event=event
         )
-        self.celery_task = CeleryTask(celery_task) if celery_task else None
+        self.celery_task = CeleryTask(celery_task)
 
     def run(self) -> TaskResults:
         raise NotImplementedError("This should have been implemented.")

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -293,8 +293,7 @@ class Handler(ConfigMixin, PackitAPIWithDownstreamMixin):
     def clean(self):
         """clean up the mess once we're done"""
         logger.info("Cleaning up the mess.")
-        if self.api:
-            self.api.clean()
+        self.clean_api()
         self._clean_workplace()
 
 

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -11,18 +11,15 @@ from collections import defaultdict
 from datetime import datetime
 from os import getenv
 from pathlib import Path
-from typing import Dict, Optional, Set, Type
+from typing import Dict, Optional, Set, Type, Tuple
 
 from celery import Task
 from celery import signature
 from celery.canvas import Signature
 from ogr.abstract import GitProject
-
-from packit.api import PackitAPI
 from packit.config import JobConfig, JobType, PackageConfig
 from packit.constants import DATETIME_FORMAT
-from packit.local_project import LocalProject
-from packit_service.config import ServiceConfig
+
 from packit_service.models import (
     AbstractTriggerDbType,
 )
@@ -32,6 +29,11 @@ from packit_service.worker.celery_task import CeleryTask
 from packit_service.worker.events import Event, EventData
 from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.result import TaskResults
+
+from packit_service.worker.mixin import (
+    ConfigMixin,
+    PackitAPIWithDownstreamMixin,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -210,21 +212,7 @@ class TaskName(str, enum.Enum):
     github_fas_verification = "task.github_fas_verification"
 
 
-class Handler:
-    api: Optional[PackitAPI] = None
-    local_project: Optional[LocalProject] = None
-    _service_config: Optional[ServiceConfig] = None
-
-    @property
-    def service_config(self) -> ServiceConfig:
-        if not self._service_config:
-            self._service_config = ServiceConfig.get_service_config()
-        return self._service_config
-
-    @property
-    def project(self) -> Optional[GitProject]:
-        return None
-
+class Handler(ConfigMixin, PackitAPIWithDownstreamMixin):
     def run(self) -> TaskResults:
         raise NotImplementedError("This should have been implemented.")
 
@@ -275,14 +263,30 @@ class Handler:
             else:
                 shutil.rmtree(item)
 
-    def pre_check(self) -> bool:
-        """
-        Implement this method for those handlers, where you want to check if the properties are
-        correct. If this method returns False during runtime, execution of service code is skipped.
+    @staticmethod
+    def get_checkers() -> Tuple:
+        return ()
 
-        :return: False if we can skip the job execution.
+    @classmethod
+    def pre_check(
+        cls,
+        package_config: PackageConfig,
+        job_config: JobConfig,
+        event: dict,
+    ) -> bool:
         """
-        return True
+        :return: False if we have to skip the job execution.
+        """
+        checks_pass = True
+        for checker_cls in cls.get_checkers():
+            checker = checker_cls(
+                package_config=package_config,
+                job_config=job_config,
+                event=event,
+            )
+            checks_pass = checks_pass and checker.pre_check()
+
+        return checks_pass
 
     def clean(self):
         """clean up the mess once we're done"""
@@ -314,26 +318,11 @@ class JobHandler(Handler):
         self._project: Optional[GitProject] = None
         self._clean_workplace()
 
-    @property
-    def project(self) -> Optional[GitProject]:
-        if not self._project and self.data.project_url:
-            self._project = self.service_config.get_project(url=self.data.project_url)
-        return self._project
-
     @classmethod
     def get_all_subclasses(cls) -> Set[Type["JobHandler"]]:
         return set(cls.__subclasses__()).union(
             [s for c in cls.__subclasses__() for s in c.get_all_subclasses()]
         )
-
-    def check_if_actor_can_run_job_and_report(self, actor: str) -> bool:
-        """
-        Here, handlers can specify additional check of permissions for a given user
-        by overriding this method.
-
-        In case of False, we expect the method provides a feedback to the user.
-        """
-        return True
 
     def run_job(self):
         """
@@ -388,7 +377,7 @@ class RetriableJobHandler(JobHandler):
         package_config: PackageConfig,
         job_config: JobConfig,
         event: dict,
-        celery_task: Optional[Task] = None,
+        celery_task: Task,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, event=event

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -5,7 +5,7 @@
 This file defines classes for job handlers related to Bodhi
 """
 import logging
-from typing import Optional
+from typing import Optional, Tuple
 
 from celery import Task
 from fedora.client import AuthError
@@ -14,18 +14,13 @@ from packit.constants import DEFAULT_BODHI_NOTE
 
 from packit.exceptions import PackitException
 
-from packit.api import PackitAPI
-from packit.config.aliases import get_branches
-
 from packit.config import JobConfig, JobType, PackageConfig
-from packit.local_project import LocalProject
-from packit.utils.repo import RepositoryCache
 from packit_service.config import PackageConfigGetter
 from packit_service.constants import (
     CONTACTS_URL,
-    KojiBuildState,
     RETRY_INTERVAL_IN_MINUTES_WHEN_USER_ACTION_IS_NEEDED,
 )
+from packit_service.worker.checker.bodhi import IsKojiBuildComplete
 from packit_service.worker.events.koji import KojiBuildEvent
 from packit_service.worker.handlers.abstract import (
     TaskName,
@@ -33,6 +28,8 @@ from packit_service.worker.handlers.abstract import (
     reacts_to,
     RetriableJobHandler,
 )
+from packit_service.worker.handlers.mixin import GetKojiBuildEventMixin
+from packit_service.worker.mixin import LocalProjectMixin
 from packit_service.worker.result import TaskResults
 
 logger = logging.getLogger(__name__)
@@ -40,7 +37,9 @@ logger = logging.getLogger(__name__)
 
 @configured_as(job_type=JobType.bodhi_update)
 @reacts_to(event=KojiBuildEvent)
-class CreateBodhiUpdateHandler(RetriableJobHandler):
+class CreateBodhiUpdateHandler(
+    RetriableJobHandler, LocalProjectMixin, GetKojiBuildEventMixin
+):
     """
     This handler can create a bodhi update for successful Koji builds.
     """
@@ -62,63 +61,17 @@ class CreateBodhiUpdateHandler(RetriableJobHandler):
             celery_task=celery_task,
         )
 
-        # lazy properties
-        self._koji_build_event: Optional[KojiBuildEvent] = None
-
-    @property
-    def koji_build_event(self):
-        if not self._koji_build_event:
-            self._koji_build_event = KojiBuildEvent.from_event_dict(
-                self.data.event_dict
-            )
-        return self._koji_build_event
-
-    def pre_check(self) -> bool:
+    @staticmethod
+    def get_checkers() -> Tuple:
         """
         We react only on finished builds (=KojiBuildState.complete)
         and configured branches.
-        By default, we use `fedora-stable` alias.
-        (Rawhide updates are already created automatically.)
         """
-        if self.koji_build_event.state != KojiBuildState.complete:
-            logger.debug(
-                f"Skipping build '{self.koji_build_event.build_id}' "
-                f"on '{self.koji_build_event.git_ref}'. "
-                f"Build not finished yet."
-            )
-            return False
-
-        if self.koji_build_event.git_ref not in (
-            configured_branches := get_branches(
-                *(self.job_config.dist_git_branches or {"fedora-stable"}),
-                default_dg_branch="rawhide",  # Koji calls it rawhide, not main
-            )
-        ):
-            logger.info(
-                f"Skipping build on '{self.data.git_ref}'. "
-                f"Bodhi update configured only for '{configured_branches}'."
-            )
-            return False
-        return True
+        return (IsKojiBuildComplete,)
 
     def run(self) -> TaskResults:
-        self.local_project = LocalProject(
-            git_project=self.project,
-            working_dir=self.service_config.command_handler_work_dir,
-            cache=RepositoryCache(
-                cache_path=self.service_config.repository_cache,
-                add_new=self.service_config.add_repositories_to_repository_cache,
-            )
-            if self.service_config.repository_cache
-            else None,
-        )
-        packit_api = PackitAPI(
-            self.service_config,
-            self.job_config,
-            downstream_local_project=self.local_project,
-        )
         try:
-            packit_api.create_update(
+            self.packit_api.create_update(
                 dist_git_branch=self.koji_build_event.git_ref,
                 update_type="enhancement",
                 update_notes=DEFAULT_BODHI_NOTE,

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -5,7 +5,7 @@
 This file defines classes for job handlers related to Bodhi
 """
 import logging
-from typing import Tuple
+from typing import Tuple, Type
 
 from celery import Task
 from fedora.client import AuthError
@@ -20,6 +20,7 @@ from packit_service.constants import (
     CONTACTS_URL,
     RETRY_INTERVAL_IN_MINUTES_WHEN_USER_ACTION_IS_NEEDED,
 )
+from packit_service.worker.checker.abstract import Checker
 from packit_service.worker.checker.bodhi import IsKojiBuildComplete
 from packit_service.worker.events.koji import KojiBuildEvent
 from packit_service.worker.handlers.abstract import (
@@ -62,7 +63,7 @@ class CreateBodhiUpdateHandler(
         )
 
     @staticmethod
-    def get_checkers() -> Tuple:
+    def get_checkers() -> Tuple[Type[Checker], ...]:
         """We react only on finished builds (=KojiBuildState.complete)
         and configured branches.
         """

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -63,8 +63,7 @@ class CreateBodhiUpdateHandler(
 
     @staticmethod
     def get_checkers() -> Tuple:
-        """
-        We react only on finished builds (=KojiBuildState.complete)
+        """We react only on finished builds (=KojiBuildState.complete)
         and configured branches.
         """
         return (IsKojiBuildComplete,)

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -21,7 +21,7 @@ from packit_service.constants import (
     RETRY_INTERVAL_IN_MINUTES_WHEN_USER_ACTION_IS_NEEDED,
 )
 from packit_service.worker.checker.abstract import Checker
-from packit_service.worker.checker.bodhi import IsKojiBuildComplete
+from packit_service.worker.checker.bodhi import IsKojiBuildCompleteAndBranchConfigured
 from packit_service.worker.events.koji import KojiBuildEvent
 from packit_service.worker.handlers.abstract import (
     TaskName,
@@ -67,7 +67,7 @@ class CreateBodhiUpdateHandler(
         """We react only on finished builds (=KojiBuildState.complete)
         and configured branches.
         """
-        return (IsKojiBuildComplete,)
+        return (IsKojiBuildCompleteAndBranchConfigured,)
 
     def run(self) -> TaskResults:
         try:

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -5,7 +5,7 @@
 This file defines classes for job handlers related to Bodhi
 """
 import logging
-from typing import Optional, Tuple
+from typing import Tuple
 
 from celery import Task
 from fedora.client import AuthError
@@ -52,7 +52,7 @@ class CreateBodhiUpdateHandler(
         package_config: PackageConfig,
         job_config: JobConfig,
         event: dict,
-        celery_task: Optional[Task] = None,
+        celery_task: Task,
     ):
         super().__init__(
             package_config=package_config,

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -3,7 +3,7 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Type
 
 from celery import signature, Task
 from ogr.services.github import GithubProject
@@ -25,6 +25,7 @@ from packit_service.models import (
     GithubInstallationModel,
     BuildStatus,
 )
+from packit_service.worker.checker.abstract import Checker
 from packit_service.worker.checker.copr import (
     CanActorRunJob,
     CoprBuildPermission,
@@ -104,7 +105,7 @@ class CoprBuildHandler(RetriableJobHandler, GetCoprBuildJobHelperMixin):
         )
 
     @staticmethod
-    def get_checkers() -> Tuple:
+    def get_checkers() -> Tuple[Type[Checker], ...]:
         return (PermissionOnCopr, CanActorRunJob)
 
     def get_packit_github_installation_time(self) -> Optional[datetime]:
@@ -129,7 +130,7 @@ class CoprBuildHandler(RetriableJobHandler, GetCoprBuildJobHelperMixin):
 
 class AbstractCoprBuildReportHandler(JobHandler, GetCoprBuildJobHelperForIdMixin):
     @staticmethod
-    def get_checkers() -> Tuple:
+    def get_checkers() -> Tuple[Type[Checker], ...]:
         return (CoprBuildPermission,)
 
 

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -28,7 +28,7 @@ from packit_service.models import (
 from packit_service.worker.checker.copr import (
     CanActorRunJob,
     CoprBuildPermission,
-    Permission,
+    PermissionOnCopr,
 )
 from packit_service.worker.events import (
     CoprBuildEndEvent,
@@ -105,7 +105,7 @@ class CoprBuildHandler(RetriableJobHandler, GetCoprBuildJobHelperMixin):
 
     @staticmethod
     def get_checkers() -> Tuple:
-        return (Permission, CanActorRunJob)
+        return (PermissionOnCopr, CanActorRunJob)
 
     def get_packit_github_installation_time(self) -> Optional[datetime]:
         if isinstance(self.project, GithubProject) and (

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -27,9 +27,9 @@ from packit_service.models import (
 )
 from packit_service.worker.checker.abstract import Checker
 from packit_service.worker.checker.copr import (
-    CanActorRunJob,
-    CoprBuildPermission,
-    PermissionOnCopr,
+    CanActorRunTestsJob,
+    AreOwnerAndProjectMatchingJob,
+    IsGitForgeProjectAndEventOk,
 )
 from packit_service.worker.events import (
     CoprBuildEndEvent,
@@ -107,7 +107,7 @@ class CoprBuildHandler(RetriableJobHandler, GetCoprBuildJobHelperMixin):
 
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker], ...]:
-        return (PermissionOnCopr, CanActorRunJob)
+        return (IsGitForgeProjectAndEventOk, CanActorRunTestsJob)
 
     def get_packit_github_installation_time(self) -> Optional[datetime]:
         if isinstance(self.project, GithubProject) and (
@@ -134,7 +134,7 @@ class AbstractCoprBuildReportHandler(
 ):
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker], ...]:
-        return (CoprBuildPermission,)
+        return (AreOwnerAndProjectMatchingJob,)
 
 
 @configured_as(job_type=JobType.copr_build)

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -52,6 +52,7 @@ from packit_service.utils import (
     get_timezone_aware_datetime,
 )
 from packit_service.worker.handlers.mixin import (
+    GetCoprBuildEventMixin,
     GetCoprBuildJobHelperForIdMixin,
     GetCoprBuildJobHelperMixin,
 )
@@ -128,7 +129,9 @@ class CoprBuildHandler(RetriableJobHandler, GetCoprBuildJobHelperMixin):
         return self.copr_build_helper.run_copr_build()
 
 
-class AbstractCoprBuildReportHandler(JobHandler, GetCoprBuildJobHelperForIdMixin):
+class AbstractCoprBuildReportHandler(
+    JobHandler, GetCoprBuildJobHelperForIdMixin, GetCoprBuildEventMixin
+):
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker], ...]:
         return (CoprBuildPermission,)

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -94,7 +94,7 @@ class CoprBuildHandler(RetriableJobHandler, GetCoprBuildJobHelperMixin):
         package_config: PackageConfig,
         job_config: JobConfig,
         event: dict,
-        celery_task: Optional[Task] = None,
+        celery_task: Task,
     ):
         super().__init__(
             package_config=package_config,

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -3,7 +3,7 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, Tuple
 
 from celery import signature, Task
 from ogr.services.github import GithubProject
@@ -19,24 +19,24 @@ from packit_service.constants import (
     COPR_API_SUCC_STATE,
     COPR_SRPM_CHROOT,
     DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,
-    INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED,
 )
 from packit_service.models import (
-    AbstractTriggerDbType,
     CoprBuildTargetModel,
     GithubInstallationModel,
-    SRPMBuildModel,
     BuildStatus,
+)
+from packit_service.worker.checker.copr import (
+    CanActorRunJob,
+    CoprBuildPermission,
+    Permission,
 )
 from packit_service.worker.events import (
     CoprBuildEndEvent,
-    AbstractCoprBuildEvent,
     CoprBuildStartEvent,
     MergeRequestGitlabEvent,
     PullRequestGithubEvent,
     PushGitHubEvent,
     PushGitlabEvent,
-    PushPagureEvent,
     ReleaseEvent,
     CheckRerunCommitEvent,
     CheckRerunPullRequestEvent,
@@ -50,8 +50,10 @@ from packit_service.utils import (
     is_timezone_naive_datetime,
     get_timezone_aware_datetime,
 )
-from packit_service.worker.events.enums import GitlabEventAction
-from packit_service.worker.helpers.build import CoprBuildJobHelper
+from packit_service.worker.handlers.mixin import (
+    GetCoprBuildJobHelperForIdMixin,
+    GetCoprBuildJobHelperMixin,
+)
 from packit_service.worker.handlers.abstract import (
     JobHandler,
     TaskName,
@@ -84,7 +86,7 @@ logger = logging.getLogger(__name__)
 @reacts_to(CheckRerunPullRequestEvent)
 @reacts_to(CheckRerunCommitEvent)
 @reacts_to(CheckRerunReleaseEvent)
-class CoprBuildHandler(RetriableJobHandler):
+class CoprBuildHandler(RetriableJobHandler, GetCoprBuildJobHelperMixin):
     task_name = TaskName.copr_build
 
     def __init__(
@@ -100,46 +102,10 @@ class CoprBuildHandler(RetriableJobHandler):
             event=event,
             celery_task=celery_task,
         )
-        self._copr_build_helper: Optional[CoprBuildJobHelper] = None
 
-    @property
-    def copr_build_helper(self) -> CoprBuildJobHelper:
-        if not self._copr_build_helper:
-            self._copr_build_helper = CoprBuildJobHelper(
-                service_config=self.service_config,
-                package_config=self.package_config,
-                project=self.project,
-                metadata=self.data,
-                db_trigger=self.data.db_trigger,
-                job_config=self.job_config,
-                build_targets_override=self.data.build_targets_override,
-                tests_targets_override=self.data.tests_targets_override,
-                pushgateway=self.pushgateway,
-                celery_task=self.celery_task,
-            )
-        return self._copr_build_helper
-
-    def check_if_actor_can_run_job_and_report(self, actor: str) -> bool:
-        """
-        The job is not allowed for external contributors when using internal TF.
-        """
-        test_job = self.copr_build_helper.job_tests
-        if (
-            test_job
-            and test_job.use_internal_tf
-            and not self.project.can_merge_pr(actor)
-        ):
-            self.copr_build_helper.report_status_to_build(
-                description=INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED[0].format(
-                    actor=actor
-                ),
-                state=BaseCommitStatus.neutral,
-                markdown_content=INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED[1].format(
-                    packit_comment_command_prefix=self.service_config.comment_command_prefix
-                ),
-            )
-            return False
-        return True
+    @staticmethod
+    def get_checkers() -> Tuple:
+        return (Permission, CanActorRunJob)
 
     def get_packit_github_installation_time(self) -> Optional[datetime]:
         if isinstance(self.project, GithubProject) and (
@@ -160,117 +126,11 @@ class CoprBuildHandler(RetriableJobHandler):
             return self.copr_build_helper.run_copr_build_from_source_script()
         return self.copr_build_helper.run_copr_build()
 
-    def pre_check(self) -> bool:
-        if (
-            self.data.event_type == MergeRequestGitlabEvent.__name__
-            and self.data.event_dict["action"] == GitlabEventAction.closed.value
-        ):
-            # Not interested in closed merge requests
-            return False
 
-        if self.data.event_type in (
-            PushGitHubEvent.__name__,
-            PushGitlabEvent.__name__,
-            PushPagureEvent.__name__,
-        ):
-            configured_branch = self.copr_build_helper.job_build_branch
-            if self.data.git_ref != configured_branch:
-                logger.info(
-                    f"Skipping build on '{self.data.git_ref}'. "
-                    f"Push configured only for '{configured_branch}'."
-                )
-                return False
-
-        if not (self.copr_build_helper.job_build or self.copr_build_helper.job_tests):
-            logger.info("No copr_build or tests job defined.")
-            # we can't report it to end-user at this stage
-            return False
-
-        if self.copr_build_helper.is_custom_copr_project_defined():
-            logger.debug(
-                "Custom Copr owner/project set. "
-                "Checking if this GitHub project can use this Copr project."
-            )
-            if not self.copr_build_helper.check_if_custom_copr_can_be_used_and_report():
-                return False
-
-        return True
-
-
-class AbstractCoprBuildReportHandler(JobHandler):
-    def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        event: dict,
-    ):
-        super().__init__(
-            package_config=package_config,
-            job_config=job_config,
-            event=event,
-        )
-        self.copr_event = AbstractCoprBuildEvent.from_event_dict(event)
-        self._build = None
-        self._db_trigger = None
-        self._copr_build_helper: Optional[CoprBuildJobHelper] = None
-
-    def pre_check(self) -> bool:
-        if (
-            self.copr_event.owner == self.copr_build_helper.job_owner
-            and self.copr_event.project_name == self.copr_build_helper.job_project
-        ):
-            return True
-
-        logger.debug(
-            f"The Copr project {self.copr_event.owner}/{self.copr_event.project_name} "
-            f"does not match the configuration "
-            f"({self.copr_build_helper.job_owner}/{self.copr_build_helper.job_project} expected)."
-        )
-        return False
-
-    @property
-    def copr_build_helper(self) -> CoprBuildJobHelper:
-        # when reporting state of SRPM build built in Copr
-        build_targets_override = (
-            {
-                build.target
-                for build in CoprBuildTargetModel.get_all_by_build_id(
-                    str(self.copr_event.build_id)
-                )
-            }
-            if self.copr_event.chroot == COPR_SRPM_CHROOT
-            else None
-        )
-        if not self._copr_build_helper:
-            self._copr_build_helper = CoprBuildJobHelper(
-                service_config=self.service_config,
-                package_config=self.package_config,
-                project=self.project,
-                metadata=self.data,
-                db_trigger=self.db_trigger,
-                job_config=self.job_config,
-                pushgateway=self.pushgateway,
-                build_targets_override=build_targets_override,
-            )
-        return self._copr_build_helper
-
-    @property
-    def build(self):
-        if not self._build:
-            build_id = str(self.copr_event.build_id)
-            if self.copr_event.chroot == COPR_SRPM_CHROOT:
-                self._build = SRPMBuildModel.get_by_copr_build_id(build_id)
-            else:
-                self._build = CoprBuildTargetModel.get_by_build_id(
-                    build_id, self.copr_event.chroot
-                )
-        return self._build
-
-    @property
-    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
-        if not self._db_trigger:
-            self._db_trigger = self.build.get_trigger_object()
-        return self._db_trigger
+class AbstractCoprBuildReportHandler(JobHandler, GetCoprBuildJobHelperForIdMixin):
+    @staticmethod
+    def get_checkers() -> Tuple:
+        return (CoprBuildPermission,)
 
 
 @configured_as(job_type=JobType.copr_build)

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -30,7 +30,7 @@ from packit_service.models import (
 from packit_service.service.urls import get_propose_downstream_info_url
 from packit_service.utils import gather_packit_logs_to_buffer, collect_packit_logs
 from packit_service.worker.checker.abstract import Checker
-from packit_service.worker.checker.distgit import IsProjectOk, Permission
+from packit_service.worker.checker.distgit import IsProjectOk, PermissionOnDistgit
 from packit_service.worker.events import (
     PushPagureEvent,
     ReleaseEvent,
@@ -381,7 +381,7 @@ class DownstreamKojiBuildHandler(
 
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker]]:
-        return (Permission,)
+        return (PermissionOnDistgit,)
 
     def run(self) -> TaskResults:
         branch = (

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -126,8 +126,8 @@ class ProposeDownstreamHandler(
         package_config: PackageConfig,
         job_config: JobConfig,
         event: dict,
+        celery_task: Task,
         propose_downstream_run_id: Optional[int] = None,
-        celery_task: Task = None,
     ):
         super().__init__(
             package_config=package_config,
@@ -367,7 +367,7 @@ class DownstreamKojiBuildHandler(
         package_config: PackageConfig,
         job_config: JobConfig,
         event: dict,
-        celery_task: Optional[Task] = None,
+        celery_task: Task,
     ):
         super().__init__(
             package_config=package_config,

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -83,7 +83,7 @@ class SyncFromDownstream(
         )
 
     @staticmethod
-    def get_checkers() -> Tuple:
+    def get_checkers() -> Tuple[Type[Checker], ...]:
         return (IsProjectOk,)
 
     @property
@@ -380,7 +380,7 @@ class DownstreamKojiBuildHandler(
         self._packit_api = None
 
     @staticmethod
-    def get_checkers() -> Tuple[Type[Checker]]:
+    def get_checkers() -> Tuple[Type[Checker], ...]:
         return (PermissionOnDistgit,)
 
     def run(self) -> TaskResults:

--- a/packit_service/worker/handlers/forges.py
+++ b/packit_service/worker/handlers/forges.py
@@ -6,7 +6,7 @@ This file defines classes for job handlers specific for Github hooks
 TODO: The build and test handlers are independent and should be moved away.
 """
 import logging
-from typing import Tuple
+from typing import Tuple, Type
 
 from packit.config import (
     JobConfig,
@@ -19,6 +19,7 @@ from packit_service.models import (
 )
 from packit_service.utils import get_packit_commands_from_comment
 from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.checker.abstract import Checker
 from packit_service.worker.checker.forges import PermissionOnForge
 from packit_service.worker.events import (
     InstallationEvent,
@@ -142,7 +143,7 @@ class GithubFasVerificationHandler(JobHandler, GetIssueMixin):
         self.comment = self.data.event_dict.get("comment")
 
     @staticmethod
-    def get_checkers() -> Tuple:
+    def get_checkers() -> Tuple[Type[Checker], ...]:
         return (PermissionOnForge,)
 
     def run(self) -> TaskResults:

--- a/packit_service/worker/handlers/forges.py
+++ b/packit_service/worker/handlers/forges.py
@@ -19,7 +19,7 @@ from packit_service.models import (
 )
 from packit_service.utils import get_packit_commands_from_comment
 from packit_service.worker.allowlist import Allowlist
-from packit_service.worker.checker.forges import Permission
+from packit_service.worker.checker.forges import PermissionOnForge
 from packit_service.worker.events import (
     InstallationEvent,
     IssueCommentEvent,
@@ -143,7 +143,7 @@ class GithubFasVerificationHandler(JobHandler, GetIssueMixin):
 
     @staticmethod
     def get_checkers() -> Tuple:
-        return (Permission,)
+        return (PermissionOnForge,)
 
     def run(self) -> TaskResults:
         """

--- a/packit_service/worker/handlers/forges.py
+++ b/packit_service/worker/handlers/forges.py
@@ -20,7 +20,7 @@ from packit_service.models import (
 from packit_service.utils import get_packit_commands_from_comment
 from packit_service.worker.allowlist import Allowlist
 from packit_service.worker.checker.abstract import Checker
-from packit_service.worker.checker.forges import PermissionOnForge
+from packit_service.worker.checker.forges import IsIssueInNotificationRepoChecker
 from packit_service.worker.events import (
     InstallationEvent,
     IssueCommentEvent,
@@ -144,7 +144,7 @@ class GithubFasVerificationHandler(JobHandler, GetIssueMixin):
 
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker], ...]:
-        return (PermissionOnForge,)
+        return (IsIssueInNotificationRepoChecker,)
 
     def run(self) -> TaskResults:
         """

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -89,7 +89,7 @@ class KojiBuildHandler(JobHandler, GetKojiBuildJobHelperMixin):
         self._project: Optional[GitProject] = None
 
     @staticmethod
-    def get_checkers() -> Tuple[Type[Checker]]:
+    def get_checkers() -> Tuple[Type[Checker], ...]:
         return (PermissionOnKoji,)
 
     def run(self) -> TaskResults:

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -48,7 +48,7 @@ from packit_service.worker.handlers.abstract import (
 )
 from packit_service.worker.reporting import BaseCommitStatus
 from packit_service.worker.result import TaskResults
-from packit_service.worker.checker import koji
+from packit_service.worker.checker.koji import PermissionOnKoji
 from packit_service.worker.handlers.mixin import GetKojiBuildJobHelperMixin
 
 logger = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ class KojiBuildHandler(JobHandler, GetKojiBuildJobHelperMixin):
 
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker]]:
-        return (koji.Permission,)
+        return (PermissionOnKoji,)
 
     def run(self) -> TaskResults:
         return self.koji_build_helper.run_koji_build()

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -7,7 +7,7 @@ This file defines classes for job handlers specific for Fedmsg events
 
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Tuple, Type
 
 from ogr.abstract import GitProject
 from packit.config import (
@@ -16,16 +16,14 @@ from packit.config import (
 )
 from packit.config.package_config import PackageConfig
 from packit_service.constants import (
-    KOJI_PRODUCTION_BUILDS_ISSUE,
     KojiBuildState,
-    PERMISSIONS_ERROR_WRITE_OR_ADMIN,
 )
 from packit_service.constants import KojiTaskState
 from packit_service.models import AbstractTriggerDbType, KojiBuildTargetModel
 from packit_service.service.urls import (
     get_koji_build_info_url,
 )
-from packit_service.worker.events.enums import GitlabEventAction
+from packit_service.worker.checker.abstract import Checker
 from packit_service.worker.helpers.build.koji_build import KojiBuildJobHelper
 from packit_service.worker.events import (
     CheckRerunCommitEvent,
@@ -36,7 +34,6 @@ from packit_service.worker.events import (
     PullRequestGithubEvent,
     PushGitHubEvent,
     PushGitlabEvent,
-    PushPagureEvent,
     ReleaseEvent,
     AbstractPRCommentEvent,
 )
@@ -51,6 +48,8 @@ from packit_service.worker.handlers.abstract import (
 )
 from packit_service.worker.reporting import BaseCommitStatus
 from packit_service.worker.result import TaskResults
+from packit_service.worker.checker import koji
+from packit_service.worker.handlers.mixin import GetKojiBuildJobHelperMixin
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +69,7 @@ logger = logging.getLogger(__name__)
 @reacts_to(CheckRerunPullRequestEvent)
 @reacts_to(CheckRerunCommitEvent)
 @reacts_to(CheckRerunReleaseEvent)
-class KojiBuildHandler(JobHandler):
+class KojiBuildHandler(JobHandler, GetKojiBuildJobHelperMixin):
     task_name = TaskName.upstream_koji_build
 
     def __init__(
@@ -89,64 +88,12 @@ class KojiBuildHandler(JobHandler):
         self._koji_build_helper: Optional[KojiBuildJobHelper] = None
         self._project: Optional[GitProject] = None
 
-    @property
-    def koji_build_helper(self) -> KojiBuildJobHelper:
-        if not self._koji_build_helper:
-            self._koji_build_helper = KojiBuildJobHelper(
-                service_config=self.service_config,
-                package_config=self.package_config,
-                project=self.project,
-                metadata=self.data,
-                db_trigger=self.data.db_trigger,
-                job_config=self.job_config,
-                build_targets_override=self.data.build_targets_override,
-                tests_targets_override=self.data.tests_targets_override,
-            )
-        return self._koji_build_helper
+    @staticmethod
+    def get_checkers() -> Tuple[Type[Checker]]:
+        return (koji.Permission,)
 
     def run(self) -> TaskResults:
         return self.koji_build_helper.run_koji_build()
-
-    def pre_check(self) -> bool:
-        if (
-            self.data.event_type == MergeRequestGitlabEvent.__name__
-            and self.data.event_dict["action"] == GitlabEventAction.closed.value
-        ):
-            # Not interested in closed merge requests
-            return False
-
-        if self.data.event_type in (
-            PushGitHubEvent.__name__,
-            PushGitlabEvent.__name__,
-            PushPagureEvent.__name__,
-        ):
-            configured_branch = self.koji_build_helper.job_build_branch
-            if self.data.git_ref != configured_branch:
-                logger.info(
-                    f"Skipping build on '{self.data.git_ref}'. "
-                    f"Push configured only for '{configured_branch}'."
-                )
-                return False
-
-        if self.data.event_type == PullRequestGithubEvent.__name__:
-            user_can_merge_pr = self.project.can_merge_pr(self.data.actor)
-            if not (user_can_merge_pr or self.data.actor in self.service_config.admins):
-                self.koji_build_helper.report_status_to_all(
-                    description=PERMISSIONS_ERROR_WRITE_OR_ADMIN,
-                    state=BaseCommitStatus.neutral,
-                )
-                return False
-
-        if not self.koji_build_helper.is_scratch:
-            msg = "Non-scratch builds not possible from upstream."
-            self.koji_build_helper.report_status_to_all(
-                description=msg,
-                state=BaseCommitStatus.neutral,
-                url=KOJI_PRODUCTION_BUILDS_ISSUE,
-            )
-            return False
-
-        return True
 
 
 @configured_as(job_type=JobType.production_build)

--- a/packit_service/worker/handlers/mixin.py
+++ b/packit_service/worker/handlers/mixin.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 class GetKojiBuildEvent(Protocol):
-    _koji_build_event: Optional[KojiBuildEvent] = None
+    data: EventData
 
     @property
     def koji_build_event(self) -> KojiBuildEvent:
@@ -39,7 +39,7 @@ class GetKojiBuildEvent(Protocol):
 
 
 class GetKojiBuildEventMixin(ConfigMixin, GetKojiBuildEvent):
-    data: EventData
+    _koji_build_event: Optional[KojiBuildEvent] = None
 
     @property
     def koji_build_event(self):
@@ -51,14 +51,13 @@ class GetKojiBuildEventMixin(ConfigMixin, GetKojiBuildEvent):
 
 
 class GetKojiBuildJobHelper(Protocol):
-    _koji_build_helper: Optional[KojiBuildJobHelper] = None
-
     @property
     def koji_build_helper(self) -> KojiBuildJobHelper:
         ...
 
 
 class GetKojiBuildJobHelperMixin(GetKojiBuildJobHelper, ConfigMixin):
+    _koji_build_helper: Optional[KojiBuildJobHelper] = None
     package_config: PackageConfig
     job_config: JobConfig
 
@@ -79,7 +78,7 @@ class GetKojiBuildJobHelperMixin(GetKojiBuildJobHelper, ConfigMixin):
 
 
 class GetCoprBuildEvent(Protocol):
-    _copr_build_event: Optional[KojiBuildEvent] = None
+    data: EventData
 
     @property
     def copr_build_event(self) -> KojiBuildEvent:
@@ -87,7 +86,7 @@ class GetCoprBuildEvent(Protocol):
 
 
 class GetCoprBuildEventMixin(ConfigMixin, GetCoprBuildEvent):
-    data: EventData
+    _copr_build_event: Optional[KojiBuildEvent] = None
 
     @property
     def copr_event(self):
@@ -99,9 +98,6 @@ class GetCoprBuildEventMixin(ConfigMixin, GetCoprBuildEvent):
 
 
 class GetSRPMBuild(Protocol):
-    _build: Optional[SRPMBuildModel] = None
-    _db_trigger: Optional[AbstractTriggerDbType] = None
-
     @property
     def build(self) -> Optional[SRPMBuildModel]:
         ...
@@ -112,6 +108,9 @@ class GetSRPMBuild(Protocol):
 
 
 class GetCoprSRPMBuildMixin(GetSRPMBuild, GetCoprBuildEventMixin):
+    _build: Optional[SRPMBuildModel] = None
+    _db_trigger: Optional[AbstractTriggerDbType] = None
+
     @property
     def build(self):
         if not self._build:
@@ -132,8 +131,7 @@ class GetCoprSRPMBuildMixin(GetSRPMBuild, GetCoprBuildEventMixin):
 
 
 class GetCoprBuild(Protocol):
-    _build: Optional[CoprBuildTargetModel] = None
-    _db_trigger: Optional[AbstractTriggerDbType] = None
+    build_id: Optional[int] = None
 
     @property
     def build(self) -> Optional[CoprBuildTargetModel]:
@@ -145,7 +143,8 @@ class GetCoprBuild(Protocol):
 
 
 class GetCoprBuildMixin(GetCoprBuild, ConfigMixin):
-    build_id: Optional[int] = None
+    _build: Optional[CoprBuildTargetModel] = None
+    _db_trigger: Optional[AbstractTriggerDbType] = None
 
     @property
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
@@ -161,7 +160,10 @@ class GetCoprBuildMixin(GetCoprBuild, ConfigMixin):
 
 
 class GetCoprBuildJobHelper(Protocol):
-    _copr_build_helper: Optional[CoprBuildJobHelper] = None
+    package_config: PackageConfig
+    job_config: JobConfig
+    celery_task: Optional[CeleryTask] = None
+    pushgateway: Optional[Pushgateway] = None
 
     @property
     def copr_build_helper(self) -> CoprBuildJobHelper:
@@ -169,10 +171,7 @@ class GetCoprBuildJobHelper(Protocol):
 
 
 class GetCoprBuildJobHelperMixin(GetCoprBuildJobHelper, ConfigMixin):
-    package_config: PackageConfig
-    job_config: JobConfig
-    celery_task: Optional[CeleryTask] = None
-    pushgateway: Optional[Pushgateway] = None
+    _copr_build_helper: Optional[CoprBuildJobHelper] = None
 
     @property
     def copr_build_helper(self) -> CoprBuildJobHelper:
@@ -195,10 +194,7 @@ class GetCoprBuildJobHelperMixin(GetCoprBuildJobHelper, ConfigMixin):
 class GetCoprBuildJobHelperForIdMixin(
     GetCoprBuildJobHelper, GetCoprSRPMBuildMixin, ConfigMixin
 ):
-    package_config: PackageConfig
-    job_config: JobConfig
-    celery_task: Optional[CeleryTask] = None
-    pushgateway: Optional[Pushgateway] = None
+    _copr_build_helper: Optional[CoprBuildJobHelper] = None
 
     @property
     def copr_build_helper(self) -> CoprBuildJobHelper:
@@ -228,7 +224,9 @@ class GetCoprBuildJobHelperForIdMixin(
 
 
 class GetTestingFarmJobHelper(Protocol):
-    _testing_farm_job_helper: Optional[TestingFarmJobHelper] = None
+    package_config: PackageConfig
+    job_config: JobConfig
+    celery_task: Optional[CeleryTask] = None
 
     @property
     def copr_build_helper(self) -> TestingFarmJobHelper:
@@ -238,9 +236,7 @@ class GetTestingFarmJobHelper(Protocol):
 class GetTestingFarmJobHelperMixin(
     GetTestingFarmJobHelper, GetCoprBuildMixin, ConfigMixin
 ):
-    package_config: PackageConfig
-    job_config: JobConfig
-    celery_task: Optional[CeleryTask] = None
+    _testing_farm_job_helper: Optional[TestingFarmJobHelper] = None
 
     @property
     def testing_farm_job_helper(self) -> TestingFarmJobHelper:
@@ -283,8 +279,6 @@ class GetGithubCommentEventMixin(GetGithubCommentEvent, ConfigMixin):
 
 
 class GetProjectToSync(Protocol):
-    _project_to_sync: Optional[ProjectToSync] = None
-
     @property
     def dg_repo_name(self) -> str:
         ...
@@ -299,6 +293,8 @@ class GetProjectToSync(Protocol):
 
 
 class GetProjectToSyncMixin(ConfigMixin, GetProjectToSync):
+    _project_to_sync: Optional[ProjectToSync] = None
+
     @property
     def dg_repo_name(self) -> str:
         return self.data.event_dict.get("repo_name")

--- a/packit_service/worker/handlers/mixin.py
+++ b/packit_service/worker/handlers/mixin.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 import logging
 from typing import Optional, Protocol
 from packit.config import PackageConfig, JobConfig
@@ -34,7 +34,8 @@ logger = logging.getLogger(__name__)
 class GetKojiBuildEvent(Protocol):
     data: EventData
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def koji_build_event(self) -> KojiBuildEvent:
         ...
 
@@ -52,7 +53,8 @@ class GetKojiBuildEventMixin(ConfigMixin, GetKojiBuildEvent):
 
 
 class GetKojiBuildJobHelper(Protocol):
-    @abstractproperty
+    @property
+    @abstractmethod
     def koji_build_helper(self) -> KojiBuildJobHelper:
         ...
 
@@ -81,7 +83,8 @@ class GetKojiBuildJobHelperMixin(GetKojiBuildJobHelper, ConfigMixin):
 class GetCoprBuildEvent(Protocol):
     data: EventData
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def copr_event(self) -> KojiBuildEvent:
         ...
 
@@ -99,11 +102,13 @@ class GetCoprBuildEventMixin(ConfigMixin, GetCoprBuildEvent):
 
 
 class GetSRPMBuild(Protocol):
-    @abstractproperty
+    @property
+    @abstractmethod
     def build(self) -> Optional[SRPMBuildModel]:
         ...
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
         ...
 
@@ -134,7 +139,8 @@ class GetCoprSRPMBuildMixin(GetSRPMBuild, GetCoprBuildEventMixin):
 class GetCoprBuild(Protocol):
     build_id: Optional[int] = None
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
         ...
 
@@ -162,7 +168,8 @@ class GetCoprBuildJobHelper(Protocol):
     celery_task: Optional[CeleryTask] = None
     pushgateway: Optional[Pushgateway] = None
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def copr_build_helper(self) -> CoprBuildJobHelper:
         ...
 
@@ -225,7 +232,8 @@ class GetTestingFarmJobHelper(Protocol):
     job_config: JobConfig
     celery_task: Optional[CeleryTask] = None
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def testing_farm_job_helper(self) -> TestingFarmJobHelper:
         ...
 
@@ -278,15 +286,18 @@ class GetGithubCommentEventMixin(GetGithubCommentEvent, ConfigMixin):
 
 
 class GetProjectToSync(Protocol):
-    @abstractproperty
+    @property
+    @abstractmethod
     def dg_repo_name(self) -> str:
         ...
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def dg_branch(self) -> str:
         ...
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def project_to_sync(self) -> Optional[ProjectToSync]:
         ...
 

--- a/packit_service/worker/handlers/mixin.py
+++ b/packit_service/worker/handlers/mixin.py
@@ -1,0 +1,317 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+from typing import Optional, Protocol
+from packit.config import PackageConfig, JobConfig
+from packit_service.utils import get_packit_commands_from_comment
+from packit_service.config import ProjectToSync
+from packit_service.constants import COPR_SRPM_CHROOT
+from packit_service.models import (
+    AbstractTriggerDbType,
+    CoprBuildTargetModel,
+    SRPMBuildModel,
+)
+from packit_service.worker.events.event import EventData
+from packit_service.worker.events.copr import AbstractCoprBuildEvent
+from packit_service.worker.events.github import PullRequestCommentGithubEvent
+from packit_service.worker.events.gitlab import MergeRequestCommentGitlabEvent
+from packit_service.worker.events.pagure import PullRequestCommentPagureEvent
+from packit_service.worker.handlers.abstract import CeleryTask
+from packit_service.worker.helpers.build.copr_build import CoprBuildJobHelper
+from packit_service.worker.helpers.build.koji_build import KojiBuildJobHelper
+from packit_service.worker.helpers.testing_farm import TestingFarmJobHelper
+
+from packit_service.worker.mixin import ConfigMixin
+from packit_service.worker.events.koji import KojiBuildEvent
+from packit_service.worker.monitoring import Pushgateway
+
+
+logger = logging.getLogger(__name__)
+
+
+class GetKojiBuildEvent(Protocol):
+    _koji_build_event: Optional[KojiBuildEvent] = None
+
+    @property
+    def koji_build_event(self) -> KojiBuildEvent:
+        ...
+
+
+class GetKojiBuildEventMixin(ConfigMixin, GetKojiBuildEvent):
+    data: EventData
+
+    @property
+    def koji_build_event(self):
+        if not self._koji_build_event:
+            self._koji_build_event = KojiBuildEvent.from_event_dict(
+                self.data.event_dict
+            )
+        return self._koji_build_event
+
+
+class GetKojiBuildJobHelper(Protocol):
+    _koji_build_helper: Optional[KojiBuildJobHelper] = None
+
+    @property
+    def koji_build_helper(self) -> KojiBuildJobHelper:
+        ...
+
+
+class GetKojiBuildJobHelperMixin(GetKojiBuildJobHelper, ConfigMixin):
+    package_config: PackageConfig
+    job_config: JobConfig
+
+    @property
+    def koji_build_helper(self) -> KojiBuildJobHelper:
+        if not self._koji_build_helper:
+            self._koji_build_helper = KojiBuildJobHelper(
+                service_config=self.service_config,
+                package_config=self.package_config,
+                project=self.project,
+                metadata=self.data,
+                db_trigger=self.data.db_trigger,
+                job_config=self.job_config,
+                build_targets_override=self.data.build_targets_override,
+                tests_targets_override=self.data.tests_targets_override,
+            )
+        return self._koji_build_helper
+
+
+class GetCoprBuildEvent(Protocol):
+    _copr_build_event: Optional[KojiBuildEvent] = None
+
+    @property
+    def copr_build_event(self) -> KojiBuildEvent:
+        ...
+
+
+class GetCoprBuildEventMixin(ConfigMixin, GetCoprBuildEvent):
+    data: EventData
+
+    @property
+    def copr_event(self):
+        if not self._copr_build_event:
+            self._copr_build_event = AbstractCoprBuildEvent.from_event_dict(
+                self.data.event_dict
+            )
+        return self._copr_build_event
+
+
+class GetSRPMBuild(Protocol):
+    _build: Optional[SRPMBuildModel] = None
+    _db_trigger: Optional[AbstractTriggerDbType] = None
+
+    @property
+    def build(self) -> Optional[SRPMBuildModel]:
+        ...
+
+    @property
+    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
+        ...
+
+
+class GetCoprSRPMBuildMixin(GetSRPMBuild, GetCoprBuildEventMixin):
+    @property
+    def build(self):
+        if not self._build:
+            build_id = str(self.copr_event.build_id)
+            if self.copr_event.chroot == COPR_SRPM_CHROOT:
+                self._build = SRPMBuildModel.get_by_copr_build_id(build_id)
+            else:
+                self._build = CoprBuildTargetModel.get_by_build_id(
+                    build_id, self.copr_event.chroot
+                )
+        return self._build
+
+    @property
+    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
+        if not self._db_trigger:
+            self._db_trigger = self.build.get_trigger_object()
+        return self._db_trigger
+
+
+class GetCoprBuild(Protocol):
+    _build: Optional[CoprBuildTargetModel] = None
+    _db_trigger: Optional[AbstractTriggerDbType] = None
+
+    @property
+    def build(self) -> Optional[CoprBuildTargetModel]:
+        ...
+
+    @property
+    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
+        ...
+
+
+class GetCoprBuildMixin(GetCoprBuild, ConfigMixin):
+    build_id: Optional[int] = None
+
+    @property
+    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
+        if not self._db_trigger:
+            # copr build end
+            if self.build_id:
+                build = CoprBuildTargetModel.get_by_id(self.build_id)
+                self._db_trigger = build.get_trigger_object()
+            # other events
+            else:
+                self._db_trigger = self.data.db_trigger
+        return self._db_trigger
+
+
+class GetCoprBuildJobHelper(Protocol):
+    _copr_build_helper: Optional[CoprBuildJobHelper] = None
+
+    @property
+    def copr_build_helper(self) -> CoprBuildJobHelper:
+        ...
+
+
+class GetCoprBuildJobHelperMixin(GetCoprBuildJobHelper, ConfigMixin):
+    package_config: PackageConfig
+    job_config: JobConfig
+    celery_task: Optional[CeleryTask] = None
+    pushgateway: Optional[Pushgateway] = None
+
+    @property
+    def copr_build_helper(self) -> CoprBuildJobHelper:
+        if not self._copr_build_helper:
+            self._copr_build_helper = CoprBuildJobHelper(
+                service_config=self.service_config,
+                package_config=self.package_config,
+                project=self.project,
+                metadata=self.data,
+                db_trigger=self.data.db_trigger,
+                job_config=self.job_config,
+                build_targets_override=self.data.build_targets_override,
+                tests_targets_override=self.data.tests_targets_override,
+                pushgateway=self.pushgateway,
+                celery_task=self.celery_task,
+            )
+        return self._copr_build_helper
+
+
+class GetCoprBuildJobHelperForIdMixin(
+    GetCoprBuildJobHelper, GetCoprSRPMBuildMixin, ConfigMixin
+):
+    package_config: PackageConfig
+    job_config: JobConfig
+    celery_task: Optional[CeleryTask] = None
+    pushgateway: Optional[Pushgateway] = None
+
+    @property
+    def copr_build_helper(self) -> CoprBuildJobHelper:
+        # when reporting state of SRPM build built in Copr
+        build_targets_override = (
+            {
+                build.target
+                for build in CoprBuildTargetModel.get_all_by_build_id(
+                    str(self.copr_event.build_id)
+                )
+            }
+            if self.copr_event.chroot == COPR_SRPM_CHROOT
+            else None
+        )
+        if not self._copr_build_helper:
+            self._copr_build_helper = CoprBuildJobHelper(
+                service_config=self.service_config,
+                package_config=self.package_config,
+                project=self.project,
+                metadata=self.data,
+                db_trigger=self.db_trigger,
+                job_config=self.job_config,
+                pushgateway=self.pushgateway,
+                build_targets_override=build_targets_override,
+            )
+        return self._copr_build_helper
+
+
+class GetTestingFarmJobHelper(Protocol):
+    _testing_farm_job_helper: Optional[TestingFarmJobHelper] = None
+
+    @property
+    def copr_build_helper(self) -> TestingFarmJobHelper:
+        ...
+
+
+class GetTestingFarmJobHelperMixin(
+    GetTestingFarmJobHelper, GetCoprBuildMixin, ConfigMixin
+):
+    package_config: PackageConfig
+    job_config: JobConfig
+    celery_task: Optional[CeleryTask] = None
+
+    @property
+    def testing_farm_job_helper(self) -> TestingFarmJobHelper:
+        if not self._testing_farm_job_helper:
+            self._testing_farm_job_helper = TestingFarmJobHelper(
+                service_config=self.service_config,
+                package_config=self.package_config,
+                project=self.project,
+                metadata=self.data,
+                db_trigger=self.db_trigger,
+                job_config=self.job_config,
+                build_targets_override=self.data.build_targets_override,
+                tests_targets_override=self.data.tests_targets_override,
+                celery_task=self.celery_task,
+            )
+        return self._testing_farm_job_helper
+
+
+class GetGithubCommentEvent(Protocol):
+    def is_comment_event(self) -> bool:
+        ...
+
+    def is_copr_build_comment_event(self) -> bool:
+        ...
+
+
+class GetGithubCommentEventMixin(GetGithubCommentEvent, ConfigMixin):
+    def is_comment_event(self) -> bool:
+        return self.data.event_type in (
+            PullRequestCommentGithubEvent.__name__,
+            MergeRequestCommentGitlabEvent.__name__,
+            PullRequestCommentPagureEvent.__name__,
+        )
+
+    def is_copr_build_comment_event(self) -> bool:
+        return self.is_comment_event() and get_packit_commands_from_comment(
+            self.data.event_dict.get("comment"),
+            packit_comment_command_prefix=self.service_config.comment_command_prefix,
+        )[0] in ("build", "copr-build")
+
+
+class GetProjectToSync(Protocol):
+    _project_to_sync: Optional[ProjectToSync] = None
+
+    @property
+    def dg_repo_name(self) -> str:
+        ...
+
+    @property
+    def dg_branch(self) -> str:
+        ...
+
+    @property
+    def project_to_sync(self) -> Optional[ProjectToSync]:
+        ...
+
+
+class GetProjectToSyncMixin(ConfigMixin, GetProjectToSync):
+    @property
+    def dg_repo_name(self) -> str:
+        return self.data.event_dict.get("repo_name")
+
+    @property
+    def dg_branch(self) -> str:
+        return self.data.event_dict.get("git_ref")
+
+    @property
+    def project_to_sync(self) -> Optional[ProjectToSync]:
+        if self._project_to_sync is None:
+            if project_to_sync := self.service_config.get_project_to_sync(
+                dg_repo_name=self.dg_repo_name, dg_branch=self.dg_branch
+            ):
+                self._project_to_sync = project_to_sync
+        return self._project_to_sync

--- a/packit_service/worker/handlers/mixin.py
+++ b/packit_service/worker/handlers/mixin.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+from abc import abstractmethod, abstractproperty
 import logging
 from typing import Optional, Protocol
 from packit.config import PackageConfig, JobConfig
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 class GetKojiBuildEvent(Protocol):
     data: EventData
 
-    @property
+    @abstractproperty
     def koji_build_event(self) -> KojiBuildEvent:
         ...
 
@@ -51,7 +52,7 @@ class GetKojiBuildEventMixin(ConfigMixin, GetKojiBuildEvent):
 
 
 class GetKojiBuildJobHelper(Protocol):
-    @property
+    @abstractproperty
     def koji_build_helper(self) -> KojiBuildJobHelper:
         ...
 
@@ -80,8 +81,8 @@ class GetKojiBuildJobHelperMixin(GetKojiBuildJobHelper, ConfigMixin):
 class GetCoprBuildEvent(Protocol):
     data: EventData
 
-    @property
-    def copr_build_event(self) -> KojiBuildEvent:
+    @abstractproperty
+    def copr_event(self) -> KojiBuildEvent:
         ...
 
 
@@ -98,11 +99,11 @@ class GetCoprBuildEventMixin(ConfigMixin, GetCoprBuildEvent):
 
 
 class GetSRPMBuild(Protocol):
-    @property
+    @abstractproperty
     def build(self) -> Optional[SRPMBuildModel]:
         ...
 
-    @property
+    @abstractproperty
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
         ...
 
@@ -133,11 +134,7 @@ class GetCoprSRPMBuildMixin(GetSRPMBuild, GetCoprBuildEventMixin):
 class GetCoprBuild(Protocol):
     build_id: Optional[int] = None
 
-    @property
-    def build(self) -> Optional[CoprBuildTargetModel]:
-        ...
-
-    @property
+    @abstractproperty
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
         ...
 
@@ -165,7 +162,7 @@ class GetCoprBuildJobHelper(Protocol):
     celery_task: Optional[CeleryTask] = None
     pushgateway: Optional[Pushgateway] = None
 
-    @property
+    @abstractproperty
     def copr_build_helper(self) -> CoprBuildJobHelper:
         ...
 
@@ -228,8 +225,8 @@ class GetTestingFarmJobHelper(Protocol):
     job_config: JobConfig
     celery_task: Optional[CeleryTask] = None
 
-    @property
-    def copr_build_helper(self) -> TestingFarmJobHelper:
+    @abstractproperty
+    def testing_farm_job_helper(self) -> TestingFarmJobHelper:
         ...
 
 
@@ -256,9 +253,11 @@ class GetTestingFarmJobHelperMixin(
 
 
 class GetGithubCommentEvent(Protocol):
+    @abstractmethod
     def is_comment_event(self) -> bool:
         ...
 
+    @abstractmethod
     def is_copr_build_comment_event(self) -> bool:
         ...
 
@@ -279,15 +278,15 @@ class GetGithubCommentEventMixin(GetGithubCommentEvent, ConfigMixin):
 
 
 class GetProjectToSync(Protocol):
-    @property
+    @abstractproperty
     def dg_repo_name(self) -> str:
         ...
 
-    @property
+    @abstractproperty
     def dg_branch(self) -> str:
         ...
 
-    @property
+    @abstractproperty
     def project_to_sync(self) -> Optional[ProjectToSync]:
         ...
 

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -6,17 +6,13 @@ This file defines classes for job handlers specific for Testing farm
 """
 import logging
 from datetime import datetime, timezone
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Tuple
 
 from celery import Task
 from celery import signature
 
 from packit.config import JobConfig, JobType
 from packit.config.package_config import PackageConfig
-from packit_service.constants import (
-    INTERNAL_TF_TESTS_NOT_ALLOWED,
-    INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED,
-)
 from packit_service.models import (
     AbstractTriggerDbType,
     TFTTestRunTargetModel,
@@ -30,6 +26,11 @@ from packit_service.service.urls import (
     get_copr_build_info_url,
 )
 from packit_service.utils import dump_job_config, dump_package_config
+from packit_service.worker.checker.testing_farm import (
+    CanActorRunJob,
+    IsEventForJob,
+    IsEventOk,
+)
 from packit_service.worker.events import (
     TestingFarmResultsEvent,
     CheckRerunCommitEvent,
@@ -40,7 +41,6 @@ from packit_service.worker.events import (
     MergeRequestGitlabEvent,
     AbstractPRCommentEvent,
 )
-from packit_service.worker.events.enums import GitlabEventAction
 from packit_service.worker.handlers import JobHandler
 from packit_service.worker.handlers.abstract import (
     TaskName,
@@ -54,6 +54,11 @@ from packit_service.worker.helpers.testing_farm import TestingFarmJobHelper
 from packit_service.worker.monitoring import measure_time
 from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 from packit_service.worker.result import TaskResults
+from packit_service.worker.handlers.mixin import (
+    GetCoprBuildMixin,
+    GetTestingFarmJobHelperMixin,
+)
+from packit_service.worker.handlers.mixin import GetGithubCommentEventMixin
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +76,12 @@ logger = logging.getLogger(__name__)
 @reacts_to(CheckRerunPullRequestEvent)
 @reacts_to(CheckRerunCommitEvent)
 @configured_as(job_type=JobType.tests)
-class TestingFarmHandler(RetriableJobHandler):
+class TestingFarmHandler(
+    RetriableJobHandler,
+    GetTestingFarmJobHelperMixin,
+    GetCoprBuildMixin,
+    GetGithubCommentEventMixin,
+):
     """
     The automatic matching is now used only for /packit test
     TODO: We can react directly to the finished Copr build.
@@ -94,72 +104,14 @@ class TestingFarmHandler(RetriableJobHandler):
             celery_task=celery_task,
         )
         self.build_id = build_id
-        self._db_trigger: Optional[AbstractTriggerDbType] = None
         self._testing_farm_job_helper: Optional[TestingFarmJobHelper] = None
 
-    def check_if_actor_can_run_job_and_report(self, actor: str) -> bool:
-        """
-        The job is not allowed for external contributors when using internal TF.
-        """
-        if self.job_config.use_internal_tf and not self.project.can_merge_pr(actor):
-            message = (
-                INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED
-                if self.testing_farm_job_helper.job_build
-                else INTERNAL_TF_TESTS_NOT_ALLOWED
-            )
-            self.testing_farm_job_helper.report_status_to_tests(
-                description=message[0].format(actor=actor),
-                state=BaseCommitStatus.neutral,
-                markdown_content=message[1].format(
-                    packit_comment_command_prefix=self.service_config.comment_command_prefix
-                ),
-            )
-            return False
-        return True
-
-    def pre_check(self) -> bool:
-        if (
-            self.data.event_type == MergeRequestGitlabEvent.__name__
-            and self.data.event_dict["action"] == GitlabEventAction.closed.value
-        ):
-            # Not interested in closed merge requests
-            return False
-
-        if self.testing_farm_job_helper.is_test_comment_pr_argument_present():
-            return self.testing_farm_job_helper.check_comment_pr_argument_and_report()
-
-        return not (
-            self.testing_farm_job_helper.skip_build
-            and self.testing_farm_job_helper.is_copr_build_comment_event()
+    @staticmethod
+    def get_checkers() -> Tuple:
+        return (
+            IsEventOk,
+            CanActorRunJob,
         )
-
-    @property
-    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
-        if not self._db_trigger:
-            # copr build end
-            if self.build_id:
-                build = CoprBuildTargetModel.get_by_id(self.build_id)
-                self._db_trigger = build.get_trigger_object()
-            # other events
-            else:
-                self._db_trigger = self.data.db_trigger
-        return self._db_trigger
-
-    @property
-    def testing_farm_job_helper(self) -> TestingFarmJobHelper:
-        if not self._testing_farm_job_helper:
-            self._testing_farm_job_helper = TestingFarmJobHelper(
-                service_config=self.service_config,
-                package_config=self.package_config,
-                project=self.project,
-                metadata=self.data,
-                db_trigger=self.db_trigger,
-                job_config=self.job_config,
-                build_targets_override=self.data.build_targets_override,
-                tests_targets_override=self.data.tests_targets_override,
-                celery_task=self.celery_task,
-            )
-        return self._testing_farm_job_helper
 
     def build_required(self) -> bool:
         return not self.testing_farm_job_helper.skip_build and (
@@ -339,6 +291,10 @@ class TestingFarmResultsHandler(JobHandler):
         self._db_trigger: Optional[AbstractTriggerDbType] = None
         self.created = event.get("created")
 
+    @staticmethod
+    def get_checkers() -> Tuple:
+        return (IsEventForJob,)
+
     @property
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
         if not self._db_trigger:
@@ -410,13 +366,3 @@ class TestingFarmResultsHandler(JobHandler):
         )
 
         return TaskResults(success=True, details={})
-
-    def pre_check(self) -> bool:
-        if self.data.identifier != self.job_config.identifier:
-            logger.debug(
-                f"Skipping reporting, identifiers don't match "
-                f"(identifier of the test job to report: {self.data.identifier}, "
-                f"identifier from job config: {self.job_config.identifier})."
-            )
-            return False
-        return True

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -94,8 +94,8 @@ class TestingFarmHandler(
         package_config: PackageConfig,
         job_config: JobConfig,
         event: dict,
+        celery_task: Task,
         build_id: Optional[int] = None,
-        celery_task: Optional[Task] = None,
     ):
         super().__init__(
             package_config=package_config,

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -6,7 +6,7 @@ This file defines classes for job handlers specific for Testing farm
 """
 import logging
 from datetime import datetime, timezone
-from typing import Optional, Dict, List, Tuple
+from typing import Optional, Dict, List, Tuple, Type
 
 from celery import Task
 from celery import signature
@@ -26,6 +26,7 @@ from packit_service.service.urls import (
     get_copr_build_info_url,
 )
 from packit_service.utils import dump_job_config, dump_package_config
+from packit_service.worker.checker.abstract import Checker
 from packit_service.worker.checker.testing_farm import (
     CanActorRunJob,
     IsEventForJob,
@@ -107,7 +108,7 @@ class TestingFarmHandler(
         self._testing_farm_job_helper: Optional[TestingFarmJobHelper] = None
 
     @staticmethod
-    def get_checkers() -> Tuple:
+    def get_checkers() -> Tuple[Type[Checker], ...]:
         return (
             IsEventOk,
             CanActorRunJob,
@@ -292,7 +293,7 @@ class TestingFarmResultsHandler(JobHandler):
         self.created = event.get("created")
 
     @staticmethod
-    def get_checkers() -> Tuple:
+    def get_checkers() -> Tuple[Type[Checker], ...]:
         return (IsEventForJob,)
 
     @property

--- a/packit_service/worker/helpers/build/babysit.py
+++ b/packit_service/worker/helpers/build/babysit.py
@@ -110,14 +110,15 @@ def check_pending_testing_farm_runs() -> None:
             handler_kls=TestingFarmResultsHandler,
         )
 
+        event_dict = event.get_dict()
         for job_config in job_configs:
             handler = TestingFarmResultsHandler(
                 package_config=event.package_config,
                 job_config=job_config,
-                event=event.get_dict(),
+                event=event_dict,
             )
             # check for identifiers equality
-            if handler.pre_check():
+            if handler.pre_check(package_config, job_config, event_dict):
                 handler.run()
 
 

--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -63,7 +63,7 @@ class ConfigMixin(Config):
         return self.data.project_url
 
 
-class PackitAPIProtocol(Protocol):
+class PackitAPIProtocol(Config):
     api: Optional[PackitAPI] = None
     local_project: Optional[LocalProject] = None
 

--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+from abc import abstractmethod, abstractproperty
 import logging
 from typing import Optional, Protocol
 
@@ -28,15 +29,15 @@ logger = logging.getLogger(__name__)
 class Config(Protocol):
     data: EventData
 
-    @property
+    @abstractproperty
     def project(self) -> Optional[GitProject]:
         ...
 
-    @property
+    @abstractproperty
     def service_config(self) -> Optional[ServiceConfig]:
         ...
 
-    @property
+    @abstractproperty
     def project_url(self) -> str:
         ...
 
@@ -67,7 +68,7 @@ class PackitAPIProtocol(Config):
     api: Optional[PackitAPI] = None
     local_project: Optional[LocalProject] = None
 
-    @property
+    @abstractproperty
     def packit_api(self) -> PackitAPI:
         ...
 
@@ -75,6 +76,7 @@ class PackitAPIProtocol(Config):
 class PackitAPIWithDownstreamProtocol(PackitAPIProtocol):
     _packit_api: Optional[PackitAPI] = None
 
+    @abstractmethod
     def is_packager(self, user) -> bool:
         """Check that the given FAS user
         is a packager
@@ -145,10 +147,11 @@ class LocalProjectMixin(ConfigMixin):
 
 
 class GetPagurePullRequest(Protocol):
-    @property
+    @abstractproperty
     def pull_request(self) -> PullRequest:
         ...
 
+    @abstractmethod
     def get_pr_author(self) -> Optional[str]:
         ...
 
@@ -178,7 +181,7 @@ class GetPagurePullRequestMixin(GetPagurePullRequest):
 
 
 class GetIssue(Protocol):
-    @property
+    @abstractproperty
     def issue(self) -> Issue:
         ...
 

--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 import logging
 from typing import Optional, Protocol
 
@@ -29,15 +29,18 @@ logger = logging.getLogger(__name__)
 class Config(Protocol):
     data: EventData
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def project(self) -> Optional[GitProject]:
         ...
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def service_config(self) -> Optional[ServiceConfig]:
         ...
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def project_url(self) -> str:
         ...
 
@@ -67,7 +70,8 @@ class ConfigMixin(Config):
 class PackitAPIProtocol(Config):
     local_project: Optional[LocalProject] = None
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def packit_api(self) -> PackitAPI:
         ...
 
@@ -160,7 +164,8 @@ class LocalProjectMixin(ConfigMixin):
 
 
 class GetPagurePullRequest(Protocol):
-    @abstractproperty
+    @property
+    @abstractmethod
     def pull_request(self) -> PullRequest:
         ...
 
@@ -194,7 +199,8 @@ class GetPagurePullRequestMixin(GetPagurePullRequest):
 
 
 class GetIssue(Protocol):
-    @abstractproperty
+    @property
+    @abstractmethod
     def issue(self) -> Issue:
         ...
 

--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -26,8 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class Config(Protocol):
-    _project: Optional[GitProject] = None
-    _service_config: Optional[ServiceConfig] = None
     data: EventData
 
     @property
@@ -44,6 +42,8 @@ class Config(Protocol):
 
 
 class ConfigMixin(Config):
+    _project: Optional[GitProject] = None
+    _service_config: Optional[ServiceConfig] = None
     data: EventData
 
     @property
@@ -65,7 +65,6 @@ class ConfigMixin(Config):
 
 class PackitAPIProtocol(Protocol):
     api: Optional[PackitAPI] = None
-    _packit_api: Optional[PackitAPI] = None
     local_project: Optional[LocalProject] = None
 
     @property
@@ -74,6 +73,8 @@ class PackitAPIProtocol(Protocol):
 
 
 class PackitAPIWithDownstreamProtocol(PackitAPIProtocol):
+    _packit_api: Optional[PackitAPI] = None
+
     def is_packager(self, user) -> bool:
         """Check that the given FAS user
         is a packager
@@ -87,6 +88,8 @@ class PackitAPIWithDownstreamProtocol(PackitAPIProtocol):
 
 
 class PackitAPIWithDownstreamMixin(PackitAPIWithDownstreamProtocol):
+    _packit_api: Optional[PackitAPI] = None
+
     @property
     def packit_api(self):
         if not self._packit_api:
@@ -109,6 +112,8 @@ class PackitAPIWithDownstreamMixin(PackitAPIWithDownstreamProtocol):
 
 
 class PackitAPIWithUpstreamMixin(PackitAPIProtocol):
+    _packit_api: Optional[PackitAPI] = None
+
     @property
     def packit_api(self):
         if not self._packit_api:
@@ -140,8 +145,6 @@ class LocalProjectMixin(ConfigMixin):
 
 
 class GetPagurePullRequest(Protocol):
-    _pull_request: Optional[PullRequest] = None
-
     @property
     def pull_request(self) -> PullRequest:
         ...
@@ -151,6 +154,8 @@ class GetPagurePullRequest(Protocol):
 
 
 class GetPagurePullRequestMixin(GetPagurePullRequest):
+    _pull_request: Optional[PullRequest] = None
+
     @property
     def pull_request(self):
         if not self._pull_request and self.data.event_dict["committer"] == "pagure":
@@ -173,14 +178,14 @@ class GetPagurePullRequestMixin(GetPagurePullRequest):
 
 
 class GetIssue(Protocol):
-    _issue: Optional[Issue] = None
-
     @property
     def issue(self) -> Issue:
         ...
 
 
 class GetIssueMixin(GetIssue, ConfigMixin):
+    _issue: Optional[Issue] = None
+
     @property
     def issue(self):
         if not self._issue:

--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -1,0 +1,188 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+from typing import Optional, Protocol
+
+from fasjson_client import Client
+from fasjson_client.errors import APIError
+
+from ogr.abstract import Issue
+
+from packit.api import PackitAPI
+from packit.local_project import LocalProject
+from packit.utils.repo import RepositoryCache
+
+from ogr.abstract import GitProject, PullRequest, PRStatus
+
+from packit_service.config import ServiceConfig
+from packit_service.worker.events import EventData
+
+from packit_service.constants import (
+    FASJSON_URL,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Config(Protocol):
+    _project: Optional[GitProject] = None
+    _service_config: Optional[ServiceConfig] = None
+    data: EventData
+
+    @property
+    def project(self) -> Optional[GitProject]:
+        ...
+
+    @property
+    def service_config(self) -> Optional[ServiceConfig]:
+        ...
+
+    @property
+    def project_url(self) -> str:
+        ...
+
+
+class ConfigMixin(Config):
+    data: EventData
+
+    @property
+    def service_config(self) -> ServiceConfig:
+        if not self._service_config:
+            self._service_config = ServiceConfig.get_service_config()
+        return self._service_config
+
+    @property
+    def project(self) -> Optional[GitProject]:
+        if not self._project and self.data.project_url:
+            self._project = self.service_config.get_project(url=self.data.project_url)
+        return self._project
+
+    @property
+    def project_url(self) -> str:
+        return self.data.project_url
+
+
+class PackitAPIProtocol(Protocol):
+    api: Optional[PackitAPI] = None
+    _packit_api: Optional[PackitAPI] = None
+    local_project: Optional[LocalProject] = None
+
+    @property
+    def packit_api(self) -> PackitAPI:
+        ...
+
+
+class PackitAPIWithDownstreamProtocol(PackitAPIProtocol):
+    def is_packager(self, user) -> bool:
+        """Check that the given FAS user
+        is a packager
+
+        Args:
+            user (str) FAS user account name
+        Returns:
+            true if a packager false otherwise
+        """
+        ...
+
+
+class PackitAPIWithDownstreamMixin(PackitAPIWithDownstreamProtocol):
+    @property
+    def packit_api(self):
+        if not self._packit_api:
+            self._packit_api = PackitAPI(
+                self.service_config,
+                self.job_config,
+                downstream_local_project=self.local_project,
+            )
+        return self._packit_api
+
+    def is_packager(self, user):
+        self.packit_api.init_kerberos_ticket()
+        client = Client(FASJSON_URL)
+        try:
+            groups = client.list_user_groups(username=user)
+        except APIError:
+            logger.debug(f"Unable to get groups for user {user}.")
+            return False
+        return "packager" in [group["groupname"] for group in groups.result]
+
+
+class PackitAPIWithUpstreamMixin(PackitAPIProtocol):
+    @property
+    def packit_api(self):
+        if not self._packit_api:
+            self._packit_api = PackitAPI(
+                self.service_config,
+                self.job_config,
+                upstream_local_project=self.local_project,
+            )
+        return self._packit_api
+
+
+class LocalProjectMixin(ConfigMixin):
+    _local_project: Optional[LocalProject] = None
+
+    @property
+    def local_project(self) -> LocalProject:
+        if not self._local_project:
+            self._local_project = LocalProject(
+                git_project=self.project,
+                working_dir=self.service_config.command_handler_work_dir,
+                cache=RepositoryCache(
+                    cache_path=self.service_config.repository_cache,
+                    add_new=self.service_config.add_repositories_to_repository_cache,
+                )
+                if self.service_config.repository_cache
+                else None,
+            )
+        return self._local_project
+
+
+class GetPagurePullRequest(Protocol):
+    _pull_request: Optional[PullRequest] = None
+
+    @property
+    def pull_request(self) -> PullRequest:
+        ...
+
+    def get_pr_author(self) -> Optional[str]:
+        ...
+
+
+class GetPagurePullRequestMixin(GetPagurePullRequest):
+    @property
+    def pull_request(self):
+        if not self._pull_request and self.data.event_dict["committer"] == "pagure":
+            logger.debug(
+                f"Getting pull request with head commit {self.data.commit_sha}"
+                f"for repo {self.project.namespace}/{self.project.repo}"
+            )
+            prs = [
+                pr
+                for pr in self.project.get_pr_list(status=PRStatus.all)
+                if pr.head_commit == self.data.commit_sha
+            ]
+            if prs:
+                self._pull_request = prs[0]
+        return self._pull_request
+
+    def get_pr_author(self):
+        """Get the login of the author of the PR (if there is any corresponding PR)."""
+        return self.pull_request.author if self.pull_request else None
+
+
+class GetIssue(Protocol):
+    _issue: Optional[Issue] = None
+
+    @property
+    def issue(self) -> Issue:
+        ...
+
+
+class GetIssueMixin(GetIssue, ConfigMixin):
+    @property
+    def issue(self):
+        if not self._issue:
+            self._issue = self.project.get_issue(self.data.issue_id)
+        return self._issue

--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -65,11 +65,14 @@ class ConfigMixin(Config):
 
 
 class PackitAPIProtocol(Config):
-    api: Optional[PackitAPI] = None
     local_project: Optional[LocalProject] = None
 
     @abstractproperty
     def packit_api(self) -> PackitAPI:
+        ...
+
+    @abstractmethod
+    def clean_api(self) -> None:
         ...
 
 
@@ -112,6 +115,12 @@ class PackitAPIWithDownstreamMixin(PackitAPIWithDownstreamProtocol):
             return False
         return "packager" in [group["groupname"] for group in groups.result]
 
+    def clean_api(self) -> None:
+        """TODO: probably we should clean something even here
+        but for now let it do the same as before the refactoring
+        """
+        pass
+
 
 class PackitAPIWithUpstreamMixin(PackitAPIProtocol):
     _packit_api: Optional[PackitAPI] = None
@@ -125,6 +134,10 @@ class PackitAPIWithUpstreamMixin(PackitAPIProtocol):
                 upstream_local_project=self.local_project,
             )
         return self._packit_api
+
+    def clean_api(self) -> None:
+        if self._packit_api:
+            self._packit_api.clean()
 
 
 class LocalProjectMixin(ConfigMixin):

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -655,14 +655,17 @@ def test_precheck_koji_build_push(
             allowed_committers=allowed_committers,
         ),
     ]
-    koji_build_handler = DownstreamKojiBuildHandler(
-        package_config=PackageConfig(
+    package_config = (
+        PackageConfig(
             jobs=jobs,
         ),
-        job_config=jobs[0],
-        event=distgit_push_event.get_dict(),
     )
-    assert koji_build_handler.pre_check() == should_pass
+    job_config = jobs[0]
+    event = distgit_push_event.get_dict()
+    assert (
+        DownstreamKojiBuildHandler.pre_check(package_config, job_config, event)
+        == should_pass
+    )
 
 
 @pytest.mark.parametrize(
@@ -723,11 +726,14 @@ def test_precheck_koji_build_push_pr(
             )
         ]
     )
-    koji_build_handler = DownstreamKojiBuildHandler(
-        package_config=PackageConfig(
+    package_config = (
+        PackageConfig(
             jobs=jobs,
         ),
-        job_config=jobs[0],
-        event=distgit_push_event.get_dict(),
     )
-    assert koji_build_handler.pre_check() == should_pass
+    job_config = jobs[0]
+    event = distgit_push_event.get_dict()
+    assert (
+        DownstreamKojiBuildHandler.pre_check(package_config, job_config, event)
+        == should_pass
+    )

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -1650,7 +1650,7 @@ def test_pr_test_command_handler_not_allowed_external_contributor_on_internal_TF
         project_url="https://github.com/packit-service/hello-world",
     ).and_return(
         flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
-    ).once()
+    ).twice()
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False).once()
@@ -1715,7 +1715,9 @@ def test_pr_build_command_handler_not_allowed_external_contributor_on_internal_T
         project_url="https://github.com/packit-service/hello-world",
     ).and_return(
         flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
-    ).twice()
+    ).times(
+        4
+    )
     pr_embedded_command_comment_event["comment"]["body"] = "/packit build"
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False).once()

--- a/tests/unit/test_distgit.py
+++ b/tests/unit/test_distgit.py
@@ -44,7 +44,7 @@ def test_create_one_issue_for_pr():
         ]
     )
     flexmock(ProposeDownstreamHandler).should_receive("project").and_return(project)
-    handler = ProposeDownstreamHandler(None, None, {})
+    handler = ProposeDownstreamHandler(None, None, {}, flexmock())
     handler._report_errors_for_each_branch(
         {
             "f34": "Propose downstream failed for release 056",

--- a/tests/unit/test_distgit.py
+++ b/tests/unit/test_distgit.py
@@ -79,11 +79,10 @@ PAGURE_PULL_REQUEST_COMMENT_PROCESSED = '{"created_at": 1658228337, "project_url
 )
 def test_retrigger_downstream_koji_build_pre_check(user_groups, data, check_passed):
     data_dict = json.loads(data)
-    handler = DownstreamKojiBuildHandler(None, None, data_dict)
     flexmock(PackitAPI).should_receive("init_kerberos_ticket").and_return(None)
     flexmock(Client).should_receive("__getattr__").with_args(
         "list_user_groups"
     ).and_return(lambda username: user_groups)
 
-    result = handler.pre_check()
+    result = DownstreamKojiBuildHandler.pre_check(None, None, data_dict)
     assert result == check_passed

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2509,7 +2509,7 @@ def test_create_tasks_tf_identifier(
 
     event = Event()
     # Ignore remote reporting
-    flexmock(SteveJobs, report_task_accepted=lambda handler, job_config: None)
+    flexmock(SteveJobs, report_task_accepted=lambda handler_kls, job_config: None)
     # We are testing the number of tasks, the exact signatures are not important
     flexmock(handler_kls).should_receive("get_signature").and_return(None)
     flexmock(TaskResults, create_from=lambda *args, **kwargs: object())


### PR DESCRIPTION
Job handlers should be retriable and may have a CeleryTask reference.
If a job handler is instantiated just for calling the pre-check method
then it can not be given a CeleryTask reference.

The pre_check method is now a classmethod for any job handler.
The job handler's pre_check method will invoke the pre_check method of
a list of new checker classes.
A checker class needs all the parameters needed by a job handler class
but it does not need the CeleryTask reference.

All the common code between checkers and handlers has been moved
in mixin classes.

Fixes #1581
