### PR TITLE
Remove _test_check_names attribute from BaseBuildJobHelper

### DIFF
--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -62,7 +62,6 @@ class BaseBuildJobHelper(BaseJobHelper):
         self.pushgateway = pushgateway
 
         # lazy properties
-        self._test_check_names: Optional[List[str]] = None
         self._build_check_names: Optional[List[str]] = None
         self._srpm_model: Optional[SRPMBuildModel] = None
         self._srpm_path: Optional[Path] = None
@@ -372,12 +371,10 @@ class BaseBuildJobHelper(BaseJobHelper):
 
         e.g. ["testing-farm:fedora-rawhide-x86_64"]
         """
-        if not self._test_check_names:
-            self._test_check_names = [
-                self.get_test_check_cls(target, test_job_config.identifier)
-                for target in self.tests_targets_for_test_job(test_job_config)
-            ]
-        return self._test_check_names
+        return [
+            self.get_test_check_cls(target, test_job_config.identifier)
+            for target in self.tests_targets_for_test_job(test_job_config)
+        ]
 
     def create_srpm_if_needed(self) -> Optional[TaskResults]:
         """

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -85,6 +85,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         self._copr_builds_from_other_pr: Optional[
             Dict[str, CoprBuildTargetModel]
         ] = None
+        self._test_check_names: Optional[List[str]] = None
 
     @property
     def tft_api_url(self) -> str:


### PR DESCRIPTION
For BaseBuildJobHelper, methods reporting the testing farm job statuses work with job configs passed
in method arguments, therefore it doesn't make sense to store the results in the attribute and reuse it. Move this to TestingFarmJobHelper where we handle always only one test job and therefore it makes sense to store it there.


(Testing the changed functionality [here](https://github.com/lbarcziova/hello-world/pull/2), this affects only `report_status_to_all`, otherwise, the changes look good so far...)


Related to #1717

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
