### PR TITLE
Improve table on github check page

### DIFF
--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -17,6 +17,7 @@ from ogr.services.gitlab import GitlabProject
 from ogr.services.pagure import PagureProject
 
 from packit_service.constants import (
+    DOCS_URL,
     MSG_TABLE_HEADER_WITH_DETAILS,
 )
 
@@ -378,12 +379,19 @@ class StatusReporterGithubChecks(StatusReporterGithubStatuses):
     ) -> str:
         table_content = []
         if url:
-            table_content.append(f"| Dashboard | {url} |\n")
+            type_of_url = ""
+            if "dashboard.packit.dev" in url or "dashboard.stg.packit.dev":
+                type_of_url = "Dashboard"
+            elif DOCS_URL in url:
+                type_of_url = "Documentation"
+            table_content.append(f"| {type_of_url} | {url} |\n")
         if links_to_external_services is not None:
             table_content += [
                 f"| {name} | {link} |\n"
                 for name, link in links_to_external_services.items()
             ]
+        if table_content:
+            table_content += "\n"
 
         return (
             MSG_TABLE_HEADER_WITH_DETAILS + "".join(table_content)

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -449,12 +449,12 @@ def test_status_instead_check(
 
 def test_create_table():
     assert create_table_content(
-        "dashboard-url",
+        "dashboard.packit.dev-url",
         {"Testing Farm": "tf-url", "COPR build": "copr-build-url"},
     ) == (
         "| Name/Job | URL |\n"
         "| --- | --- |\n"
-        "| Dashboard | dashboard-url |\n"
+        "| Dashboard | dashboard.packit.dev-url |\n"
         "| Testing Farm | tf-url |\n"
-        "| COPR build | copr-build-url |\n"
+        "| COPR build | copr-build-url |\n\n"
     )


### PR DESCRIPTION
Fixes packit-service#1641

---

RELEASE NOTES BEGIN
Fixed the markdown table format in the github checks page. The table was broken when the user's repo was not allowed to use Packit.
RELEASE NOTES END
