### PR TITLE
Don't pass get_timezone_aware_datetime() to Query.filter()

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -55,7 +55,6 @@ from sqlalchemy.types import ARRAY
 from packit.config import JobConfigTriggerType
 from packit.exceptions import PackitException
 from packit_service.constants import ALLOWLIST_CONSTANTS
-from packit_service.utils import get_timezone_aware_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -1389,8 +1388,7 @@ class SRPMBuildModel(ProjectAndTriggersConnector, Base):
             sa_session()
             .query(SRPMBuildModel)
             .filter(
-                get_timezone_aware_datetime(SRPMBuildModel.build_submitted_time)
-                < delta_ago,
+                SRPMBuildModel.build_submitted_time < delta_ago,
                 SRPMBuildModel.logs.isnot(None),
             )
         )


### PR DESCRIPTION
reverts one hunk from f04b3737

The comparison is done in the database so the function is not needed.

Fixes #1752
