### PR TITLE
Improve link in reporting about custom Coprs

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -247,7 +247,7 @@ CUSTOM_COPR_PROJECT_NOT_ALLOWED_CONTENT = (
     "the configured `{copr_project}` Copr project.\n\n"
     "Please, add this git-forge project `{forge_project}` "
     "to `Packit allowed forge projects`"
-    "in the [Copr project settings](https://copr.fedorainfracloud.org/coprs/{copr_project}/edit/#packit_forge_projects_allowed). "  # noqa
+    "in the [Copr project settings]({copr_settings_url}#packit_forge_projects_allowed). "
 )
 
 CUSTOM_COPR_PROJECT_ALLOWED_IN_PACKIT_CONFIG = (
@@ -258,7 +258,7 @@ CUSTOM_COPR_PROJECT_ALLOWED_IN_PACKIT_CONFIG = (
     "in Packit for the allowed projects soon. "
     "Therefore, please, add this git-forge project `{forge_project}` "
     "to `Packit allowed forge projects`"
-    "in the [Copr project settings](https://copr.fedorainfracloud.org/coprs/{copr_project}/edit/#packit_forge_projects_allowed). "  # noqa
+    "in the [Copr project settings]({copr_settings_url}#packit_forge_projects_allowed). "
 )
 
 FASJSON_URL = "https://fasjson.fedoraproject.org"

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -222,6 +222,12 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
     def forge_project(self):
         return f"{self.project.service.hostname}/{self.project.namespace}/{self.project.repo}"
 
+    @property
+    def copr_settings_url(self):
+        return self.api.copr_helper.get_copr_settings_url(
+            self.job_owner, self.job_project
+        )
+
     def build_target2test_targets(self, build_target: str) -> Set[str]:
         """
         Return all test targets defined for the build target
@@ -390,6 +396,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             markdown_content = CUSTOM_COPR_PROJECT_ALLOWED_IN_PACKIT_CONFIG.format(
                 copr_project=self.configured_copr_project,
                 forge_project=self.forge_project,
+                copr_settings_url=self.copr_settings_url,
             )
             self.status_reporter.comment(body=markdown_content)
             return True
@@ -402,6 +409,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             markdown_content=CUSTOM_COPR_PROJECT_NOT_ALLOWED_CONTENT.format(
                 copr_project=self.configured_copr_project,
                 forge_project=self.forge_project,
+                copr_settings_url=self.copr_settings_url,
             ),
         )
         return False
@@ -592,6 +600,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 markdown_content = CUSTOM_COPR_PROJECT_NOT_ALLOWED_CONTENT.format(
                     copr_project=self.configured_copr_project,
                     forge_project=self.forge_project,
+                    copr_settings_url=self.copr_settings_url,
                 )
                 self.status_reporter.comment(body=markdown_content)
 

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -1691,18 +1691,20 @@ def test_check_if_custom_copr_can_be_used_and_report(
             job_trigger_model_type=JobTriggerModelType.pull_request,
         ),
     )
-    copr_build_helper._api = flexmock(
-        copr_helper=flexmock(
-            copr_client=flexmock(
-                config={"username": "nobody"},
-                project_proxy=flexmock(
-                    get=lambda owner, project: {
-                        "packit_forge_projects_allowed": git_forge_allowed_list
-                    }
-                ),
-            )
+    copr_helper = flexmock(
+        copr_client=flexmock(
+            config={"username": "nobody"},
+            project_proxy=flexmock(
+                get=lambda owner, project: {
+                    "packit_forge_projects_allowed": git_forge_allowed_list
+                }
+            ),
         )
     )
+    copr_helper.should_receive("get_copr_settings_url").with_args(
+        "the-owner", "the-project"
+    ).and_return().times(0 if allowed else 1)
+    copr_build_helper._api = flexmock(copr_helper=copr_helper)
     flexmock(CoprBuildJobHelper).should_receive("report_status_to_build").times(
         0 if allowed else 1
     )

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -2584,6 +2584,9 @@ def test_submit_copr_build(
     flexmock(helper).should_receive("srpm_path").and_return("")
     flexmock(helper).should_receive("forge_project").and_return("")
     flexmock(helper).should_receive("configured_copr_project").and_return("")
+    flexmock(CoprHelper).should_receive("get_copr_settings_url").and_return(
+        "https://copr.fedorainfracloud.org/coprs//edit/"
+    )
     flexmock(helper).should_receive("status_reporter").and_return(
         flexmock()
         .should_receive("comment")


### PR DESCRIPTION
Reuse an existing method for getting Copr project settings URL so that the link is correct also for group projects (`@groupname` is transformed to `g/groupname`, [context](https://github.com/rhinstaller/anaconda/commit/8901c8417cd6da8e2a6802afe443b5019f1d6ec8#commitcomment-85141118)).

---

RELEASE NOTES BEGIN
When we report to set  `Packit allowed forge projects` in the Copr projects, the link for the group projects is now correct.
RELEASE NOTES END
