### PR TITLE
Update to match config changes in Packit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
 ANSIBLE_PYTHON ?= $(shell command -v /usr/bin/python3 2> /dev/null || echo /usr/bin/python2)
 AP ?= ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=$(ANSIBLE_PYTHON)
 PATH_TO_SECRETS ?= $(CURDIR)/secrets/
-COV_REPORT ?= term-missing
+COV_REPORT ?= --cov=packit_service --cov-report=term-missing
 COLOR ?= yes
 SOURCE_BRANCH ?= $(shell git branch --show-current)
 CONTAINER_RUN_INTERACTIVE ?= -it
@@ -37,7 +37,7 @@ worker: files/install-deps-worker.yaml files/recipe-worker.yaml
 
 check:
 	find . -name "*.pyc" -exec rm {} \;
-	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --color=$(COLOR) --verbose --showlocals --cov=packit_service --cov-report=$(COV_REPORT) $(TEST_TARGET)
+	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --color=$(COLOR) --verbose --showlocals $(COV_REPORT) $(TEST_TARGET)
 
 # In most cases you don't need to build your test-image, the one in registry should be all you need.
 build-test-image: files/install-deps-worker.yaml files/install-deps.yaml files/recipe-tests.yaml

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1530,6 +1530,8 @@ class AllowlistModel(Base):
 
 
 class TestingFarmResult(str, enum.Enum):
+    __test__ = False
+
     new = "new"
     queued = "queued"
     running = "running"

--- a/packit_service/worker/events/testing_farm.py
+++ b/packit_service/worker/events/testing_farm.py
@@ -16,6 +16,8 @@ from packit_service.worker.events.event import AbstractForgeIndependentEvent
 
 
 class TestingFarmResultsEvent(AbstractForgeIndependentEvent):
+    __test__ = False
+
     def __init__(
         self,
         pipeline_id: str,

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -88,6 +88,8 @@ class TestingFarmHandler(
     TODO: We can react directly to the finished Copr build.
     """
 
+    __test__ = False
+
     task_name = TaskName.testing_farm
 
     def __init__(
@@ -258,6 +260,7 @@ class TestingFarmHandler(
 @configured_as(job_type=JobType.tests)
 @reacts_to(event=TestingFarmResultsEvent)
 class TestingFarmResultsHandler(JobHandler):
+    __test__ = False
     task_name = TaskName.testing_farm_results
 
     def __init__(

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -51,6 +51,8 @@ logger = logging.getLogger(__name__)
 
 
 class TestingFarmJobHelper(CoprBuildJobHelper):
+    __test__ = False
+
     def __init__(
         self,
         service_config: ServiceConfig,

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -8,9 +8,7 @@ import requests
 from ogr.abstract import GitProject, PullRequest
 from ogr.utils import RequestResponse
 
-from packit.config import JobType, JobConfigTriggerType
-from packit.config.job_config import JobConfig
-from packit.config.package_config import PackageConfig
+from packit.config import JobConfig, PackageConfig
 from packit.exceptions import PackitConfigException, PackitException
 from packit.utils import nested_get
 from packit_service.config import ServiceConfig
@@ -815,15 +813,11 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         We need to get more details ourselves."""
         self = cls(
             service_config=ServiceConfig.get_service_config(),
-            package_config=PackageConfig(),
+            package_config=None,
             project=None,
             metadata=None,
             db_trigger=None,
-            job_config=JobConfig(
-                # dummy values to be able to construct the object
-                type=JobType.tests,
-                trigger=JobConfigTriggerType.pull_request,
-            ),
+            job_config=None,
         )
 
         response = self.send_testing_farm_request(

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -9,7 +9,13 @@ from copr.v3 import Client, CoprNoResultException
 from flexmock import flexmock
 
 import packit_service.worker.helpers.build.babysit
-from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
+from packit.config import (
+    CommonPackageConfig,
+    JobConfig,
+    JobConfigTriggerType,
+    JobType,
+    PackageConfig,
+)
 from packit_service.models import (
     CoprBuildTargetModel,
     JobTriggerModelType,
@@ -138,8 +144,13 @@ def test_check_copr_build_updated():
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
         PackageConfig(
             jobs=[
-                JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)
-            ]
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
+            packages={"package": CommonPackageConfig()},
         )
     )
     flexmock(CoprBuildEndHandler).should_receive("run").and_return().once()
@@ -294,8 +305,13 @@ def test_check_pending_testing_farm_runs(created):
     flexmock(TestingFarmResultsEvent).should_receive("get_package_config").and_return(
         PackageConfig(
             jobs=[
-                JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.pull_request)
-            ]
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
+            packages={"package": CommonPackageConfig()},
         )
     )
     flexmock(TestingFarmResultsHandler).should_receive("run").and_return().once()
@@ -374,17 +390,28 @@ def test_check_pending_testing_farm_runs_identifiers(identifier):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="first",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="first",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="second",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="second",
+                        )
+                    },
                 ),
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
-            ]
+            ],
+            packages={"package": CommonPackageConfig()},
         )
     )
     flexmock(TestingFarmResultsHandler).should_receive("run").and_return().once()

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -10,8 +10,14 @@ from ogr.services.github import GithubProject
 from ogr.services.pagure import PagureProject
 
 from packit.api import PackitAPI
-from packit.config import JobConfigTriggerType, PackageConfig, JobConfig, JobType
-from packit.config.common_package_config import Deployment
+from packit.config import (
+    CommonPackageConfig,
+    Deployment,
+    JobConfig,
+    JobConfigTriggerType,
+    JobType,
+    PackageConfig,
+)
 from packit.constants import CONFIG_FILE_NAMES
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
@@ -651,13 +657,18 @@ def test_precheck_koji_build_push(
         JobConfig(
             type=JobType.koji_build,
             trigger=JobConfigTriggerType.commit,
-            dist_git_branches=["f36"],
-            allowed_committers=allowed_committers,
+            packages={
+                "package": CommonPackageConfig(
+                    dist_git_branches=["f36"],
+                    allowed_committers=allowed_committers,
+                )
+            },
         ),
     ]
     package_config = (
         PackageConfig(
             jobs=jobs,
+            packages={"package": CommonPackageConfig()},
         ),
     )
     job_config = jobs[0]
@@ -714,8 +725,12 @@ def test_precheck_koji_build_push_pr(
         JobConfig(
             type=JobType.koji_build,
             trigger=JobConfigTriggerType.commit,
-            dist_git_branches=["f36"],
-            allowed_pr_authors=allowed_pr_authors,
+            packages={
+                "package": CommonPackageConfig(
+                    dist_git_branches=["f36"],
+                    allowed_pr_authors=allowed_pr_authors,
+                )
+            },
         ),
     ]
     flexmock(PagureProject).should_receive("get_pr_list").and_return(
@@ -729,6 +744,7 @@ def test_precheck_koji_build_push_pr(
     package_config = (
         PackageConfig(
             jobs=jobs,
+            packages={"package": CommonPackageConfig()},
         ),
     )
     job_config = jobs[0]

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -58,12 +58,18 @@ def mock_release_class(release_class, project_class, **kwargs):
 def mock_comment(request):
     project_class, release_class, forge, author = request.param
 
-    packit_yaml = (
-        "{'specfile_path': 'packit.spec', 'synced_files': [],"
-        "'jobs': [{'trigger': 'release', 'job': 'propose_downstream',"
-        "'metadata': {'dist-git-branch': 'main'}}],"
-        "'downstream_package_name': 'packit'}"
-    )
+    packit_yaml = """\
+downstream_package_name: packit
+specfile_path: packit.spec
+files_to_sync:
+  - packit.spec
+
+jobs:
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - main
+"""
     flexmock(
         project_class,
         get_file_content=lambda path, ref: packit_yaml,

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -14,8 +14,13 @@ import packit_service
 import packit_service.service.urls as urls
 from ogr.services.github import GithubProject
 from ogr.utils import RequestResponse
-from packit.config import JobConfig, JobConfigTriggerType, JobType
-from packit.config.package_config import PackageConfig
+from packit.config import (
+    CommonPackageConfig,
+    JobConfig,
+    JobConfigTriggerType,
+    JobType,
+    PackageConfig,
+)
 from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
 from packit_service.config import PackageConfigGetter, ServiceConfig
@@ -106,70 +111,115 @@ def koji_build_scratch_end():
 @pytest.fixture(scope="module")
 def pc_build_pr():
     return PackageConfig(
-        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                _targets=["fedora-all"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-all"],
+                        specfile_path="test.spec",
+                    )
+                },
             )
         ],
+        packages={
+            "package": CommonPackageConfig(
+                specfile_path="test.spec",
+            )
+        },
     )
 
 
 @pytest.fixture(scope="module")
 def pc_koji_build_pr():
     return PackageConfig(
-        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.upstream_koji_build,
                 trigger=JobConfigTriggerType.pull_request,
-                _targets=["fedora-all"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-all"],
+                        specfile_path="test.spec",
+                    )
+                },
             )
         ],
+        packages={
+            "package": CommonPackageConfig(
+                specfile_path="test.spec",
+            )
+        },
     )
 
 
 @pytest.fixture(scope="module")
 def pc_build_push():
     return PackageConfig(
-        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.commit,
-                _targets=["fedora-all"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-all"],
+                        specfile_path="test.spec",
+                    )
+                },
             )
         ],
+        packages={
+            "package": CommonPackageConfig(
+                specfile_path="test.spec",
+            )
+        },
     )
 
 
 @pytest.fixture(scope="module")
 def pc_build_release():
     return PackageConfig(
-        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.release,
-                _targets=["fedora-all"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-all"],
+                        specfile_path="test.spec",
+                    )
+                },
             )
         ],
+        packages={
+            "package": CommonPackageConfig(
+                specfile_path="test.spec",
+            )
+        },
     )
 
 
 @pytest.fixture(scope="module")
 def pc_tests():
     return PackageConfig(
-        specfile_path="test.spec",
         jobs=[
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
-                _targets=["fedora-all"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-all"],
+                        specfile_path="test.spec",
+                    )
+                },
             )
         ],
+        packages={
+            "package": CommonPackageConfig(
+                specfile_path="test.spec",
+            )
+        },
     )
 
 
@@ -430,17 +480,31 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     urls.DASHBOARD_URL = "https://dashboard.localhost"
 
     config = PackageConfig(
-        specfile_path="test.spec",
+        packages={
+            "package": CommonPackageConfig(
+                specfile_path="test.spec",
+            )
+        },
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                _targets=["fedora-rawhide"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-rawhide"],
+                        specfile_path="test.spec",
+                    )
+                },
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
-                _targets=["fedora-rawhide"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-rawhide"],
+                        specfile_path="test.spec",
+                    )
+                },
             ),
         ],
     )
@@ -641,24 +705,43 @@ def test_copr_build_end_report_multiple_testing_farm_jobs(
     urls.DASHBOARD_URL = "https://dashboard.localhost"
 
     config = PackageConfig(
-        specfile_path="test.spec",
+        packages={
+            "package": CommonPackageConfig(
+                specfile_path="test.spec",
+            )
+        },
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                _targets=["fedora-rawhide"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-rawhide"],
+                        specfile_path="test.spec",
+                    )
+                },
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
-                identifier="test1",
-                _targets=["fedora-rawhide"],
+                packages={
+                    "package": CommonPackageConfig(
+                        identifier="test1",
+                        _targets=["fedora-rawhide"],
+                        specfile_path="test.spec",
+                    )
+                },
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
-                identifier="test2",
-                _targets=["fedora-rawhide", "other-target"],
+                packages={
+                    "package": CommonPackageConfig(
+                        identifier="test2",
+                        _targets=["fedora-rawhide", "other-target"],
+                        specfile_path="test.spec",
+                    )
+                },
             ),
         ],
     )
@@ -760,17 +843,31 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     )
 
     config = PackageConfig(
-        specfile_path="test.spec",
+        packages={
+            "package": CommonPackageConfig(
+                specfile_path="test.spec",
+            )
+        },
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                _targets=["fedora-rawhide"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-rawhide"],
+                        specfile_path="test.spec",
+                    )
+                },
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
-                _targets=["fedora-rawhide"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-rawhide"],
+                        specfile_path="test.spec",
+                    )
+                },
             ),
         ],
     )
@@ -898,17 +995,31 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     )
 
     config = PackageConfig(
-        specfile_path="test.spec",
+        packages={
+            "package": CommonPackageConfig(
+                specfile_path="test.spec",
+            )
+        },
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                _targets=["fedora-rawhide"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-rawhide"],
+                        specfile_path="test.spec",
+                    )
+                },
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
-                _targets=["fedora-rawhide"],
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-rawhide"],
+                        specfile_path="test.spec",
+                    )
+                },
             ),
         ],
     )

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -13,7 +13,7 @@ from ogr.services.github import GithubProject, GithubService
 
 import packit_service
 from packit.api import PackitAPI
-from packit.config import JobType, JobConfig, JobConfigTriggerType
+from packit.config import CommonPackageConfig, JobType, JobConfig, JobConfigTriggerType
 from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
 from packit_service.config import ServiceConfig
@@ -479,7 +479,11 @@ def test_check_and_report(
         JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            _targets=["fedora-rawhide"],
+            packages={
+                "package": CommonPackageConfig(
+                    _targets=["fedora-rawhide"],
+                )
+            },
         )
     ]
     flexmock(PullRequestGithubEvent).should_receive("get_package_config").and_return(

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -5,9 +5,15 @@ from pathlib import Path
 import pytest
 from flexmock import flexmock
 
-from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
-from packit.config.aliases import get_build_targets
 from packit.copr_helper import CoprHelper
+from packit.config import (
+    CommonPackageConfig,
+    JobConfig,
+    JobConfigTriggerType,
+    JobType,
+    PackageConfig,
+)
+from packit.config.aliases import get_build_targets
 from packit.local_project import LocalProject
 from packit.utils.repo import RepositoryCache
 from packit_service.config import ServiceConfig
@@ -39,7 +45,9 @@ def _mock_targets(jobs, job, job_type):
     project_service = flexmock(instance_url="https://github.com")
     return CoprBuildJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=job,  # BuildHelper looks at all jobs in the end
         project=flexmock(
             service=project_service, namespace="packit", repo="testing_package"
@@ -60,7 +68,11 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -72,7 +84,11 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -84,7 +100,11 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.release,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             (JobConfigTriggerType.release, JobTriggerModelType.release),
@@ -96,7 +116,11 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             (JobConfigTriggerType.commit, JobTriggerModelType.branch_push),
@@ -108,12 +132,20 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    _targets=["different", "os", "target"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["different", "os", "target"],
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -125,12 +157,20 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    _targets=["different", "os", "target"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["different", "os", "target"],
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -142,12 +182,20 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["different", "os", "target"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["different", "os", "target"],
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.commit, JobTriggerModelType.branch_push),
@@ -159,6 +207,7 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -170,6 +219,7 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -181,7 +231,11 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -193,10 +247,12 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -208,11 +264,16 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -224,11 +285,16 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -240,11 +306,16 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=list(ONE_CHROOT_SET),
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=list(ONE_CHROOT_SET),
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -256,14 +327,17 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.commit, JobTriggerModelType.branch_push),
@@ -275,14 +349,17 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -294,11 +371,17 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
-                JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.commit),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
+                ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.commit, JobTriggerModelType.branch_push),
@@ -310,12 +393,18 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
-                JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.commit),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
+                ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
             {"fedora-stable"},
@@ -326,17 +415,22 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.commit, JobTriggerModelType.branch_push),
@@ -348,11 +442,16 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=list(ONE_CHROOT_SET),
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=list(ONE_CHROOT_SET),
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -364,12 +463,20 @@ def _mock_targets(jobs, job, job_type):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["fedora-rawhide"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["fedora-rawhide"],
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -395,6 +502,7 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -406,7 +514,11 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -418,10 +530,12 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -433,11 +547,16 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -449,11 +568,16 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -465,11 +589,16 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=list(ONE_CHROOT_SET),
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=list(ONE_CHROOT_SET),
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -481,14 +610,17 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.commit, JobTriggerModelType.branch_push),
@@ -500,14 +632,17 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -519,12 +654,18 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
-                JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.commit),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
+                ),
             ],
             (JobConfigTriggerType.commit, JobTriggerModelType.branch_push),
             {"fedora-stable"},
@@ -535,12 +676,18 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
-                JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.commit),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
+                ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
             set(),
@@ -551,17 +698,22 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
-                    type=JobType.tests, trigger=JobConfigTriggerType.pull_request
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             (JobConfigTriggerType.commit, JobTriggerModelType.branch_push),
@@ -573,11 +725,16 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=list(ONE_CHROOT_SET),
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=list(ONE_CHROOT_SET),
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -589,12 +746,20 @@ def test_configured_build_targets(jobs, job_type, build_chroots):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["fedora-rawhide"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["fedora-rawhide"],
+                        )
+                    },
                 ),
             ],
             (JobConfigTriggerType.pull_request, JobTriggerModelType.pull_request),
@@ -609,7 +774,9 @@ def test_configured_tests_targets(jobs, job_type, test_chroots):
     project_service = flexmock(instance_url="https://github.com")
     helper = TestingFarmJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[-1],  # test job is always the last in the list
         project=flexmock(
             service=project_service, namespace="packit", repo="testing_package"
@@ -632,20 +799,27 @@ def test_deduced_copr_targets():
         JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.commit,
-            owner="mf",
-            project="custom-copr-targets",
+            packages={
+                "package": CommonPackageConfig(
+                    owner="mf",
+                    project="custom-copr-targets",
+                )
+            },
         ),
         JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.release,
+            packages={"packages": CommonPackageConfig()},
         ),
         JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
+            packages={"packages": CommonPackageConfig()},
         ),
         JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.commit,
+            packages={"packages": CommonPackageConfig()},
         ),
     ]
     job_type = (JobConfigTriggerType.commit, JobTriggerModelType.branch_push)
@@ -661,7 +835,9 @@ def test_deduced_copr_targets():
     assert copr_build_helper.configured_build_targets == {"opensuse-tumbleweed-x86_64"}
     assert TestingFarmJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[-1],  # BuildHelper looks at all jobs in the end
         project=flexmock(
             service=flexmock(), namespace="packit", repo="testing_package"
@@ -683,11 +859,16 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -701,7 +882,11 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -715,7 +900,11 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -729,7 +918,13 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets={
+                                "epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}
+                            },
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -743,7 +938,13 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets={
+                                "epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}
+                            },
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -757,7 +958,11 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["centos-stream-8"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["centos-stream-8"],
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -771,11 +976,16 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["centos-stream-8"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["centos-stream-8"],
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -789,7 +999,11 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["epel-7-x86_64"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-x86_64"],
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -803,7 +1017,11 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["epel-7-x86_64"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-x86_64"],
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -817,7 +1035,11 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["epel-7-ppc64le"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-ppc64le"],
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -831,7 +1053,11 @@ def test_deduced_copr_targets():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["epel-7-ppc64le"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-ppc64le"],
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -851,7 +1077,9 @@ def test_build_targets_overrides(
 ):
     copr_build_helper = CoprBuildJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[-1],  # BuildHelper looks at all jobs in the end
         project=flexmock(),
         metadata=flexmock(pr_id=None),
@@ -889,11 +1117,16 @@ def test_build_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -907,7 +1140,13 @@ def test_build_targets_overrides(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets={
+                                "epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}
+                            },
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -921,7 +1160,13 @@ def test_build_targets_overrides(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets={
+                                "epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}
+                            },
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -935,7 +1180,11 @@ def test_build_targets_overrides(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["centos-stream-8"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["centos-stream-8"],
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -949,11 +1198,16 @@ def test_build_targets_overrides(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["centos-stream-8"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["centos-stream-8"],
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -967,7 +1221,11 @@ def test_build_targets_overrides(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["epel-7-x86_64"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-x86_64"],
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -981,7 +1239,11 @@ def test_build_targets_overrides(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["epel-7-x86_64"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-x86_64"],
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -995,7 +1257,11 @@ def test_build_targets_overrides(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["epel-7-ppc64le"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-ppc64le"],
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1009,7 +1275,11 @@ def test_build_targets_overrides(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["epel-7-ppc64le"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-ppc64le"],
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1029,7 +1299,9 @@ def test_tests_targets_overrides(
 ):
     testing_farm_helper = TestingFarmJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[-1],  # BuildHelper looks at all jobs in the end
         project=flexmock(),
         metadata=flexmock(pr_id=None),
@@ -1119,13 +1391,19 @@ def test_copr_build_target2test_targets(
         JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            _targets=configured_targets,
-            use_internal_tf=use_internal_tf,
+            packages={
+                "package": CommonPackageConfig(
+                    _targets=configured_targets,
+                    use_internal_tf=use_internal_tf,
+                )
+            },
         )
     ]
     copr_build_helper = CoprBuildJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[0],
         project=flexmock(),
         metadata=flexmock(pr_id=None),
@@ -1143,15 +1421,23 @@ def test_copr_build_and_test_targets_both_jobs_defined():
         JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            _targets={
-                "epel-8-x86_64": {},
-                "fedora-35-x86_64": {"distros": ["fedora-35", "fedora-36"]},
+            packages={
+                "package": CommonPackageConfig(
+                    _targets={
+                        "epel-8-x86_64": {},
+                        "fedora-35-x86_64": {"distros": ["fedora-35", "fedora-36"]},
+                    },
+                )
             },
         ),
         JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
-            _targets=["fedora-35", "fedora-36", "epel-8"],
+            packages={
+                "package": CommonPackageConfig(
+                    _targets=["fedora-35", "fedora-36", "epel-8"],
+                )
+            },
         ),
     ]
     flexmock(copr_build, get_valid_build_targets=get_build_targets)
@@ -1163,7 +1449,9 @@ def test_copr_build_and_test_targets_both_jobs_defined():
         )
         helper = helper(
             service_config=ServiceConfig.get_service_config(),
-            package_config=PackageConfig(jobs=jobs),
+            package_config=PackageConfig(
+                jobs=jobs, packages={"package": CommonPackageConfig()}
+            ),
             job_config=jobs[i],
             project=flexmock(),
             metadata=flexmock(pr_id=None),
@@ -1209,7 +1497,11 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             "fedora-32-x86_64",
@@ -1221,7 +1513,13 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets={
+                                "epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}
+                            },
+                        )
+                    },
                 )
             ],
             "centos-7-x86_64",
@@ -1233,7 +1531,13 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets={
+                                "epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}
+                            },
+                        )
+                    },
                 )
             ],
             "rhel-7-x86_64",
@@ -1245,7 +1549,13 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets={"epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}},
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets={
+                                "epel-7-x86_64": {"distros": ["centos-7", "rhel-7"]}
+                            },
+                        )
+                    },
                 )
             ],
             "rhel-7-x86_64",
@@ -1257,7 +1567,11 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["epel-7-x86_64"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-x86_64"],
+                        )
+                    },
                 )
             ],
             "centos-7-x86_64",
@@ -1269,8 +1583,12 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["epel-7-x86_64"],
-                    use_internal_tf=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-x86_64"],
+                            use_internal_tf=True,
+                        )
+                    },
                 )
             ],
             "rhel-7-x86_64",
@@ -1282,7 +1600,11 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["centos-stream-9-x86_64"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["centos-stream-9-x86_64"],
+                        )
+                    },
                 )
             ],
             "centos-stream-9-x86_64",
@@ -1294,11 +1616,16 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["centos-stream-9-x86_64"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["centos-stream-9-x86_64"],
+                        )
+                    },
                 ),
             ],
             "centos-stream-9-x86_64",
@@ -1310,8 +1637,12 @@ def test_copr_build_and_test_targets_both_jobs_defined():
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=["centos-stream-9-x86_64"],
-                    use_internal_tf=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["centos-stream-9-x86_64"],
+                            use_internal_tf=True,
+                        )
+                    },
                 )
             ],
             "centos-stream-9-x86_64",
@@ -1324,7 +1655,9 @@ def test_copr_test_target2build_target(job_config, test_target, build_target):
     jobs = job_config
     testing_farm_helper = TestingFarmJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[0],
         project=flexmock(),
         metadata=flexmock(pr_id=None),
@@ -1353,7 +1686,11 @@ def test_copr_test_target2build_target(job_config, test_target, build_target):
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1366,7 +1703,11 @@ def test_copr_test_target2build_target(job_config, test_target, build_target):
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1381,7 +1722,9 @@ def test_koji_targets_overrides(
 ):
     koji_build_helper = KojiBuildJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[0],
         project=flexmock(),
         metadata=flexmock(),
@@ -1399,16 +1742,19 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.pull_request,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             None,
             id="copr_build&pull_request",
@@ -1418,16 +1764,19 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             JobConfig(
                 type=JobType.build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.pull_request,
             JobConfig(
                 type=JobType.build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             None,
             id="build&pull_request",
@@ -1437,16 +1786,19 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.pull_request,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             None,
             id="copr_build&pr_comment",
@@ -1456,16 +1808,19 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.release,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.release,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.release,
+                packages={"packages": CommonPackageConfig()},
             ),
             None,
             id="copr_build&release",
@@ -1475,16 +1830,19 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.commit,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.commit,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.commit,
+                packages={"packages": CommonPackageConfig()},
             ),
             None,
             id="copr_build&push",
@@ -1494,20 +1852,24 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.pull_request,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             None,
             id="copr_build[pr+commit]&pull_request",
@@ -1517,20 +1879,24 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.pull_request,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             None,
             id="copr_build[commit+pr]&pull_request",
@@ -1540,20 +1906,24 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.commit,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.commit,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.commit,
+                packages={"packages": CommonPackageConfig()},
             ),
             None,
             id="copr_build[pr+commit]&push",
@@ -1563,17 +1933,20 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.pull_request,
             None,
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             id="test&pr",
         ),
@@ -1582,24 +1955,29 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.pull_request,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             id="copr_build+test&pr",
         ),
@@ -1608,24 +1986,29 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfig(
                 type=JobType.build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.pull_request,
             JobConfig(
                 type=JobType.build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             id="build+test&pr",
         ),
@@ -1634,28 +2017,34 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.pull_request,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfig(
                 type=JobType.tests,
                 trigger=JobConfigTriggerType.pull_request,
+                packages={"packages": CommonPackageConfig()},
             ),
             id="copr_build[pr+commit]+test[pr]&pr",
         ),
@@ -1664,24 +2053,29 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.commit,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.commit,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.commit,
+                packages={"packages": CommonPackageConfig()},
             ),
             None,
             id="copr_build[pr+commit]+test[pr]&commit",
@@ -1691,28 +2085,34 @@ def test_koji_targets_overrides(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.release,
+                packages={"packages": CommonPackageConfig()},
             ),
             JobConfigTriggerType.release,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.release,
+                packages={"packages": CommonPackageConfig()},
             ),
             None,
             id="copr_build[pr+commit]+test[pr]&commit",
@@ -1728,7 +2128,9 @@ def test_build_handler_job_and_test_properties(
 ):
     copr_build_helper = CoprBuildJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=init_job,
         project=flexmock(),
         metadata=flexmock(pr_id=None),
@@ -1749,6 +2151,7 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1763,7 +2166,11 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    owner="custom-owner",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="custom-owner",
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1778,7 +2185,11 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="custom-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="custom-project",
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1793,8 +2204,12 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    owner="custom-owner",
-                    project="custom-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="custom-owner",
+                            project="custom-project",
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1809,8 +2224,12 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    owner="custom-owner",
-                    project="custom-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="custom-owner",
+                            project="custom-project",
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -1825,6 +2244,7 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             JobConfigTriggerType.commit,
@@ -1839,6 +2259,7 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             JobConfigTriggerType.release,
@@ -1853,6 +2274,7 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"packages": CommonPackageConfig()},
                 )
             ],
             JobConfigTriggerType.release,
@@ -1867,14 +2289,22 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    owner="commit-owner",
-                    project="commit-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="commit-owner",
+                            project="commit-project",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    owner="pr-owner",
-                    project="pr-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="pr-owner",
+                            project="pr-project",
+                        )
+                    },
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -1889,10 +2319,12 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -1907,12 +2339,17 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    owner="custom-owner",
-                    project="custom-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="custom-owner",
+                            project="custom-project",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -1927,12 +2364,17 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    owner="custom-owner",
-                    project="custom-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="custom-owner",
+                            project="custom-project",
+                        )
+                    },
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -1947,18 +2389,27 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    owner="pr-owner",
-                    project="pr-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="pr-owner",
+                            project="pr-project",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    owner="commit-owner",
-                    project="commit-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="commit-owner",
+                            project="commit-project",
+                        )
+                    },
                 ),
             ],
             JobConfigTriggerType.pull_request,
@@ -1973,18 +2424,27 @@ def test_build_handler_job_and_test_properties(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    owner="pr-owner",
-                    project="pr-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="pr-owner",
+                            project="pr-project",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"packages": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    owner="commit-owner",
-                    project="commit-project",
+                    packages={
+                        "package": CommonPackageConfig(
+                            owner="commit-owner",
+                            project="commit-project",
+                        )
+                    },
                 ),
             ],
             JobConfigTriggerType.commit,
@@ -2006,7 +2466,9 @@ def test_copr_project_and_namespace(
 ):
     copr_build_helper = CoprBuildJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[0],  # BuildHelper looks at all jobs in the end
         project=flexmock(
             namespace="the/example/namespace",
@@ -2036,8 +2498,12 @@ def test_copr_project_and_namespace(
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                owner="the-owner",
-                project="the-project",
+                packages={
+                    "package": CommonPackageConfig(
+                        owner="the-owner",
+                        project="the-project",
+                    )
+                },
             ),
             "",
             False,
@@ -2047,8 +2513,12 @@ def test_copr_project_and_namespace(
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                owner="the-owner",
-                project="the-project",
+                packages={
+                    "package": CommonPackageConfig(
+                        owner="the-owner",
+                        project="the-project",
+                    )
+                },
             ),
             "something/different",
             False,
@@ -2058,8 +2528,12 @@ def test_copr_project_and_namespace(
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                owner="the-owner",
-                project="the-project",
+                packages={
+                    "package": CommonPackageConfig(
+                        owner="the-owner",
+                        project="the-project",
+                    )
+                },
             ),
             "git.instance.io/the/example/namespace/the-example-repo",
             True,
@@ -2069,8 +2543,12 @@ def test_copr_project_and_namespace(
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
-                owner="the-owner",
-                project="the-project",
+                packages={
+                    "package": CommonPackageConfig(
+                        owner="the-owner",
+                        project="the-project",
+                    )
+                },
             ),
             "something/different\ngit.instance.io/the/example/namespace/the-example-repo",
             True,
@@ -2086,7 +2564,9 @@ def test_check_if_custom_copr_can_be_used_and_report(
     service_config = ServiceConfig.get_service_config()
     copr_build_helper = CoprBuildJobHelper(
         service_config=service_config,
-        package_config=PackageConfig(jobs=[job]),
+        package_config=PackageConfig(
+            jobs=[job], packages={"package": CommonPackageConfig()}
+        ),
         job_config=job,  # BuildHelper looks at all jobs in the end
         project=flexmock(
             namespace="the/example/namespace",
@@ -2129,7 +2609,11 @@ def test_check_if_custom_copr_can_be_used_and_report(
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.pull_request,
@@ -2142,8 +2626,12 @@ def test_check_if_custom_copr_can_be_used_and_report(
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.commit,
-                    _targets=STABLE_VERSIONS,
-                    branch="build-branch",
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                            branch="build-branch",
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.commit,
@@ -2156,8 +2644,12 @@ def test_check_if_custom_copr_can_be_used_and_report(
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.release,
-                    _targets=STABLE_VERSIONS,
-                    branch="build-branch",
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                            branch="build-branch",
+                        )
+                    },
                 )
             ],
             JobConfigTriggerType.release,
@@ -2173,7 +2665,9 @@ def test_targets_for_koji_build(
     pr_id = 41 if job_config_trigger_type == JobConfigTriggerType.pull_request else None
     koji_build_helper = KojiBuildJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[0],
         project=flexmock(),
         metadata=flexmock(pr_id=pr_id),
@@ -2200,14 +2694,23 @@ def test_repository_cache_invocation():
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=STABLE_VERSIONS,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=STABLE_VERSIONS,
+                        )
+                    },
                 )
             ],
+            packages={"package": CommonPackageConfig()},
         ),
         job_config=JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
-            _targets=STABLE_VERSIONS,
+            packages={
+                "package": CommonPackageConfig(
+                    _targets=STABLE_VERSIONS,
+                )
+            },
         ),
         project=flexmock(
             service=flexmock(),
@@ -2239,11 +2742,14 @@ def test_local_project_not_called_when_initializing_api():
         JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
+            packages={"packages": CommonPackageConfig()},
         )
     ]
     copr_build_helper = CoprBuildJobHelper(
         service_config=ServiceConfig.get_service_config(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[0],
         project=flexmock(),
         metadata=flexmock(pr_id=1),

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -7,7 +7,7 @@ import celery
 import pytest
 from flexmock import flexmock
 
-from packit.config import JobConfig, JobConfigTriggerType, JobType
+from packit.config import CommonPackageConfig, JobConfig, JobConfigTriggerType, JobType
 from packit_service.config import ServiceConfig
 from packit_service.constants import COMMENT_REACTION
 from packit_service.worker.events import (
@@ -59,6 +59,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -71,6 +72,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -83,6 +85,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {TestingFarmHandler},
@@ -96,6 +99,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             set(),
@@ -109,6 +113,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -121,6 +126,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -133,6 +139,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -145,6 +152,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -158,6 +166,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildStartHandler},
@@ -170,6 +179,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildEndHandler},
@@ -183,6 +193,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildStartHandler},
@@ -195,6 +206,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildEndHandler},
@@ -208,6 +220,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {TestingFarmResultsHandler},
@@ -221,6 +234,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiBuildHandler},
@@ -233,6 +247,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiBuildHandler},
@@ -245,6 +260,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiBuildHandler},
@@ -257,6 +273,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiBuildHandler},
@@ -269,6 +286,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiBuildHandler},
@@ -281,6 +299,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiTaskReportHandler},
@@ -294,10 +313,12 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler, TestingFarmHandler},
@@ -310,10 +331,12 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildStartHandler},
@@ -326,10 +349,12 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildEndHandler},
@@ -342,10 +367,12 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {TestingFarmResultsHandler},
@@ -359,14 +386,17 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -380,14 +410,17 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -400,14 +433,17 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -421,10 +457,12 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             set(),
@@ -438,18 +476,22 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler, TestingFarmHandler},
@@ -463,7 +505,11 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    skip_build=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            skip_build=True,
+                        )
+                    },
                 ),
             ],
             {TestingFarmHandler},
@@ -476,11 +522,16 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    skip_build=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            skip_build=True,
+                        )
+                    },
                 ),
             ],
             {CoprBuildHandler, TestingFarmHandler},
@@ -494,18 +545,22 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -519,18 +574,22 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildStartHandler},
@@ -544,18 +603,22 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildEndHandler},
@@ -569,18 +632,22 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {TestingFarmResultsHandler},
@@ -594,18 +661,22 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             set(),
@@ -620,14 +691,17 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {TestingFarmHandler},
@@ -641,14 +715,17 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -662,14 +739,17 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildStartHandler},
@@ -683,14 +763,17 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildEndHandler},
@@ -704,14 +787,17 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {TestingFarmResultsHandler},
@@ -725,14 +811,17 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             set(),
@@ -747,10 +836,12 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler, KojiBuildHandler},
@@ -764,10 +855,12 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildStartHandler},
@@ -781,10 +874,12 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiTaskReportHandler},
@@ -798,6 +893,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.koji_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {DownstreamKojiBuildHandler},
@@ -810,6 +906,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.koji_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiBuildReportHandler},
@@ -822,6 +919,7 @@ from packit_service.worker.result import TaskResults
                 JobConfig(
                     type=JobType.bodhi_update,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CreateBodhiUpdateHandler, KojiBuildReportHandler},
@@ -866,6 +964,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             set(),
@@ -881,6 +980,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             set(),
@@ -896,6 +996,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -911,6 +1012,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -926,6 +1028,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -941,6 +1044,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {TestingFarmHandler},
@@ -956,6 +1060,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {TestingFarmHandler},
@@ -971,6 +1076,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiBuildHandler},
@@ -986,7 +1092,11 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    skip_build=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            skip_build=True,
+                        )
+                    },
                 ),
             ],
             {TestingFarmHandler},
@@ -1002,7 +1112,11 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    skip_build=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            skip_build=True,
+                        )
+                    },
                 ),
             ],
             {TestingFarmHandler},
@@ -1018,6 +1132,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             set(),
@@ -1033,6 +1148,7 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -1087,6 +1203,7 @@ def test_get_handlers_for_comment_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -1101,7 +1218,11 @@ def test_get_handlers_for_comment_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="the-identifier",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="the-identifier",
+                        )
+                    },
                 ),
             ],
             {CoprBuildHandler},
@@ -1117,7 +1238,11 @@ def test_get_handlers_for_comment_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="the-identifier",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="the-identifier",
+                        )
+                    },
                 ),
             ],
             set(),
@@ -1133,6 +1258,7 @@ def test_get_handlers_for_comment_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             set(),
@@ -1148,6 +1274,7 @@ def test_get_handlers_for_comment_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {TestingFarmHandler},
@@ -1162,6 +1289,7 @@ def test_get_handlers_for_comment_event(
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiBuildHandler},
@@ -1176,6 +1304,7 @@ def test_get_handlers_for_comment_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {CoprBuildHandler},
@@ -1190,6 +1319,7 @@ def test_get_handlers_for_comment_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {TestingFarmHandler},
@@ -1204,6 +1334,7 @@ def test_get_handlers_for_comment_event(
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiBuildHandler},
@@ -1218,6 +1349,7 @@ def test_get_handlers_for_comment_event(
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {KojiBuildHandler},
@@ -1265,9 +1397,16 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
-            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
             id="build_for_pr&CoprBuildHandler&PullRequestGithubEvent",
         ),
         pytest.param(
@@ -1278,9 +1417,16 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
-            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
             id="build_for_pr&CoprBuildStartHandler&CoprBuildStartEvent",
         ),
         pytest.param(
@@ -1291,9 +1437,16 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
-            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
             id="build_for_pr&CoprBuildEndHandler&CoprBuildEndEvent",
         ),
         # Test only for pr:
@@ -1305,6 +1458,7 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             [],
@@ -1319,13 +1473,21 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
-            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
             id="build_for_pr+tests_for_pr&CoprBuildHandler&PullRequestGithubEvent",
         ),
         pytest.param(
@@ -1337,13 +1499,21 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
-            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
             id="test_for_pr+build_for_pr&CoprBuildHandler&PullRequestGithubEvent",
         ),
         # Multiple builds for pr:
@@ -1355,24 +1525,40 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
             ],
             id="build_for_pr_twice&CoprBuildHandler&PullRequestGithubEvent",
@@ -1386,24 +1572,40 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 )
             ],
             id="build_for_pr+build_for_commit+build_for_release"
@@ -1417,24 +1619,40 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
             ],
             id="build_for_pr+build_for_commit+build_for_release"
@@ -1448,24 +1666,40 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             id="build_for_pr+build_for_commit+build_for_release"
@@ -1480,17 +1714,29 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [],
@@ -1505,24 +1751,40 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
@@ -1536,24 +1798,40 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
@@ -1567,24 +1845,40 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
@@ -1598,24 +1892,40 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
@@ -1629,24 +1939,40 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
@@ -1661,29 +1987,49 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project0",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project0",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project0",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project0",
+                        )
+                    },
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1697,29 +2043,49 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project0",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project0",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1733,29 +2099,49 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project0",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project0",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1769,29 +2155,49 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project0",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project0",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project0",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project0",
+                        )
+                    },
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1805,29 +2211,49 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project0",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project0",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project0",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project0",
+                        )
+                    },
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1841,29 +2267,49 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project0",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project0",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.commit,
-                    project="project2",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project2",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.release,
-                    project="project3",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project3",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    project="project1",
+                    packages={
+                        "package": CommonPackageConfig(
+                            project="project1",
+                        )
+                    },
                 ),
             ],
             id="build_for_pr+tests_for_pr+build_for_commit+build_for_release"
@@ -1878,13 +2324,21 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
-            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
             id="build_for_pr+production_build_for_pr&CoprBuildHandler&PullRequestGithubEvent",
         ),
         pytest.param(
@@ -1895,16 +2349,19 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             id="build_for_pr+production_build_for_pr&KojiBuildHandler&PullRequestGithubEvent",
@@ -1917,16 +2374,19 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             id="build_for_pr+production_build_for_pr&KojiBuildReportHandler&KojiBuildEvent",
@@ -1940,9 +2400,16 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
-            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
             id="build_for_pr&CoprBuildHandler&PullRequestCommentGithubEvent",
         ),
         pytest.param(
@@ -1953,9 +2420,16 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
-            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
             id="build_for_pr&CoprBuildHandler&MergeRequestCommentGitlabEvent",
         ),
         pytest.param(
@@ -1966,9 +2440,16 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
-            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
             id="build_for_pr&CoprBuildHandler&PullRequestCommentPagureEvent",
         ),
         # Build comment for test defined:
@@ -1980,6 +2461,7 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             [],
@@ -1994,9 +2476,16 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
-            [JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.pull_request)],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                )
+            ],
             id="tests_for_pr&TestingFarmHandler&PullRequestCommentGithubEvent",
         ),
         # Propose update retrigger:
@@ -2008,12 +2497,14 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             [
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             id="propose_downstream_for_release&TestingFarmHandler&PullRequestCommentGithubEvent",
@@ -2026,12 +2517,14 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.koji_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             [
                 JobConfig(
                     type=JobType.koji_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             id="koji_build_for_commit&DownstreamKojiBuildHandler&PushPagureEvent",
@@ -2044,12 +2537,14 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.koji_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             [
                 JobConfig(
                     type=JobType.koji_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             id="koji_build_for_commit&KojiBuildReportHandler&KojiBuildEvent",
@@ -2062,12 +2557,14 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.bodhi_update,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             [
                 JobConfig(
                     type=JobType.bodhi_update,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             id="bodhi_update_for_commit&CreateBodhiUpdateHandler&KojiBuildEvent",
@@ -2080,12 +2577,14 @@ def test_get_handlers_for_check_rerun_event(
                 JobConfig(
                     type=JobType.bodhi_update,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             [
                 JobConfig(
                     type=JobType.bodhi_update,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
             id="bodhi_update_for_commit&KojiBuildReportHandler&KojiBuildEvent",
@@ -2287,16 +2786,19 @@ def test_handler_doesnt_match_to_job(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {},
@@ -2308,41 +2810,19 @@ def test_handler_doesnt_match_to_job(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
-                ),
-            ],
-            {},
-        ),
-        pytest.param(
-            PullRequestCommentGithubEvent,
-            JobConfigTriggerType.release,
-            [
-                JobConfig(
-                    type=JobType.build,
-                    trigger=JobConfigTriggerType.pull_request,
-                ),
-                JobConfig(
-                    type=JobType.propose_downstream,
-                    trigger=JobConfigTriggerType.release,
-                ),
-                JobConfig(
-                    type=JobType.propose_downstream,
-                    trigger=JobConfigTriggerType.release,
-                ),
-            ],
-            [
-                JobConfig(
-                    type=JobType.propose_downstream,
-                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {},
@@ -2354,10 +2834,41 @@ def test_handler_doesnt_match_to_job(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                ),
+                JobConfig(
+                    type=JobType.propose_downstream,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                ),
+                JobConfig(
+                    type=JobType.propose_downstream,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.propose_downstream,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            PullRequestCommentGithubEvent,
+            JobConfigTriggerType.release,
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             [],
@@ -2370,12 +2881,14 @@ def test_handler_doesnt_match_to_job(
                 JobConfig(
                     type=JobType.koji_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.koji_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {},
@@ -2387,20 +2900,24 @@ def test_handler_doesnt_match_to_job(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.koji_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.koji_build,
                     trigger=JobConfigTriggerType.commit,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             {},
@@ -2412,19 +2929,31 @@ def test_handler_doesnt_match_to_job(
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="first",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="first",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="second",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="second",
+                        )
+                    },
                 ),
             ],
             [
                 JobConfig(
                     type=JobType.build,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="first",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="first",
+                        )
+                    },
                 ),
             ],
             {"job_identifier": "first"},
@@ -2459,12 +2988,20 @@ def test_get_jobs_matching_trigger(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="foo",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="foo",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="bar",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="bar",
+                        )
+                    },
                 ),
             ],
             TestingFarmResultsHandler,
@@ -2477,10 +3014,12 @@ def test_get_jobs_matching_trigger(
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 ),
             ],
             TestingFarmResultsHandler,

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -9,10 +9,11 @@ from flexmock import flexmock
 from ogr.abstract import GitProject
 from packit.api import PackitAPI
 from packit.config import (
-    PackageConfig,
+    CommonPackageConfig,
     JobConfig,
-    JobType,
     JobConfigTriggerType,
+    JobType,
+    PackageConfig,
 )
 from packit.exceptions import PackitCommandFailedError
 from packit.upstream import Upstream
@@ -73,13 +74,20 @@ def build_helper(
         JobConfig(
             type=JobType.upstream_koji_build,
             trigger=trigger or JobConfigTriggerType.pull_request,
-            _targets=_targets,
-            owner=owner,
-            scratch=scratch,
+            packages={
+                "package": CommonPackageConfig(
+                    _targets=_targets,
+                    owner=owner,
+                    scratch=scratch,
+                )
+            },
         )
     )
 
-    pkg_conf = PackageConfig(jobs=jobs, downstream_package_name="dummy")
+    pkg_conf = PackageConfig(
+        jobs=jobs,
+        packages={"package": CommonPackageConfig(downstream_package_name="dummy")},
+    )
     handler = KojiBuildJobHelper(
         service_config=ServiceConfig(),
         package_config=pkg_conf,

--- a/tests/unit/test_propose_downstream.py
+++ b/tests/unit/test_propose_downstream.py
@@ -4,7 +4,7 @@
 import pytest
 from flexmock import flexmock
 
-from packit.config import PackageConfig, JobConfig, JobType
+from packit.config import CommonPackageConfig, PackageConfig, JobConfig, JobType
 from packit.config.job_config import JobConfigTriggerType
 from packit_service.config import ServiceConfig
 from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJobHelper
@@ -18,7 +18,11 @@ from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJo
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
-                    dist_git_branches=["main", "f34"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            dist_git_branches=["main", "f34"],
+                        )
+                    },
                 ),
             ],
             JobConfigTriggerType.release,
@@ -30,7 +34,11 @@ from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJo
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
-                    dist_git_branches=["f34", "main"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            dist_git_branches=["f34", "main"],
+                        )
+                    },
                 ),
             ],
             JobConfigTriggerType.release,
@@ -42,7 +50,11 @@ from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJo
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
-                    dist_git_branches=["f35", "f34"],
+                    packages={
+                        "package": CommonPackageConfig(
+                            dist_git_branches=["f35", "f34"],
+                        )
+                    },
                 ),
             ],
             JobConfigTriggerType.release,
@@ -54,6 +66,7 @@ from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJo
                 JobConfig(
                     type=JobType.propose_downstream,
                     trigger=JobConfigTriggerType.release,
+                    packages={"packages": CommonPackageConfig()},
                 ),
             ],
             JobConfigTriggerType.release,
@@ -69,7 +82,9 @@ def test_branches(jobs, job_config_trigger_type, branches_override, branches):
     flexmock(ServiceConfig, get_project=lambda url: project)
     propose_downstream_helper = ProposeDownstreamJobHelper(
         service_config=ServiceConfig(),
-        package_config=PackageConfig(jobs=jobs),
+        package_config=PackageConfig(
+            jobs=jobs, packages={"package": CommonPackageConfig()}
+        ),
         job_config=jobs[0],
         project=flexmock(),
         metadata=flexmock(pr_id=None),

--- a/tests/unit/test_srpm_logs.py
+++ b/tests/unit/test_srpm_logs.py
@@ -11,10 +11,11 @@ from flexmock import flexmock
 from ogr.abstract import GitProject
 from packit.api import PackitAPI
 from packit.config import (
-    PackageConfig,
+    CommonPackageConfig,
     JobConfig,
-    JobType,
     JobConfigTriggerType,
+    JobType,
+    PackageConfig,
 )
 from packit_service.config import ServiceConfig
 from packit_service.models import SRPMBuildModel
@@ -48,13 +49,20 @@ def build_helper(
         JobConfig(
             type=JobType.production_build,
             trigger=trigger or JobConfigTriggerType.pull_request,
-            _targets=_targets,
-            owner="nobody",
-            scratch=scratch,
+            packages={
+                "package": CommonPackageConfig(
+                    _targets=_targets,
+                    owner="nobody",
+                    scratch=scratch,
+                )
+            },
         )
     )
 
-    pkg_conf = PackageConfig(jobs=jobs, downstream_package_name="dummy")
+    pkg_conf = PackageConfig(
+        jobs=jobs,
+        packages={"package": CommonPackageConfig(downstream_package_name="dummy")},
+    )
     handler = KojiBuildJobHelper(
         service_config=ServiceConfig(),
         package_config=pkg_conf,

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -8,8 +8,13 @@ from flexmock import flexmock
 
 import packit_service.models
 import packit_service.service.urls as urls
-from packit.config import JobConfig, JobType, JobConfigTriggerType
-from packit.config.package_config import PackageConfig
+from packit.config import (
+    CommonPackageConfig,
+    JobConfig,
+    JobConfigTriggerType,
+    JobType,
+    PackageConfig,
+)
 from packit.local_project import LocalProject
 from packit_service.config import PackageConfigGetter, ServiceConfig
 from packit_service.models import JobTriggerModel, JobTriggerModelType, BuildStatus
@@ -83,6 +88,7 @@ def test_testing_farm_response(
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
                 )
             ],
         )
@@ -190,7 +196,11 @@ def test_distro2compose(target, compose, use_internal_tf):
         job_config=JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            use_internal_tf=use_internal_tf,
+            packages={
+                "package": CommonPackageConfig(
+                    use_internal_tf=use_internal_tf,
+                )
+            },
         ),
     )
     job_helper = flexmock(job_helper)
@@ -221,7 +231,11 @@ def test_distro2compose_for_aarch64(target, compose, use_internal_tf):
         job_config=JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            use_internal_tf=use_internal_tf,
+            packages={
+                "package": CommonPackageConfig(
+                    use_internal_tf=use_internal_tf,
+                )
+            },
         ),
     )
     job_helper = flexmock(job_helper)
@@ -572,9 +586,13 @@ def test_payload(
         job_config=JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            use_internal_tf=use_internal_tf,
-            tmt_plan=tmt_plan,
-            tf_post_install_script=tf_post_install_script,
+            packages={
+                "package": CommonPackageConfig(
+                    use_internal_tf=use_internal_tf,
+                    tmt_plan=tmt_plan,
+                    tf_post_install_script=tf_post_install_script,
+                )
+            },
         ),
     )
 
@@ -743,8 +761,12 @@ def test_test_repo(fmf_url, fmf_ref, result_url, result_ref):
         job_config=JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            fmf_url=fmf_url,
-            fmf_ref=fmf_ref,
+            packages={
+                "package": CommonPackageConfig(
+                    fmf_url=fmf_url,
+                    fmf_ref=fmf_ref,
+                )
+            },
         ),
     )
     job_helper = flexmock(job_helper)
@@ -829,11 +851,15 @@ def test_get_request_details():
 def test_trigger_build(copr_build, run_new_build, wait_for_build):
     valid_commit_sha = "1111111111111111111111111111111111111111"
 
-    package_config = PackageConfig()
+    package_config = PackageConfig(packages={"package": CommonPackageConfig()})
     job_config = JobConfig(
         type=JobType.tests,
-        spec_source_id=1,
         trigger=JobConfigTriggerType.pull_request,
+        packages={
+            "package": CommonPackageConfig(
+                spec_source_id=1,
+            )
+        },
     )
     job_config._files_to_sync_used = False
     package_config.jobs = [job_config]
@@ -897,7 +923,11 @@ def test_fmf_url(job_fmf_url, pr_id, fmf_url):
     job_config = JobConfig(
         trigger=JobConfigTriggerType.pull_request,
         type=JobType.tests,
-        fmf_url=job_fmf_url,
+        packages={
+            "package": CommonPackageConfig(
+                fmf_url=job_fmf_url,
+            )
+        },
     )
     metadata = flexmock(pr_id=pr_id)
 
@@ -934,7 +964,11 @@ def test_get_additional_builds():
     job_config = JobConfig(
         trigger=JobConfigTriggerType.pull_request,
         type=JobType.tests,
-        _targets=["test-target", "another-test-target"],
+        packages={
+            "package": CommonPackageConfig(
+                _targets=["test-target", "another-test-target"],
+            )
+        },
     )
     metadata = flexmock(
         event_dict={"comment": "/packit-dev test my-namespace/my-repo#10"}
@@ -986,7 +1020,11 @@ def test_get_additional_builds_pr_not_in_db():
     job_config = JobConfig(
         trigger=JobConfigTriggerType.pull_request,
         type=JobType.tests,
-        _targets=["test-target", "another-test-target"],
+        packages={
+            "package": CommonPackageConfig(
+                _targets=["test-target", "another-test-target"],
+            )
+        },
     )
     metadata = flexmock(
         event_dict={"comment": "/packit-dev test my-namespace/my-repo#10"}
@@ -1019,7 +1057,11 @@ def test_get_additional_builds_builds_not_in_db():
     job_config = JobConfig(
         trigger=JobConfigTriggerType.pull_request,
         type=JobType.tests,
-        _targets=["test-target", "another-test-target"],
+        packages={
+            "package": CommonPackageConfig(
+                _targets=["test-target", "another-test-target"],
+            )
+        },
     )
     metadata = flexmock(
         event_dict={"comment": "/packit-dev test my-namespace/my-repo#10"}
@@ -1059,7 +1101,11 @@ def test_get_additional_builds_wrong_format():
     job_config = JobConfig(
         trigger=JobConfigTriggerType.pull_request,
         type=JobType.tests,
-        _targets=["test-target", "another-test-target"],
+        packages={
+            "package": CommonPackageConfig(
+                _targets=["test-target", "another-test-target"],
+            )
+        },
     )
     metadata = flexmock(
         event_dict={"comment": "/packit-dev test my/namespace/my-repo#10"}
@@ -1173,7 +1219,11 @@ def test_get_artifacts(chroot, build, additional_build, result):
     job_config = JobConfig(
         trigger=JobConfigTriggerType.pull_request,
         type=JobType.tests,
-        _targets=["test-target", "another-test-target"],
+        packages={
+            "package": CommonPackageConfig(
+                _targets=["test-target", "another-test-target"],
+            )
+        },
     )
     metadata = flexmock(
         event_dict={"comment": "/packit-dev test my/namespace/my-repo#10"}
@@ -1205,7 +1255,11 @@ def test_get_artifacts(chroot, build, additional_build, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    use_internal_tf=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            use_internal_tf=True,
+                        )
+                    },
                 )
             ],
             {"event_type": "PullRequestGithubEvent"},
@@ -1217,12 +1271,20 @@ def test_get_artifacts(chroot, build, additional_build, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="public",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="public",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    use_internal_tf=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            use_internal_tf=True,
+                        )
+                    },
                 ),
             ],
             {"event_type": "PullRequestGithubEvent"},
@@ -1234,13 +1296,21 @@ def test_get_artifacts(chroot, build, additional_build, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="public",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="public",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    use_internal_tf=True,
-                    skip_build=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            use_internal_tf=True,
+                            skip_build=True,
+                        )
+                    },
                 ),
             ],
             {"event_type": "PullRequestGithubEvent"},
@@ -1252,12 +1322,20 @@ def test_get_artifacts(chroot, build, additional_build, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    identifier="public",
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="public",
+                        )
+                    },
                 ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    use_internal_tf=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            use_internal_tf=True,
+                        )
+                    },
                 ),
             ],
             {"event_type": "PullRequestCommentGithubEvent", "comment": "/packit test"},
@@ -1267,7 +1345,7 @@ def test_get_artifacts(chroot, build, additional_build, result):
     ],
 )
 def test_check_if_actor_can_run_job_and_report(jobs, event, should_pass):
-    package_config = PackageConfig()
+    package_config = PackageConfig(packages={"package": CommonPackageConfig()})
     package_config.jobs = jobs
 
     flexmock(PullRequestModel).should_receive("get_or_create").and_return(

--- a/tests_openshift/database/test_tasks.py
+++ b/tests_openshift/database/test_tasks.py
@@ -8,7 +8,13 @@ from munch import Munch
 
 import packit_service
 from ogr.services.github import GithubProject
-from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
+from packit.config import (
+    CommonPackageConfig,
+    PackageConfig,
+    JobConfig,
+    JobType,
+    JobConfigTriggerType,
+)
 from packit_service.models import (
     CoprBuildTargetModel,
     SRPMBuildModel,
@@ -81,18 +87,23 @@ def test_check_copr_build(clean_before_and_after, packit_build_752):
     )
     flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
         PackageConfig(
+            packages={"packit": CommonPackageConfig()},
             jobs=[
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    _targets=[
-                        "fedora-30-x86_64",
-                        "fedora-rawhide-x86_64",
-                        "fedora-31-x86_64",
-                        "fedora-32-x86_64",
-                    ],
+                    packages={
+                        "packit": CommonPackageConfig(
+                            _targets=[
+                                "fedora-30-x86_64",
+                                "fedora-rawhide-x86_64",
+                                "fedora-31-x86_64",
+                                "fedora-32-x86_64",
+                            ]
+                        )
+                    },
                 )
-            ]
+            ],
         )
     )
     coprs_response = Munch(

--- a/tests_openshift/openshift_integration/test_pkgtool.py
+++ b/tests_openshift/openshift_integration/test_pkgtool.py
@@ -12,7 +12,7 @@ from requre.online_replacing import (
 from requre.helpers.files import StoreFiles
 from requre.helpers.simple_object import Simple
 from requre.helpers.git.pushinfo import PushInfoStorageList
-from requre.helpers.tempfile import TempFile
+from requre.helpers.tempfile import MkTemp, MkDTemp
 from requre.helpers.git.fetchinfo import FetchInfoStorageList
 from requre.helpers.git.repo import Repo
 
@@ -64,10 +64,10 @@ from packit.pkgtool import PkgTool
     )
 )
 @apply_decorator_to_all_methods(
-    replace_module_match(what="tempfile.mkdtemp", decorate=TempFile.mkdtemp())
+    replace_module_match(what="tempfile.mkdtemp", decorate=MkDTemp.decorator_plain())
 )
 @apply_decorator_to_all_methods(
-    replace_module_match(what="tempfile.mktemp", decorate=TempFile.mktemp())
+    replace_module_match(what="tempfile.mktemp", decorate=MkTemp.decorator_plain())
 )
 # Be aware that decorator stores login and token to test_data, replace it by some value.
 # Default precommit hook doesn't do that for copr.v3.helpers, see README.md


### PR DESCRIPTION
packit/packit#1727 changes the config schema and objects in a backwards incompatible way.

Update (mainly the tests) to acomodate for this.

Merge after the PR above is merged.