### PR TITLE
tests: install deepdiff in the test image

### DIFF
--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -19,4 +19,5 @@
           - pytest
           - pytest-cov
           - pytest-flask
+          - deepdiff
         executable: pip3


### PR DESCRIPTION
To be used to make comparing large dict-like objects friendlier.

Related to #1722.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>