### PR TITLE
Skip actor pre_check if actor not present

### DIFF
--- a/packit_service/worker/checker/abstract.py
+++ b/packit_service/worker/checker/abstract.py
@@ -1,3 +1,4 @@
+import logging
 from abc import abstractmethod
 from typing import Optional
 
@@ -6,6 +7,8 @@ from packit.config.package_config import PackageConfig
 
 from packit_service.worker.events import EventData
 from packit_service.worker.mixin import ConfigMixin, PackitAPIWithDownstreamMixin
+
+logger = logging.getLogger(__name__)
 
 
 class Checker(ConfigMixin, PackitAPIWithDownstreamMixin):
@@ -35,5 +38,6 @@ class ActorChecker(Checker):
 
     def pre_check(self) -> bool:
         if not self.actor:
-            return False
+            logger.debug("Actor not set for this event, skipping the actor check.")
+            return True
         return self._pre_check()

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -188,6 +188,30 @@ def test_precheck_push_to_a_different_branch(github_push_event):
     assert not CoprBuildHandler.pre_check(package_config, job_config, event)
 
 
+def test_precheck_push_actor_check(github_push_event):
+    flexmock(GitBranchModel).should_receive("get_or_create").and_return(
+        flexmock(id=1, job_config_trigger_type=JobConfigTriggerType.commit)
+    )
+
+    package_config = PackageConfig(
+        jobs=[
+            JobConfig(
+                type=JobType.copr_build,
+                trigger=JobConfigTriggerType.commit,
+                branch="branch",
+            ),
+        ]
+    )
+    job_config = JobConfig(
+        type=JobType.copr_build,
+        trigger=JobConfigTriggerType.commit,
+        branch="branch",
+    )
+    event = github_push_event.get_dict()
+    actor_checker = CoprBuildHandler.get_checkers()[1]
+    assert actor_checker(package_config, job_config, event).pre_check()
+
+
 def test_precheck_koji_build_non_scratch(github_pr_event):
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=342,


### PR DESCRIPTION
This should make the behaviour the same as it was previously (before handler pre_checks refactoring
https://github.com/packit/packit-service/blob/da94cc9b511843d73e9b94d20677f0b1d1426bf8/packit_service/worker/jobs.py#L422): if the actor is None, the actor pre_check will be skipped (e.g. pushes to branch, releases).

---

RELEASE NOTES BEGIN

RELEASE NOTES END
