### PR TITLE
tests: move 'skip_build' from package- to the job-level

### DIFF
--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -2837,10 +2837,10 @@ def test_copr_build_invalid_copr_project_name(github_pr_event):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    skip_build=True,
                     packages={
                         "package": CommonPackageConfig(
                             use_internal_tf=True,
-                            skip_build=True,
                         )
                     },
                 ),
@@ -2858,9 +2858,9 @@ def test_copr_build_invalid_copr_project_name(github_pr_event):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    skip_build=True,
                     packages={
                         "package": CommonPackageConfig(
-                            skip_build=True,
                             identifier="public",
                         )
                     },

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -1304,10 +1304,10 @@ def test_get_artifacts(chroot, build, additional_build, result):
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
+                    skip_build=True,
                     packages={
                         "package": CommonPackageConfig(
                             use_internal_tf=True,
-                            skip_build=True,
                         )
                     },
                 ),


### PR DESCRIPTION
This configuration is only needed in jobs.

Related to packit/packit#1770.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

Merge after packit/packit#1770.