### PR TITLE
Normalise default Copr project name

### DIFF
--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Iterable, List, Optional, Set, Tuple
 
@@ -126,10 +127,20 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             f"-{self.job_config.identifier}" if self.job_config.identifier else ""
         )
 
-        return (
+        copr_project_name = (
             f"{service_prefix}{namespace}-{self.project.repo}-{ref_identifier}"
             f"{configured_identifier}"
         )
+
+        return self.normalise_copr_project_name(copr_project_name)
+
+    @staticmethod
+    def normalise_copr_project_name(copr_project_name: str) -> str:
+        """
+        Transform not allowed characters for Copr project name to '-'
+        (name must contain only letters, digits, underscores, dashes and dots).
+        """
+        return re.sub(r"[^\w.-]", "-", copr_project_name)
 
     @property
     def job_project(self) -> Optional[str]:

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -923,16 +923,18 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             raise ex
         except PackitCoprProjectException as ex:
             msg = (
-                "We were not able to find Copr project"
-                f"({owner}/{self.job_project}) "
+                "We were not able to find or create Copr project"
+                f" `{owner}/{self.job_project}` "
                 "specified in the config with the following error:\n"
-                f"```\n{str(ex.__cause__)}\n```\n---\n"
+                f"```\n{str(ex)}\n```\n---\n"
                 "Please check your configuration for:\n\n"
                 "1. typos in owner and project name (groups need to be prefixed with `@`)\n"
-                "2. whether the project itself exists (Packit creates projects"
+                "2. whether the project name doesn't contain not allowed characters (only letters, "
+                "digits, underscores, dashes and dots must be used)\n"
+                "3. whether the project itself exists (Packit creates projects"
                 " only in its own namespace)\n"
-                "3. whether Packit is allowed to build in your Copr project\n"
-                "4. whether your Copr project/group is not private"
+                "4. whether Packit is allowed to build in your Copr project\n"
+                "5. whether your Copr project/group is not private"
             )
             self.status_reporter.comment(body=msg)
             raise ex

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -14,9 +14,6 @@ from copr.v3 import CoprRequestException, CoprAuthException
 from copr.v3.proxies.build import BuildProxy
 from flexmock import flexmock
 from munch import Munch
-
-import packit
-import packit_service
 from ogr.abstract import CommitStatus, GitProject
 from ogr.exceptions import GitForgeInternalError, GitlabAPIException, OgrNetworkError
 from ogr.services.github import GithubProject
@@ -26,6 +23,9 @@ from ogr.services.github.check_run import (
     create_github_check_run_output,
 )
 from ogr.services.gitlab import GitlabProject
+
+import packit
+import packit_service
 from packit.actions import ActionName
 from packit.api import PackitAPI
 from packit.config import JobConfig, JobConfigTriggerType, JobType, PackageConfig
@@ -2610,3 +2610,21 @@ def test_submit_copr_build(
             ownername="", projectname="", path="", buildopts=buildopts
         ).and_return(flexmock(id=0))
         helper.submit_copr_build()
+
+
+@pytest.mark.parametrize(
+    "raw_name,expected_name",
+    [
+        ("packit-specfile-91-fedora-epel", "packit-specfile-91-fedora-epel"),
+        ("packit-specfile-91-fedora+epel", "packit-specfile-91-fedora-epel"),
+        ("packit-specfile-my@fancy@branch", "packit-specfile-my-fancy-branch"),
+        ("packit-specfile-v23:1", "packit-specfile-v23-1"),
+    ],
+)
+def test_normalise_copr_project_name(raw_name, expected_name):
+    assert (
+        CoprBuildJobHelper.normalise_copr_project_name(raw_name)
+        == expected_name
+    )
+
+


### PR DESCRIPTION
Fixes #1640

---

RELEASE NOTES BEGIN
Packit Service will now replace invalid characters for the Copr projects using the default naming scheme.
RELEASE NOTES END
