### PR TITLE
sentry: log also DEBUG level in issues

### DIFF
--- a/packit_service/sentry_integration.py
+++ b/packit_service/sentry_integration.py
@@ -7,6 +7,7 @@ from os import getenv
 from typing import List
 
 from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 from packit_service.utils import only_once
 
@@ -53,6 +54,13 @@ def configure_sentry(
         from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 
         integrations.append(SqlalchemyIntegration())
+
+    # https://docs.sentry.io/platforms/python/guides/logging/
+    sentry_logging = LoggingIntegration(
+        level=logging.DEBUG,  # Log everything, from DEBUG and above
+        event_level=logging.ERROR,  # Send errors as events
+    )
+    integrations.append(sentry_logging)
 
     sentry_sdk.init(
         secret_key,


### PR DESCRIPTION
sentry provides INFO logs by default inside issues: this is not enough
when we investigate issues as we provide valuable information in these
statements, let's give this a try!

More info: https://docs.sentry.io/platforms/python/guides/logging/


Fixes #1718

---

RELEASE NOTES BEGIN
N/A￼
RELEASE NOTES END