### PR TITLE
The old job names now cause error states

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -420,13 +420,12 @@ class SteveJobs:
         if deprecation_msg := DEPRECATED_JOB_TYPES.get(job_config.type):
             job_helper = self.initialize_job_helper(handler_kls, job_config)
             job_helper.status_reporter.report(
-                state=BaseCommitStatus.neutral,  # TODO: change to warning in Nov 2022
+                state=BaseCommitStatus.error,
                 description=f"Job name `{job_config.type.name}` deprecated.",
                 url=f"{DOCS_CONFIGURATION_URL}/#supported-jobs",
                 check_names=f"config-deprecation-{job_config.type.name}",
                 markdown_content=f"{deprecation_msg}\n\n"
-                "This status will be switched to a warning since November "
-                "and the support for the old name will be removed "
+                "The support for the old name will be removed "
                 "by the end of the year.",
             )
 

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -420,7 +420,7 @@ def test_check_rerun_pr_koji_build_handler_old_job_name(
         {"rawhide", "f34"}
     )
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
-        state=BaseCommitStatus.neutral,
+        state=BaseCommitStatus.error,
         description="Job name `production_build` deprecated.",
         check_name="config-deprecation-production_build",
         url="https://packit.dev/docs/configuration/#supported-jobs",
@@ -433,8 +433,7 @@ def test_check_rerun_pr_koji_build_handler_old_job_name(
         "non-scratch/production builds.) "
         "To be explicit, use `upstream_koji_build` for builds triggered in upstream and "
         "`koji_build` for builds triggered in downstream.\n\n"
-        "This status will be switched to a warning since November and "
-        "the support for the old name will be removed by the end of the year.",
+        "The support for the old name will be removed by the end of the year.",
     ).once()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.pending,


### PR DESCRIPTION
Signed-off-by: Frantisek Lachman <flachman@redhat.com>

---

RELEASE NOTES BEGIN
The job names deprecated in October (`build` alias of `copr_build` and `production_build` replaced by `upstream_koji_build`) newly lead to an error state (was `neutral` ) of the deprecated status created by Packit.
The old names will be removed by the end of the year.
RELEASE NOTES END
