### PR TITLE
Do not repeat custom copr restriction message

### DIFF
--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -393,6 +393,7 @@ class TestingFarmResultsHandler(JobHandler):
         status_reporter = StatusReporter.get_instance(
             project=self.project,
             commit_sha=self.data.commit_sha,
+            packit_user=self.service_config.get_github_account_name(),
             trigger_id=trigger.id if trigger else None,
             pr_id=self.data.pr_id,
         )

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -57,7 +57,7 @@ from packit_service.worker.celery_task import CeleryTask
 from packit_service.worker.helpers.build.build_helper import BaseBuildJobHelper
 from packit_service.worker.events import EventData
 from packit_service.worker.monitoring import Pushgateway, measure_time
-from packit_service.worker.reporting import BaseCommitStatus
+from packit_service.worker.reporting import BaseCommitStatus, DuplicateCheckMode
 from packit_service.worker.result import TaskResults
 
 logger = logging.getLogger(__name__)
@@ -409,7 +409,10 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 forge_project=self.forge_project,
                 copr_settings_url=self.copr_settings_url,
             )
-            self.status_reporter.comment(body=markdown_content)
+            self.status_reporter.comment(
+                body=markdown_content,
+                duplicate_check=DuplicateCheckMode.check_all_comments,
+            )
             return True
 
         self.report_status_to_build(

--- a/packit_service/worker/helpers/job_helper.py
+++ b/packit_service/worker/helpers/job_helper.py
@@ -141,6 +141,7 @@ class BaseJobHelper:
             self._status_reporter = StatusReporter.get_instance(
                 project=self.project,
                 commit_sha=self.metadata.commit_sha,
+                packit_user=self.service_config.get_github_account_name(),
                 trigger_id=trigger.id if trigger else None,
                 pr_id=self.metadata.pr_id,
             )

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -92,6 +92,7 @@ def test_testing_farm_response(
     config.should_receive("get_project").with_args(
         url="https://github.com/packit/ogr"
     ).and_return()
+    config.should_receive("get_github_account_name").and_return("packit-as-a-service")
     created_dt = datetime.utcnow()
     event_dict = TFResultsEvent(
         pipeline_id="id",


### PR DESCRIPTION
Some slight refactoring of duplicate message check into status reporter using an optional argument + then using it in appropriate places.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

Fixes #1686 

RELEASE NOTES BEGIN
Packit now won't repeatedly comment in pull requests about the need to migrate configuration of allowed forge projects to Copr.
RELEASE NOTES END
