### PR TITLE
Access srpm_build_deps from JobConfig object

### DIFF
--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -122,7 +122,7 @@ class CoprBuildHandler(RetriableJobHandler, GetCoprBuildJobHelperMixin):
         installed_at = self.get_packit_github_installation_time()
         if installed_at:
             installed_at = get_timezone_aware_datetime(installed_at)
-        if self.package_config.srpm_build_deps is not None or (
+        if self.job_config.srpm_build_deps is not None or (
             installed_at and installed_at > DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR
         ):
             return self.copr_build_helper.run_copr_build_from_source_script()

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -538,7 +538,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                     # use the latest stable chroot
                     script_chroot=self.get_latest_fedora_stable_chroot(),
                     script_builddeps=self.get_packit_copr_download_urls()
-                    + (self.package_config.srpm_build_deps or []),
+                    + (self.job_config.srpm_build_deps or []),
                     buildopts=buildopts,
                 )
             else:

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -2296,7 +2296,7 @@ def test_run_copr_build_from_source_script(
             job_trigger_model_type=JobTriggerModelType.pull_request,
         ),
     )
-    helper.package_config.srpm_build_deps = srpm_build_deps
+    helper.job_config.srpm_build_deps = srpm_build_deps
     flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
         type=JobTriggerModelType.pull_request, trigger_id=123
     ).and_return(flexmock(id=2, type=JobTriggerModelType.pull_request))
@@ -2392,7 +2392,7 @@ def test_run_copr_build_from_source_script_github_outage_retry(
         ),
         task=CeleryTask(flexmock(request=flexmock(retries=retry_number))),
     )
-    helper.package_config.srpm_build_deps = ["make", "findutils"]
+    helper.job_config.srpm_build_deps = ["make", "findutils"]
     flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
         type=JobTriggerModelType.pull_request, trigger_id=123
     ).and_return(flexmock(id=2, type=JobTriggerModelType.pull_request))


### PR DESCRIPTION
This will enable using srpm_build_deps on the job level while defining on top-level will still work because of the implemented inheriting global values. In packit there is [a test for the inheritance](https://github.com/packit/packit/blob/2e316980c3a00156fa7d3ac313dc53304e1dcf95/tests/unit/test_package_config.py#L2029) where `srpm_build_deps` is checked as well.

Fixes #1715

---

RELEASE NOTES BEGIN
`srpm_build_deps` can be now configured also on the job configuration level.
RELEASE NOTES END
