### PR TITLE
SLO1: raise limit from 15s to 30s

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -668,8 +668,8 @@ class SteveJobs:
         )
         logger.debug(f"Reporting initial status time: {response_time} seconds.")
         pushgateway.initial_status_time.observe(response_time)
-        if response_time > 15:
-            pushgateway.no_status_after_15_s.inc()
+        if response_time > 30:
+            pushgateway.no_status_after_30_s.inc()
             # https://github.com/packit/packit-service/issues/1728
             # we need more info why this has happened
             logger.debug(f"Event dict: {self.event}.")

--- a/packit_service/worker/monitoring.py
+++ b/packit_service/worker/monitoring.py
@@ -56,9 +56,9 @@ class Pushgateway:
             registry=self.registry,
         )
 
-        self.no_status_after_15_s = Counter(
-            "no_status_after_15_s",
-            "Number of PRs/commits with no commit status for more than 15s",
+        self.no_status_after_30_s = Counter(
+            "no_status_after_30_s",
+            "Number of PRs/commits with no commit status for more than 30s",
             registry=self.registry,
         )
 


### PR DESCRIPTION
    If a job defines a lot of targets (10+), we can easily run out of SLO1
    because it takes 1s to set one check. With the current implementation,
    we measure how long it took to set every single status line - even the
    last one.
    
    We want to preserve this to be sure all are set in a reasonable time.
    
Precise description:
https://github.com/packit/packit-service/issues/1728#issuecomment-1326534470
    
Fixes #1728


RELEASE NOTES BEGIN
We have changed the limit for our [SLO1](https://packit.dev/docs/service-level-objectives/#slo1-changes-to-github-prs-receive-a-status-update-within-15-seconds-in-99-of-cases): it was increased from 15s to 30s to account for setting all statuses.
RELEASE NOTES END