### PR TITLE
fix(build logs URL formatting): strings → int cast

### DIFF
--- a/packit_service/worker/helpers/build/babysit.py
+++ b/packit_service/worker/helpers/build/babysit.py
@@ -141,7 +141,8 @@ def check_pending_copr_builds() -> None:
     pending_copr_builds = CoprBuildTargetModel.get_all_by_status(BuildStatus.pending)
     builds_grouped_by_id = collections.defaultdict(list)
     for build in pending_copr_builds:
-        builds_grouped_by_id[build.build_id].append(build)
+        # our DB uses str(build_id) but our code expects int(build_id)
+        builds_grouped_by_id[int(build.build_id)].append(build)
 
     for build_id, builds in builds_grouped_by_id.items():
         update_copr_builds(build_id, builds)
@@ -257,7 +258,9 @@ def update_copr_build_state(
         return
     event = event_kls(
         topic=FedmsgTopic.copr_build_finished.value,
-        build_id=build.build_id,
+        build_id=int(
+            build.build_id
+        ),  # we expect int there even though we have str in DB
         build=build,
         chroot=build.target,
         status=(

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -94,7 +94,7 @@ def test_check_copr_build_already_successful():
 def test_check_copr_build_updated(build_status):
     db_build = (
         flexmock(
-            build_id=55,
+            build_id="55",
             status=build_status,
             build_submitted_time=datetime.datetime.utcnow(),
             target="the-target",
@@ -174,7 +174,7 @@ def test_check_copr_build_updated(build_status):
 def test_check_copr_build_waiting_started():
     db_build = (
         flexmock(
-            build_id=55,
+            build_id="55",
             status=BuildStatus.waiting_for_srpm,
             build_submitted_time=datetime.datetime.utcnow(),
             target="the-target",
@@ -258,7 +258,7 @@ def test_check_copr_build_waiting_started():
 def test_check_copr_build_waiting_already_started():
     db_build = (
         flexmock(
-            build_id=55,
+            build_id="55",
             status=BuildStatus.waiting_for_srpm,
             build_submitted_time=datetime.datetime.utcnow(),
             target="the-target",
@@ -385,7 +385,7 @@ def test_check_update_copr_builds_timeout():
     )
     build = flexmock(
         status=BuildStatus.pending,
-        build_id=1,
+        build_id="1",
         build_submitted_time=datetime.datetime.utcnow() - datetime.timedelta(weeks=2),
     )
     build.should_receive("set_status").with_args(BuildStatus.error).once()
@@ -407,9 +407,9 @@ def test_check_pending_copr_builds_no_builds():
 
 
 def test_check_pending_copr_builds():
-    build1 = flexmock(status=BuildStatus.pending, build_id=1)
-    build2 = flexmock(status=BuildStatus.pending, build_id=2)
-    build3 = flexmock(status=BuildStatus.pending, build_id=1)
+    build1 = flexmock(status=BuildStatus.pending, build_id="1")
+    build2 = flexmock(status=BuildStatus.pending, build_id="2")
+    build3 = flexmock(status=BuildStatus.pending, build_id="1")
     flexmock(CoprBuildTargetModel).should_receive("get_all_by_status").with_args(
         BuildStatus.pending
     ).and_return([build1, build2, build3])

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -934,8 +934,9 @@ class TestEvents:
         assert event_object.project.full_repo_name == "packit/packit"
         assert not event_object.identifier
 
+    @pytest.mark.parametrize("build_id", (1044215, "1044215"))
     def test_parse_copr_build_event_start(
-        self, copr_build_results_start, copr_build_pr
+        self, copr_build_results_start, copr_build_pr, build_id
     ):
         flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
             copr_build_pr
@@ -945,7 +946,7 @@ class TestEvents:
 
         assert isinstance(event_object, AbstractCoprBuildEvent)
         assert event_object.topic == FedmsgTopic.copr_build_started
-        assert event_object.build_id == 1044215
+        assert event_object.build_id == int(build_id)
         assert event_object.chroot == "fedora-rawhide-x86_64"
         assert event_object.status == 3
         assert event_object.owner == "packit"


### PR DESCRIPTION
For some reason, Copr build models use build_id as str but in code, we
expect it to be int.

This commit fixes formatting of build_id to construct a build logs URL.

Fixes PCKT-002-PACKIT-SERVICE-4WT