### PR TITLE
Don't calculate the retrigger message during __init__()

### DIFF
--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -94,7 +94,10 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             pushgateway=pushgateway,
         )
         self.celery_task = celery_task
-        self.msg_retrigger: str = MSG_RETRIGGER.format(
+
+    @property
+    def msg_retrigger(self) -> str:
+        return MSG_RETRIGGER.format(
             job="build",
             command="copr-build" if self.job_build else "build",
             place="pull request",

--- a/packit_service/worker/helpers/build/koji_build.py
+++ b/packit_service/worker/helpers/build/koji_build.py
@@ -53,15 +53,18 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
             build_targets_override=build_targets_override,
             tests_targets_override=tests_targets_override,
         )
-        self.msg_retrigger: str = MSG_RETRIGGER.format(
+
+        # Lazy properties
+        self._supported_koji_targets = None
+
+    @property
+    def msg_retrigger(self) -> str:
+        return MSG_RETRIGGER.format(
             job="build",
             command="upstream-koji-build",
             place="pull request",
             packit_comment_command_prefix=self.service_config.comment_command_prefix,
         )
-
-        # Lazy properties
-        self._supported_koji_targets = None
 
     @property
     def is_scratch(self) -> bool:

--- a/packit_service/worker/helpers/job_helper.py
+++ b/packit_service/worker/helpers/job_helper.py
@@ -39,7 +39,6 @@ class BaseJobHelper:
         self.package_config = package_config
         self.project: GitProject = project
         self.db_trigger = db_trigger
-        self.msg_retrigger: Optional[str] = ""
         self.metadata: EventData = metadata
         self.run_model: Optional[PipelineModel] = None
         self.pushgateway = pushgateway
@@ -52,6 +51,10 @@ class BaseJobHelper:
         self._pr_id: Optional[int] = None
         self._is_reporting_allowed: Optional[bool] = None
         self._is_gitlab_instance: Optional[bool] = None
+
+    @property
+    def msg_retrigger(self) -> str:
+        return ""
 
     @property
     def local_project(self) -> LocalProject:

--- a/packit_service/worker/helpers/propose_downstream.py
+++ b/packit_service/worker/helpers/propose_downstream.py
@@ -41,7 +41,6 @@ class ProposeDownstreamJobHelper(BaseJobHelper):
             job_config=job_config,
         )
         self.branches_override = branches_override
-        self.msg_retrigger: str = ""
         self._check_names: Optional[List[str]] = None
         self._default_dg_branch: Optional[str] = None
         self._job: Optional[JobConfig] = None
@@ -58,6 +57,10 @@ class ProposeDownstreamJobHelper(BaseJobHelper):
 
     def get_check(self, branch: str = None) -> str:
         return self.get_check_cls(branch, identifier=self.job_config.identifier)
+
+    @property
+    def msg_retrigger(self) -> str:
+        return ""
 
     @property
     def check_names(self) -> List[str]:

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -819,7 +819,6 @@ def test_get_request_details():
     flexmock(
         TFJobHelper,
         send_testing_farm_request=request_response,
-        job_build=None,
     )
     details = TFJobHelper.get_request_details(request_id)
     assert details == request


### PR DESCRIPTION
This way it can be avoided to have further properties calculated during __init__().

This way we can avoid calculating the 'job_build' property, which caused issues after TestingFarmJobHelper.get_request_details() was modified in e666087f to pass None as package_config, instead of a dummy PackageConfig object.

Test this by not mocking the job_build attribute of TestingFarmJobHelper in test_get_request_details().

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>