### PR TITLE
Export variables set in run_worker.sh

### DIFF
--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -36,6 +36,7 @@ elif [[ "${CELERY_COMMAND}" == "worker" ]]; then
     # Number of concurrent worker threads executing tasks.
     DEFAULT_CONCURRENCY="1"
     CONCURRENCY="${CONCURRENCY:-$DEFAULT_CONCURRENCY}"
+    export CONCURRENCY
 
     # Options: prefork | eventlet | gevent | solo
     # https://www.distributedpython.com/2018/10/26/celery-execution-pool/
@@ -46,6 +47,7 @@ elif [[ "${CELERY_COMMAND}" == "worker" ]]; then
     else
       POOL="${POOL:-$DEFAULT_POOL}"
     fi
+    export POOL
 
     # if this worker serves the long-running queue, it needs the repository cache
     if [[ "$QUEUES" == *"long-running"* ]]; then


### PR DESCRIPTION
Initially, they were used only in the same script to pass arguments to `celery worker` command. But now we use them also in [models.py](https://github.com/packit/packit-service/blob/0d907f93052b727fe55e23529471ae3d38e0b80e/packit_service/models.py#L79) to see whether we're running multi-threaded. This change is needed when we don't explicitly set `POOL` as pod's env. variable, but set it in the script based on the `CONCURRENCY` value (5eb8c83743).
