### PR TITLE
fix(build logs URL): make logs available while building

### DIFF
--- a/packit_service/worker/events/copr.py
+++ b/packit_service/worker/events/copr.py
@@ -151,7 +151,7 @@ class AbstractCoprBuildEvent(AbstractForgeIndependentEvent):
         return (
             "https://download.copr.fedorainfracloud.org/"
             f"results/{self.owner}/{self.project_name}/{self.chroot}/"
-            f"{self.build_id:08d}{pkg}/builder-live.log.gz"
+            f"{self.build_id:08d}{pkg}/builder-live.log"
         )
 
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -915,7 +915,7 @@ class TestEvents:
 
         assert event_object.get_copr_build_logs_url() == (
             "https://download.copr.fedorainfracloud.org/results/packit/"
-            "packit-service-hello-world-24/fedora-rawhide-x86_64/01044215-hello/builder-live.log.gz"
+            "packit-service-hello-world-24/fedora-rawhide-x86_64/01044215-hello/builder-live.log"
         )
 
         flexmock(PackageConfigGetter).should_receive(

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -605,7 +605,7 @@ def test_payload(
     job_helper.should_receive("job_project").and_return(copr_project)
 
     # URLs shortened for clarity
-    log_url = "https://copr-be.cloud.fedoraproject.org/results/.../builder-live.log.gz"
+    log_url = "https://copr-be.cloud.fedoraproject.org/results/.../builder-live.log"
     srpm_url = (
         f"https://download.copr.fedorainfracloud.org/results/.../{repo}-0.1-1.src.rpm"
     )
@@ -777,7 +777,7 @@ def test_test_repo(fmf_url, fmf_ref, result_url, result_ref):
 
     build_id = 1
     # URLs shortened for clarity
-    log_url = "https://copr-be.cloud.fedoraproject.org/results/.../builder-live.log.gz"
+    log_url = "https://copr-be.cloud.fedoraproject.org/results/.../builder-live.log"
     srpm_url = (
         f"https://download.copr.fedorainfracloud.org/results/.../{repo}-0.1-1.src.rpm"
     )


### PR DESCRIPTION
.log.gz - available once the build is done

.log - available sooner: while the build is running

thanks @praiskup!


TODO:

- [x] Write new tests or update the old ones to cover new functionality.

Fixes #1714

---

RELEASE NOTES BEGIN
The Copr build logs URL now points to logs that are available even while building.
RELEASE NOTES END