### PR TITLE
Fix a typo in the failure message

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -451,9 +451,8 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             self.report_status_to_tests(
                 description="We were not able to get any Copr builds for given additional PR. "
                 "Please, make sure the comment command is in correct format "
-                "`/packit test repo/namespace#pr_id`",
+                "`/packit test namespace/repo#pr_id`",
                 state=BaseCommitStatus.error,
-                url="",
             )
             return False
 


### PR DESCRIPTION
A typo was introduced in packit/packit-service#1658 where the `namespace` and `repo` were in the wrong order. 

Also removed the parameter `url` as the default value for `url` in `report_status_to_tests` is already an empty string.
