### PR TITLE
use latest bodhi v6 client

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -40,9 +40,8 @@
           # remove if we decide not to use concurrency
           - python3-eventlet
           - python3-gevent
-          # workaround for https://github.com/fedora-infra/bodhi/issues/4660
-          - https://kojipkgs.fedoraproject.org/packages/bodhi/5.7.5/1.fc35/noarch/python3-bodhi-5.7.5-1.fc35.noarch.rpm
-          - https://kojipkgs.fedoraproject.org/packages/bodhi/5.7.5/1.fc35/noarch/python3-bodhi-client-5.7.5-1.fc35.noarch.rpm
+          # v6 = bodhi-client, v5 = python3-bodhi{,-client}
+          - bodhi-client
         # needed when installing from koji - there are no GPG-signed packages
         disable_gpg_check: true
         state: present

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -27,10 +27,8 @@
           - python3-flexmock # because of the hack during the alembic upgrade
           # (see d90948124e46_add_tables_for_triggers_koji_and_tests.py )
           - python-jwt
-          # workaround for https://github.com/fedora-infra/bodhi/issues/4660
-          # we need to explicitly install here so that `tasks/install-packit-deps.yaml` doesn't pick up bodhi-client 6
-          - https://kojipkgs.fedoraproject.org/packages/bodhi/5.7.5/1.fc35/noarch/python3-bodhi-5.7.5-1.fc35.noarch.rpm
-          - https://kojipkgs.fedoraproject.org/packages/bodhi/5.7.5/1.fc35/noarch/python3-bodhi-client-5.7.5-1.fc35.noarch.rpm
+          # v6 = bodhi-client, v5 = python3-bodhi{,-client}
+          - bodhi-client
         state: present
         # needed when installing from koji - there are no GPG-signed packages
         disable_gpg_check: true


### PR DESCRIPTION
Don't pin to bodhi v5 and instead use the latest bodhi client (v6).

Related: https://github.com/packit/packit-service/issues/1681

~~Merge after https://github.com/packit/packit/pull/1746~~

~~Maybe not, we actually need this to be merged first: https://softwarefactory-project.io/zuul/t/packit-service/build/d8bdad87cc484aa8a847005ca02b1311/log/job-output.txt~~

Merge after https://github.com/packit/packit/pull/1746 // please don't ask

Let's merge the packit PR first, then this one so we'll have a new stg deployment with the new packit code.

---

RELEASE NOTES BEGIN
N/A￼
RELEASE NOTES END