### PR TITLE
Do not bump with empty release_suffix

### DIFF
--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -425,12 +425,17 @@ class BaseBuildJobHelper(BaseJobHelper):
         )
         self._srpm_model.set_start_time(datetime.datetime.utcnow())
 
+        bump_version = (
+            self.job_config.release_suffix  # do not modify version if release suffix is ''
+            and self.job_config.trigger
+            != JobConfigTriggerType.release  # do not modify version for release
+        )
+
         try:
             self._srpm_path = Path(
                 self.api.create_srpm(
                     srpm_dir=self.api.up.local_project.working_dir,
-                    bump_version=self.job_config.trigger
-                    != JobConfigTriggerType.release,
+                    bump_version=bump_version,
                     release_suffix=self.job_config.release_suffix,
                 )
             )


### PR DESCRIPTION
Do bump means do update version.
The bump flag wins over the release_suffix value,
this is obvious when using the command line tool
but less natural when using packit-service.
Since the code is the same for both CLI and service we need to force the bump flag, calculated by the service,
 to be False when release suffix is empty.

fixes packit/packit#1695

---

RELEASE NOTES BEGIN
Packit as a service will no modify a package version when release suffix in config is empty.
RELEASE NOTES END
