### PR TITLE
Move monitoring.py:measure_time() to utils.py:elapsed_seconds()

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -55,6 +55,7 @@ from sqlalchemy.types import ARRAY
 from packit.config import JobConfigTriggerType
 from packit.exceptions import PackitException
 from packit_service.constants import ALLOWLIST_CONSTANTS
+from packit_service.utils import get_timezone_aware_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -1388,7 +1389,8 @@ class SRPMBuildModel(ProjectAndTriggersConnector, Base):
             sa_session()
             .query(SRPMBuildModel)
             .filter(
-                SRPMBuildModel.build_submitted_time < delta_ago,
+                get_timezone_aware_datetime(SRPMBuildModel.build_submitted_time)
+                < delta_ago,
                 SRPMBuildModel.logs.isnot(None),
             )
         )

--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -7,7 +7,6 @@ from io import StringIO
 from logging import StreamHandler
 from typing import List, Tuple
 
-
 from packit.config import JobConfig, PackageConfig
 from packit.schema import JobConfigSchema, PackageConfigSchema
 from packit.utils import PackitFormatter
@@ -143,15 +142,31 @@ def is_timezone_naive_datetime(datetime_to_check: datetime) -> bool:
 
 def get_timezone_aware_datetime(datetime_to_update: datetime) -> datetime:
     """
-    Set timezone for datetime so that it is timezone-aware.
+    Make the datetime object timezone aware (utc) if needed.
 
     Args:
-        datetime_to_update: datetime to update
+        datetime_to_update: datetime to check and update
 
     Result:
         timezone-aware datetime
     """
-    return datetime_to_update.replace(tzinfo=timezone.utc)
+    if is_timezone_naive_datetime(datetime_to_update):
+        return datetime_to_update.replace(tzinfo=timezone.utc)
+    return datetime_to_update
+
+
+def elapsed_seconds(begin: datetime, end: datetime) -> float:
+    """
+    Make the datetime objects timezone aware (utc) if needed
+    and measure time between them in seconds.
+
+    Returns:
+        elapsed seconds between begin and end
+    """
+    begin = get_timezone_aware_datetime(begin)
+    end = get_timezone_aware_datetime(end)
+
+    return (end - begin).total_seconds()
 
 
 def get_packit_commands_from_comment(

--- a/packit_service/worker/database.py
+++ b/packit_service/worker/database.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-from datetime import timedelta, datetime
+from datetime import timedelta
 from gzip import open as gzip_open
 from logging import getLogger, DEBUG, INFO
 from os import getenv
@@ -28,9 +28,8 @@ def discard_old_srpm_build_logs():
     )
     ago = timedelta(days=int(outdated_after_days))
     for build in SRPMBuildModel.get_older_than(ago):
-        age = datetime.utcnow() - build.build_submitted_time
         logger.debug(
-            f"SRPM build {build.id}, age '{age}' is older than '{ago}'. "
+            f"SRPM build {build.id} is older than '{ago}'. "
             "Discarding log and artifact url."
         )
         build.set_logs(None)

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -25,7 +25,7 @@ from packit_service.service.urls import (
     get_testing_farm_info_url,
     get_copr_build_info_url,
 )
-from packit_service.utils import dump_job_config, dump_package_config
+from packit_service.utils import dump_job_config, dump_package_config, elapsed_seconds
 from packit_service.worker.checker.abstract import Checker
 from packit_service.worker.checker.testing_farm import (
     CanActorRunJob,
@@ -52,7 +52,6 @@ from packit_service.worker.handlers.abstract import (
     RetriableJobHandler,
 )
 from packit_service.worker.helpers.testing_farm import TestingFarmJobHelper
-from packit_service.worker.monitoring import measure_time
 from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 from packit_service.worker.result import TaskResults
 from packit_service.worker.handlers.mixin import (
@@ -329,8 +328,8 @@ class TestingFarmResultsHandler(JobHandler):
             self.pushgateway.test_runs_started.inc()
         else:
             self.pushgateway.test_runs_finished.inc()
-            test_run_time = measure_time(
-                end=datetime.now(timezone.utc), begin=test_run_model.submitted_time
+            test_run_time = elapsed_seconds(
+                begin=test_run_model.submitted_time, end=datetime.now(timezone.utc)
             )
             self.pushgateway.test_run_finished_time.observe(test_run_time)
 

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -52,11 +52,11 @@ from packit_service.service.urls import (
     get_copr_build_info_url,
     get_srpm_build_info_url,
 )
-from packit_service.utils import get_package_nvrs
+from packit_service.utils import get_package_nvrs, elapsed_seconds
 from packit_service.worker.celery_task import CeleryTask
 from packit_service.worker.helpers.build.build_helper import BaseBuildJobHelper
 from packit_service.worker.events import EventData
-from packit_service.worker.monitoring import Pushgateway, measure_time
+from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.reporting import BaseCommitStatus, DuplicateCheckMode
 from packit_service.worker.result import TaskResults
 
@@ -405,8 +405,8 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         Measure the time it took to set the failed status in case of event (e.g. failed SRPM)
         that prevents Copr build to be submitted.
         """
-        time = measure_time(
-            end=datetime.now(timezone.utc), begin=self.metadata.task_accepted_time
+        time = elapsed_seconds(
+            begin=self.metadata.task_accepted_time, end=datetime.now(timezone.utc)
         )
         for _ in range(number_of_builds):
             self.pushgateway.copr_build_not_submitted_time.labels(

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -21,7 +21,7 @@ from packit_service.constants import (
     COMMENT_REACTION,
     PACKIT_VERIFY_FAS_COMMAND,
 )
-from packit_service.utils import get_packit_commands_from_comment
+from packit_service.utils import get_packit_commands_from_comment, elapsed_seconds
 from packit_service.worker.allowlist import Allowlist
 from packit_service.worker.events import (
     Event,
@@ -55,7 +55,7 @@ from packit_service.worker.helpers.build import (
 )
 from packit_service.worker.helpers.propose_downstream import ProposeDownstreamJobHelper
 from packit_service.worker.helpers.testing_farm import TestingFarmJobHelper
-from packit_service.worker.monitoring import Pushgateway, measure_time
+from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.parser import Parser
 from packit_service.worker.reporting import BaseCommitStatus
 from packit_service.worker.result import TaskResults
@@ -664,8 +664,8 @@ class SteveJobs:
             number_of_build_targets: Number of build targets in case of CoprBuildHandler.
         """
         pushgateway = Pushgateway()
-        response_time = measure_time(
-            end=task_accepted_time, begin=self.event.created_at
+        response_time = elapsed_seconds(
+            begin=self.event.created_at, end=task_accepted_time
         )
         logger.debug(f"Reporting initial status time: {response_time} seconds.")
         pushgateway.initial_status_time.observe(response_time)

--- a/packit_service/worker/monitoring.py
+++ b/packit_service/worker/monitoring.py
@@ -3,29 +3,10 @@
 
 import logging
 import os
-from datetime import datetime
 
 from prometheus_client import CollectorRegistry, Counter, push_to_gateway, Histogram
 
-from packit_service.utils import is_timezone_naive_datetime, get_timezone_aware_datetime
-
 logger = logging.getLogger(__name__)
-
-
-def measure_time(begin: datetime, end: datetime) -> float:
-    """
-    Make the datetime objects timezone aware (utc) if needed
-    and measure time between them in seconds.
-
-    Returns:
-        float seconds between begin and end
-    """
-    if is_timezone_naive_datetime(begin):
-        begin = get_timezone_aware_datetime(begin)
-    if is_timezone_naive_datetime(end):
-        end = get_timezone_aware_datetime(end)
-
-    return (end - begin).total_seconds()
 
 
 class Pushgateway:

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from boto3.s3.transfer import S3Transfer
@@ -12,7 +12,7 @@ from packit_service.worker import database
 
 
 def test_cleanup_old_srpm_build_logs():
-    srpm_build = flexmock(id=1, build_submitted_time=datetime.utcnow())
+    srpm_build = flexmock(id=1, build_submitted_time=datetime.now(timezone.utc))
     flexmock(srpm_build).should_receive("set_logs").with_args(None).once()
     flexmock(srpm_build).should_receive("set_url").with_args(None).once()
     flexmock(SRPMBuildModel).should_receive("get_older_than").and_return(

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -5,7 +5,7 @@
 A book with our finest spells
 """
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, List, Tuple
 from packit_service.worker.result import TaskResults
@@ -46,5 +46,5 @@ def squash_the_message_structure_like_listener(message):
     # Some older message used a `msg` key
     body = message.get("body") or message.get("msg")
     body["topic"] = message["topic"]
-    body["timestamp"] = datetime.utcnow().timestamp()
+    body["timestamp"] = datetime.now(timezone.utc).timestamp()
     return body

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,13 +1,16 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-from packit_service.models import optional_time
-from datetime import datetime
+from datetime import datetime, timezone
+
 import pytest
+
+from packit_service.models import optional_time
 
 
 @pytest.mark.parametrize(
-    "input_object,expected_type", [(datetime.utcnow(), str), (None, type(None))]
+    "input_object,expected_type",
+    [(datetime.now(timezone.utc), str), (None, type(None))],
 )
 def test_optional_time(input_object, expected_type):
     # optional_time returns a string if its passed a datetime object

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from celery import Signature
@@ -100,7 +100,7 @@ def test_testing_farm_response(
         url="https://github.com/packit/ogr"
     ).and_return()
     config.should_receive("get_github_account_name").and_return("packit-as-a-service")
-    created_dt = datetime.utcnow()
+    created_dt = datetime.now(timezone.utc)
     event_dict = TFResultsEvent(
         pipeline_id="id",
         result=tests_result,


### PR DESCRIPTION
so it's together with `is_timezone_naive_datetime()` and `get_timezone_aware_datetime()`

- Change `get_timezone_aware_datetime()` so that it calls `is_timezone_naive_datetime()` first
- Changed some `datetime.utcnow()` to `datetime.now(timezone.utc)`

Initially, I just wanted to fix all [the Sourcery warnings](https://docs.sourcery.ai/Reference/Built-in-Rules/suggestions/aware-datetime-for-utc) (to create timezone-aware datetime objects instead of timezone-naive).
In the database, we however still store the values timezone-naive, so we have to use `utcnow()` when setting those values.

We already have the above functions (added in #1251) for safe comparison/subtraction of timezone-aware and timezone-naive values (to avoid `TypeError`), but the ultimate solution would be to change the DateTimes in the database to be timezone-aware. (#1749 )