### PR TITLE
testing farm composes: pick distro if user requested it

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -482,9 +482,19 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             return None
 
         if target in composes:
+            logger.debug(f"Target {target} is directly in the compose list.")
             return target
 
         distro, arch = target.rsplit("-", 1)
+
+        # we append -x86_64 to target by default
+        # when that happens and the user precisely specified the compose via target
+        # we should just use it instead of continuing below with our logic
+        # some of those changes can change the target and result in a failure
+        if distro in composes and arch == "x86_64":
+            logger.debug(f"Distro {distro} is directly in the compose list for x86_64.")
+            return distro
+
         compose = (
             distro.title()
             .replace("Centos", "CentOS")
@@ -616,6 +626,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
                 details={"msg": msg},
             )
         chroot = self.test_target2build_target(target)
+        logger.debug(f"Running testing farm for target {target}, chroot={chroot}.")
 
         if not self.skip_build and chroot not in self.build_targets:
             self.report_missing_build_chroot(chroot)

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -174,6 +174,7 @@ def test_testing_farm_response(
         ("centos-8.4-x86_64", "CentOS-8.4", True),
         # If target is present in the available composes, just return it
         ("RHEL-7.8-ZStream", "RHEL-7.8-ZStream", True),
+        ("RHEL-7.8-ZStream-x86_64", "RHEL-7.8-ZStream", True),
         ("RHEL-7.9-rhui", "RHEL-7.9-rhui", True),
     ],
 )


### PR DESCRIPTION
This is a follow up to c0ca4cd18758f6cd1de36607978b90271b08950d

The problem is that we suffix target names with {arch} and hence why we
need this code to make the use case above work.

Also added more `.debug()` lines in our code so we can spot errors like
these better in future. I could not find `target={target}` log lines in
sentry so it was hard to deduce the content of the variable.

Related #1653
Sentry issues:
* https://sentry.io/organizations/red-hat-0p/issues/3650852245/?project=1767823&query=is%3Aunresolved
* https://sentry.io/organizations/red-hat-0p/issues/3634172476/?project=1767823&query=is%3Aunresolved

- [x] Write new tests or update the old ones to cover new functionality.

---

RELEASE NOTES BEGIN
Packit now correctly selects a Testing Farm compose when it's specified correctly in the configuration without an architecture suffix.
RELEASE NOTES END