### PR TITLE
Default execution pool type is based on concurrency

### DIFF
--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -40,7 +40,12 @@ elif [[ "${CELERY_COMMAND}" == "worker" ]]; then
     # Options: prefork | eventlet | gevent | solo
     # https://www.distributedpython.com/2018/10/26/celery-execution-pool/
     DEFAULT_POOL="solo"
-    POOL="${POOL:-$DEFAULT_POOL}"
+    DEFAULT_CONCURRENCY_POOL="gevent"
+    if ((CONCURRENCY > 1)); then
+      POOL="${POOL:-$DEFAULT_CONCURRENCY_POOL}"
+    else
+      POOL="${POOL:-$DEFAULT_POOL}"
+    fi
 
     # if this worker serves the long-running queue, it needs the repository cache
     if [[ "$QUEUES" == *"long-running"* ]]; then

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -86,6 +86,7 @@ if is_multi_threaded():
     # Downside of a single session is that if postgres is (oom)killed and a transaction
     # fails to rollback you have to restart the workers so that they pick another session.
     singleton_session = Session()
+    logger.debug("Going to use a single SQLAlchemy session.")
 else:  # service/httpd
     Session = scoped_session(Session)
     singleton_session = None


### PR DESCRIPTION
i.e. it's now `gevent` if `CONCURRENCY > 1`.
So that we don't have to (but still can) set the `POOL` explicitly.