### PR TITLE
Create group models

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,15 @@ more easily, with rootless podman, you can use our make target.
 Both expect that the `alembic upgrade head` is run in [run_httpd.sh](files/run_httpd.sh)
 during (packit-)service pod/container start.
 
+When modifying the migration manually, do not forget to update the downgrade
+path as well. You can test that downgrade of the last migration passes by
+running `alembic downgrade -1` in the service pod/container.
+Make sure that the migration is self-sufficient and does not rely on models in
+the `models.py` module. Otherwise, if the models change in the future, it would
+not be possible to run the migrations in the correct order.
+To satisfy this, add the state of models required by your migration to the
+migration itself (i.e. copy the model from `models.py`)
+
 #### with docker:
 
     $ docker-compose up service
@@ -161,6 +170,10 @@ ERROR [alembic.util.messaging] Target database is not up to date.
 Chances are that the _packit service pod_ is not properly started or
 for some reasons it is not running the
 `alembic upgrade head` command.
+It could also mean that your changes are too complicated for alembic
+to autogenerate a migration. In such case, run the `alembic revision`
+command without `--autogenerate` to create just the template and
+write the migration commands manually.
 
 ### How to check what's inside postgres?
 

--- a/alembic/versions/68ce6a306b30_add_koji_build_groups.py
+++ b/alembic/versions/68ce6a306b30_add_koji_build_groups.py
@@ -1,0 +1,449 @@
+"""Add Koji build groups
+
+Revision ID: 68ce6a306b30
+Revises: 9fe0e970880f
+Create Date: 2022-11-29 10:24:00.722554
+
+"""
+import collections
+import enum
+import itertools
+from datetime import datetime
+from typing import TYPE_CHECKING, List
+
+from packit_service.models import ProjectAndTriggersConnector
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy.orm
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Enum,
+    Table,
+    ForeignKey,
+    JSON,
+    Text,
+    Boolean,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.ext.declarative import declarative_base
+
+if TYPE_CHECKING:
+    Base = object
+else:
+    Base = declarative_base()
+
+
+# revision identifiers, used by Alembic.
+revision = "68ce6a306b30"
+down_revision = "9fe0e970880f"
+branch_labels = None
+depends_on = None
+
+
+tf_copr_association_table = Table(
+    "tf_copr_build_association_table",
+    Base.metadata,  # type: ignore
+    Column("copr_id", ForeignKey("copr_build_targets.id"), primary_key=True),
+    Column("tft_id", ForeignKey("tft_test_run_targets.id"), primary_key=True),
+)
+
+
+class JobTriggerModelType(str, enum.Enum):
+    pull_request = "pull_request"
+    branch_push = "branch_push"
+    release = "release"
+    issue = "issue"
+
+
+class JobTriggerModel(Base):
+    __tablename__ = "job_triggers"
+    id = Column(Integer, primary_key=True)  # our database PK
+    type = Column(Enum(JobTriggerModelType))
+    trigger_id = Column(Integer, index=True)
+
+    runs = relationship("PipelineModel", back_populates="job_trigger")
+
+
+class PipelineModel(Base):
+    __tablename__ = "pipelines"
+    id = Column(Integer, primary_key=True)  # our database PK
+    # datetime.utcnow instead of datetime.utcnow() because it's an argument to the function,
+    # so it will run when the model is initiated, not when the table is made
+    datetime = Column(DateTime, default=datetime.utcnow)
+
+    job_trigger_id = Column(Integer, ForeignKey("job_triggers.id"))
+    job_trigger = relationship("JobTriggerModel", back_populates="runs")
+
+    srpm_build_id = Column(Integer, ForeignKey("srpm_builds.id"), index=True)
+    srpm_build = relationship("SRPMBuildModel", back_populates="runs")
+    copr_build_group_id = Column(
+        Integer, ForeignKey("copr_build_groups.id"), index=True
+    )
+    copr_build_group = relationship("CoprBuildGroupModel", back_populates="runs")
+    koji_build_group_id = Column(
+        Integer, ForeignKey("koji_build_groups.id"), index=True
+    )
+    koji_build_group = relationship("KojiBuildGroupModel", back_populates="runs")
+    koji_build_id = Column(Integer, ForeignKey("koji_build_targets.id"), index=True)
+    koji_build = relationship("KojiBuildTargetModel", back_populates="runs")
+    test_run_group_id = Column(
+        Integer, ForeignKey("tft_test_run_groups.id"), index=True
+    )
+    test_run_group = relationship("TFTTestRunGroupModel", back_populates="runs")
+    sync_release_run_id = Column(
+        Integer, ForeignKey("sync_release_runs.id"), index=True
+    )
+    sync_release_run = relationship("SyncReleaseModel", back_populates="runs")
+
+
+class TestingFarmResult(str, enum.Enum):
+    __test__ = False
+
+    new = "new"
+    queued = "queued"
+    running = "running"
+    passed = "passed"
+    failed = "failed"
+    skipped = "skipped"
+    error = "error"
+    unknown = "unknown"
+    needs_inspection = "needs_inspection"
+
+
+class TFTTestRunTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "tft_test_run_targets"
+    id = Column(Integer, primary_key=True)
+    pipeline_id = Column(String, index=True)
+    identifier = Column(String)
+    commit_sha = Column(String)
+    status = Column(Enum(TestingFarmResult))
+    target = Column(String)
+    web_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the model is initiated, not when the table is made
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    data = Column(JSON)
+    tft_test_run_group_id = Column(Integer, ForeignKey("tft_test_run_groups.id"))
+    copr_builds = relationship(
+        "CoprBuildTargetModel",
+        secondary=tf_copr_association_table,
+        backref="tft_test_run_targets",
+    )
+
+    group_of_targets = relationship(
+        "TFTTestRunGroupModel", back_populates="tft_test_run_targets"
+    )
+
+
+class BuildStatus(str, enum.Enum):
+    success = "success"
+    pending = "pending"
+    failure = "failure"
+    error = "error"
+    waiting_for_srpm = "waiting_for_srpm"
+
+
+class CoprBuildTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "copr_build_targets"
+    id = Column(Integer, primary_key=True)
+    build_id = Column(String, index=True)  # copr build id
+
+    # commit sha of the PR (or a branch, release) we used for a build
+    commit_sha = Column(String, index=True)
+    # what's the build status?
+    status = Column(Enum(BuildStatus))
+    # chroot, but we use the word target in our docs
+    target = Column(String)
+    # URL to copr web ui for the particular build
+    web_url = Column(String)
+    # url to copr build logs
+    build_logs_url = Column(String)
+    # for monitoring: time when we set the status about accepted task
+    task_accepted_time = Column(DateTime)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the copr build is initiated, not when the table is made
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+
+    # project name as shown in copr
+    project_name = Column(String)
+    owner = Column(String)
+
+    # metadata for the build which didn't make it to schema yet
+    # metadata is reserved to sqlalch
+    data = Column(JSON)
+
+    # info about built packages we get from Copr, e.g.
+    # [
+    #   {
+    #       "arch": "noarch",
+    #       "epoch": 0,
+    #       "name": "python3-packit",
+    #       "release": "1.20210930124525726166.main.0.g0b7b36b.fc36",
+    #       "version": "0.38.0",
+    #   }
+    # ]
+    built_packages = Column(JSON)
+    copr_build_group_id = Column(Integer, ForeignKey("copr_build_groups.id"))
+
+    group_of_targets = relationship(
+        "CoprBuildGroupModel", back_populates="copr_build_targets"
+    )
+
+
+class SRPMBuildModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "srpm_builds"
+    id = Column(Integer, primary_key=True)
+    status = Column(Enum(BuildStatus))
+    # our logs we want to show to the user
+    logs = Column(Text)
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+    commit_sha = Column(String)
+    # url for downloading the SRPM
+    url = Column(Text)
+    # attributes for SRPM built by Copr
+    logs_url = Column(Text)
+    copr_build_id = Column(String, index=True)
+    copr_web_url = Column(Text)
+
+    runs = relationship("PipelineModel", back_populates="srpm_build")
+
+
+class KojiBuildTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "koji_build_targets"
+    id = Column(Integer, primary_key=True)
+    build_id = Column(String, index=True)  # koji build id
+
+    # commit sha of the PR (or a branch, release) we used for a build
+    commit_sha = Column(String)
+    # what's the build status?
+    status = Column(String)
+    # chroot, but we use the word target in our docs
+    target = Column(String)
+    # URL to koji web ui for the particular build
+    web_url = Column(String)
+    # url to koji build logs
+    build_logs_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the koji build is initiated, not when the table is made
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+
+    # metadata for the build which didn't make it to schema yet
+    # metadata is reserved to sqlalch
+    data = Column(JSON)
+
+    # it is a scratch build?
+    scratch = Column(Boolean)
+    koji_build_group_id = Column(Integer, ForeignKey("koji_build_groups.id"))
+
+    group_of_targets = relationship(
+        "KojiBuildGroupModel", back_populates="koji_build_targets"
+    )
+    runs = relationship("PipelineModel", back_populates="koji_build")
+
+
+class SyncReleaseTargetStatus(str, enum.Enum):
+    queued = "queued"
+    running = "running"
+    error = "error"
+    retry = "retry"
+    submitted = "submitted"
+
+
+class SyncReleaseTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "sync_release_run_targets"
+    id = Column(Integer, primary_key=True)
+    branch = Column(String, default="unknown")
+    downstream_pr_url = Column(String)
+    status = Column(Enum(SyncReleaseTargetStatus))
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    start_time = Column(DateTime)
+    finished_time = Column(DateTime)
+    logs = Column(Text)
+    sync_release_id = Column(Integer, ForeignKey("sync_release_runs.id"))
+
+    sync_release = relationship(
+        "SyncReleaseModel", back_populates="sync_release_targets"
+    )
+
+
+class SyncReleaseStatus(str, enum.Enum):
+    running = "running"
+    finished = "finished"
+    error = "error"
+
+
+class SyncReleaseJobType(str, enum.Enum):
+    pull_from_upstream = "pull_from_upstream"
+    propose_downstream = "propose_downstream"
+
+
+class SyncReleaseModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "sync_release_runs"
+    id = Column(Integer, primary_key=True)
+    status = Column(Enum(SyncReleaseStatus))
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    job_type = Column(
+        Enum(SyncReleaseJobType), default=SyncReleaseJobType.propose_downstream
+    )
+
+    runs = relationship("PipelineModel", back_populates="sync_release_run")
+    sync_release_targets = relationship(
+        "SyncReleaseTargetModel", back_populates="sync_release"
+    )
+
+
+class GroupModel:
+    @property
+    def grouped_targets(self):
+        raise NotImplementedError
+
+
+class TFTTestRunGroupModel(ProjectAndTriggersConnector, GroupModel, Base):
+    __tablename__ = "tft_test_run_groups"
+    id = Column(Integer, primary_key=True)
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+
+    runs = relationship("PipelineModel", back_populates="test_run_group")
+    tft_test_run_targets = relationship(
+        "TFTTestRunTargetModel", back_populates="group_of_targets"
+    )
+
+    @property
+    def grouped_targets(self) -> List["TFTTestRunTargetModel"]:
+        return self.tft_test_run_targets
+
+
+class CoprBuildGroupModel(ProjectAndTriggersConnector, GroupModel, Base):
+    __tablename__ = "copr_build_groups"
+    id = Column(Integer, primary_key=True)
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+
+    runs = relationship("PipelineModel", back_populates="copr_build_group")
+    copr_build_targets = relationship(
+        "CoprBuildTargetModel", back_populates="group_of_targets"
+    )
+
+    @property
+    def grouped_targets(self) -> List["CoprBuildTargetModel"]:
+        return self.copr_build_targets
+
+
+class KojiBuildGroupModel(ProjectAndTriggersConnector, GroupModel, Base):
+    __tablename__ = "koji_build_groups"
+    id = Column(Integer, primary_key=True)
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+
+    runs = relationship("PipelineModel", back_populates="koji_build_group")
+    koji_build_targets = relationship(
+        "KojiBuildTargetModel", back_populates="group_of_targets"
+    )
+
+    @property
+    def grouped_targets(self):
+        return self.koji_build_targets
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+
+    op.create_table(
+        "koji_build_groups",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("submitted_time", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "koji_build_targets",
+        sa.Column("koji_build_group_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        None,
+        "koji_build_targets",
+        "koji_build_groups",
+        ["koji_build_group_id"],
+        ["id"],
+    )
+    op.add_column(
+        "pipelines", sa.Column("koji_build_group_id", sa.Integer(), nullable=True)
+    )
+    op.create_foreign_key(
+        None, "pipelines", "koji_build_groups", ["koji_build_group_id"], ["id"]
+    )
+
+    # Group by the same SRPM
+    srpm_ids = collections.defaultdict(list)
+    for koji_build in session.query(KojiBuildTargetModel):
+        srpm_ids[koji_build.runs[0].srpm_build.id].append(koji_build.id)
+
+    for srpm_id, builds in srpm_ids.items():
+        group = KojiBuildGroupModel()
+        for build_id in builds:
+            build = (
+                session.query(KojiBuildTargetModel)
+                .filter(KojiBuildTargetModel.id == build_id)
+                .one()
+            )
+            group.grouped_targets.append(build)
+
+        session.add(group)
+
+        # Link the pipeline to groups
+        # TODO: should we merge the groups? This would result in deletion and possibly some mess
+        for pipeline in (
+            session.query(PipelineModel)
+            .filter(PipelineModel.srpm_build_id == srpm_id)
+            .filter(PipelineModel.koji_build_id.is_not(None))
+        ):
+            pipeline.koji_build_group = group
+            session.add(pipeline)
+
+    op.drop_constraint("runs_koji_build_id_fkey", "pipelines")
+    op.drop_column("pipelines", "koji_build_id")
+
+    session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+
+    op.add_column("pipelines", sa.Column("koji_build_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "runs_koji_build_id_fkey",
+        "pipelines",
+        "koji_build_targets",
+        ["koji_build_id"],
+        ["id"],
+    )
+
+    # Split the groups back, this may not fully produce the same thing.
+    for group in session.query(KojiBuildGroupModel):
+        for pipeline, koji_build in itertools.zip_longest(
+            group.runs, group.koji_build_targets
+        ):
+            if not pipeline:
+                # Not enough pipelines, create a new one
+                pipeline = PipelineModel()
+            if not koji_build:
+                continue
+            pipeline.koji_build = koji_build
+            session.add(pipeline)
+
+    op.drop_constraint(
+        "koji_build_targets_koji_build_group_id_fkey", "koji_build_targets"
+    )
+    op.drop_column("koji_build_targets", "koji_build_group_id")
+    op.drop_constraint("pipelines_koji_build_group_id_fkey", "pipelines")
+    op.drop_column("pipelines", "koji_build_group_id")
+    op.drop_table("koji_build_groups")
+    session.commit()

--- a/alembic/versions/70c369f7ba80_add_explicit_mapping_of_tf_to_copr.py
+++ b/alembic/versions/70c369f7ba80_add_explicit_mapping_of_tf_to_copr.py
@@ -1,0 +1,317 @@
+"""Add explicit mapping of TF to Copr
+
+Revision ID: 70c369f7ba80
+Revises: f5792581522c
+Create Date: 2022-11-27 20:20:00.136412
+
+"""
+import enum
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from packit_service.models import ProjectAndTriggersConnector
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy.orm
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Enum,
+    Table,
+    ForeignKey,
+    JSON,
+    Text,
+    Boolean,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.ext.declarative import declarative_base
+
+if TYPE_CHECKING:
+    Base = object
+else:
+    Base = declarative_base()
+
+# revision identifiers, used by Alembic.
+revision = "70c369f7ba80"
+down_revision = "f5792581522c"
+branch_labels = None
+depends_on = None
+
+tf_copr_association_table = Table(
+    "tf_copr_build_association_table",
+    Base.metadata,  # type: ignore
+    Column("copr_id", ForeignKey("copr_build_targets.id"), primary_key=True),
+    Column("tft_id", ForeignKey("tft_test_run_targets.id"), primary_key=True),
+)
+
+
+class JobTriggerModelType(str, enum.Enum):
+    pull_request = "pull_request"
+    branch_push = "branch_push"
+    release = "release"
+    issue = "issue"
+
+
+class JobTriggerModel(Base):
+    __tablename__ = "job_triggers"
+    id = Column(Integer, primary_key=True)  # our database PK
+    type = Column(Enum(JobTriggerModelType))
+    trigger_id = Column(Integer, index=True)
+
+    runs = relationship("PipelineModel", back_populates="job_trigger")
+
+
+class PipelineModel(Base):
+    __tablename__ = "pipelines"
+    id = Column(Integer, primary_key=True)  # our database PK
+    # datetime.utcnow instead of datetime.utcnow() because it's an argument to the function,
+    # so it will run when the model is initiated, not when the table is made
+    datetime = Column(DateTime, default=datetime.utcnow)
+
+    job_trigger_id = Column(Integer, ForeignKey("job_triggers.id"))
+    job_trigger = relationship("JobTriggerModel", back_populates="runs")
+
+    srpm_build_id = Column(Integer, ForeignKey("srpm_builds.id"), index=True)
+    srpm_build = relationship("SRPMBuildModel", back_populates="runs")
+    copr_build_id = Column(Integer, ForeignKey("copr_build_targets.id"), index=True)
+    copr_build = relationship("CoprBuildTargetModel", back_populates="runs")
+    koji_build_id = Column(Integer, ForeignKey("koji_build_targets.id"), index=True)
+    koji_build = relationship("KojiBuildTargetModel", back_populates="runs")
+    test_run_id = Column(Integer, ForeignKey("tft_test_run_targets.id"), index=True)
+    test_run = relationship("TFTTestRunTargetModel", back_populates="runs")
+    sync_release_run_id = Column(
+        Integer, ForeignKey("sync_release_runs.id"), index=True
+    )
+    sync_release_run = relationship("SyncReleaseModel", back_populates="runs")
+
+
+class TestingFarmResult(str, enum.Enum):
+    __test__ = False
+
+    new = "new"
+    queued = "queued"
+    running = "running"
+    passed = "passed"
+    failed = "failed"
+    skipped = "skipped"
+    error = "error"
+    unknown = "unknown"
+    needs_inspection = "needs_inspection"
+
+
+class TFTTestRunTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "tft_test_run_targets"
+    id = Column(Integer, primary_key=True)
+    pipeline_id = Column(String, index=True)
+    identifier = Column(String)
+    commit_sha = Column(String)
+    status = Column(Enum(TestingFarmResult))
+    target = Column(String)
+    web_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the model is initiated, not when the table is made
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    data = Column(JSON)
+    copr_builds = relationship(
+        "CoprBuildTargetModel",
+        secondary=tf_copr_association_table,
+        backref="tft_test_run_targets",
+    )
+
+    runs = relationship("PipelineModel", back_populates="test_run")
+
+
+class BuildStatus(str, enum.Enum):
+    success = "success"
+    pending = "pending"
+    failure = "failure"
+    error = "error"
+    waiting_for_srpm = "waiting_for_srpm"
+
+
+class CoprBuildTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "copr_build_targets"
+    id = Column(Integer, primary_key=True)
+    build_id = Column(String, index=True)  # copr build id
+
+    # commit sha of the PR (or a branch, release) we used for a build
+    commit_sha = Column(String, index=True)
+    # what's the build status?
+    status = Column(Enum(BuildStatus))
+    # chroot, but we use the word target in our docs
+    target = Column(String)
+    # URL to copr web ui for the particular build
+    web_url = Column(String)
+    # url to copr build logs
+    build_logs_url = Column(String)
+    # for monitoring: time when we set the status about accepted task
+    task_accepted_time = Column(DateTime)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the copr build is initiated, not when the table is made
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+
+    # project name as shown in copr
+    project_name = Column(String)
+    owner = Column(String)
+
+    # metadata for the build which didn't make it to schema yet
+    # metadata is reserved to sqlalch
+    data = Column(JSON)
+
+    # info about built packages we get from Copr, e.g.
+    # [
+    #   {
+    #       "arch": "noarch",
+    #       "epoch": 0,
+    #       "name": "python3-packit",
+    #       "release": "1.20210930124525726166.main.0.g0b7b36b.fc36",
+    #       "version": "0.38.0",
+    #   }
+    # ]
+    built_packages = Column(JSON)
+
+    runs = relationship("PipelineModel", back_populates="copr_build")
+
+
+class SRPMBuildModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "srpm_builds"
+    id = Column(Integer, primary_key=True)
+    status = Column(Enum(BuildStatus))
+    # our logs we want to show to the user
+    logs = Column(Text)
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+    commit_sha = Column(String)
+    # url for downloading the SRPM
+    url = Column(Text)
+    # attributes for SRPM built by Copr
+    logs_url = Column(Text)
+    copr_build_id = Column(String, index=True)
+    copr_web_url = Column(Text)
+
+    runs = relationship("PipelineModel", back_populates="srpm_build")
+
+
+class KojiBuildTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "koji_build_targets"
+    id = Column(Integer, primary_key=True)
+    build_id = Column(String, index=True)  # koji build id
+
+    # commit sha of the PR (or a branch, release) we used for a build
+    commit_sha = Column(String)
+    # what's the build status?
+    status = Column(String)
+    # chroot, but we use the word target in our docs
+    target = Column(String)
+    # URL to koji web ui for the particular build
+    web_url = Column(String)
+    # url to koji build logs
+    build_logs_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the koji build is initiated, not when the table is made
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+
+    # metadata for the build which didn't make it to schema yet
+    # metadata is reserved to sqlalch
+    data = Column(JSON)
+
+    # it is a scratch build?
+    scratch = Column(Boolean)
+
+    runs = relationship("PipelineModel", back_populates="koji_build")
+
+
+class SyncReleaseTargetStatus(str, enum.Enum):
+    queued = "queued"
+    running = "running"
+    error = "error"
+    retry = "retry"
+    submitted = "submitted"
+
+
+class SyncReleaseTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "sync_release_run_targets"
+    id = Column(Integer, primary_key=True)
+    branch = Column(String, default="unknown")
+    downstream_pr_url = Column(String)
+    status = Column(Enum(SyncReleaseTargetStatus))
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    start_time = Column(DateTime)
+    finished_time = Column(DateTime)
+    logs = Column(Text)
+    sync_release_id = Column(Integer, ForeignKey("sync_release_runs.id"))
+
+    sync_release = relationship(
+        "SyncReleaseModel", back_populates="sync_release_targets"
+    )
+
+
+class SyncReleaseStatus(str, enum.Enum):
+    running = "running"
+    finished = "finished"
+    error = "error"
+
+
+class SyncReleaseJobType(str, enum.Enum):
+    pull_from_upstream = "pull_from_upstream"
+    propose_downstream = "propose_downstream"
+
+
+class SyncReleaseModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "sync_release_runs"
+    id = Column(Integer, primary_key=True)
+    status = Column(Enum(SyncReleaseStatus))
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    job_type = Column(
+        Enum(SyncReleaseJobType), default=SyncReleaseJobType.propose_downstream
+    )
+
+    runs = relationship("PipelineModel", back_populates="sync_release_run")
+    sync_release_targets = relationship(
+        "SyncReleaseTargetModel", back_populates="sync_release"
+    )
+
+
+def upgrade():
+    # ### commands auto generated by Alembic - please adjust! ###
+    op.create_table(
+        "tf_copr_build_association_table",
+        sa.Column("copr_id", sa.Integer(), nullable=False),
+        sa.Column("tft_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["copr_id"],
+            ["copr_build_targets.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["tft_id"],
+            ["tft_test_run_targets.id"],
+        ),
+        sa.PrimaryKeyConstraint("copr_id", "tft_id"),
+    )
+
+    # Add the data
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+
+    for tf_run in session.query(TFTTestRunTargetModel):
+        if tf_run.copr_builds:
+            continue
+        builds = [run.copr_build for run in tf_run.runs if run and run.copr_build]
+        tf_run.copr_builds.extend(builds)
+        session.add(tf_run)
+
+    session.commit()
+
+
+def downgrade():
+    # ### commands auto generated by Alembic - please adjust! ###
+    op.drop_table("tf_copr_build_association_table")
+    # ### end Alembic commands ###

--- a/alembic/versions/9fe0e970880f_add_copr_build_groups.py
+++ b/alembic/versions/9fe0e970880f_add_copr_build_groups.py
@@ -1,0 +1,425 @@
+"""Add copr build groups
+
+Revision ID: 9fe0e970880f
+Revises: a9c49475e9c7
+Create Date: 2022-11-28 20:37:50.780407
+
+"""
+import collections
+import enum
+import itertools
+from datetime import datetime
+from typing import TYPE_CHECKING, List
+
+from packit_service.models import ProjectAndTriggersConnector
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy.orm
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Enum,
+    Table,
+    ForeignKey,
+    JSON,
+    Text,
+    Boolean,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.ext.declarative import declarative_base
+
+if TYPE_CHECKING:
+    Base = object
+else:
+    Base = declarative_base()
+
+
+# revision identifiers, used by Alembic.
+revision = "9fe0e970880f"
+down_revision = "a9c49475e9c7"
+branch_labels = None
+depends_on = None
+
+
+tf_copr_association_table = Table(
+    "tf_copr_build_association_table",
+    Base.metadata,  # type: ignore
+    Column("copr_id", ForeignKey("copr_build_targets.id"), primary_key=True),
+    Column("tft_id", ForeignKey("tft_test_run_targets.id"), primary_key=True),
+)
+
+
+class JobTriggerModelType(str, enum.Enum):
+    pull_request = "pull_request"
+    branch_push = "branch_push"
+    release = "release"
+    issue = "issue"
+
+
+class JobTriggerModel(Base):
+    __tablename__ = "job_triggers"
+    id = Column(Integer, primary_key=True)  # our database PK
+    type = Column(Enum(JobTriggerModelType))
+    trigger_id = Column(Integer, index=True)
+
+    runs = relationship("PipelineModel", back_populates="job_trigger")
+
+
+class PipelineModel(Base):
+    __tablename__ = "pipelines"
+    id = Column(Integer, primary_key=True)  # our database PK
+    # datetime.utcnow instead of datetime.utcnow() because it's an argument to the function,
+    # so it will run when the model is initiated, not when the table is made
+    datetime = Column(DateTime, default=datetime.utcnow)
+
+    job_trigger_id = Column(Integer, ForeignKey("job_triggers.id"))
+    job_trigger = relationship("JobTriggerModel", back_populates="runs")
+
+    srpm_build_id = Column(Integer, ForeignKey("srpm_builds.id"), index=True)
+    srpm_build = relationship("SRPMBuildModel", back_populates="runs")
+    copr_build_id = Column(Integer, ForeignKey("copr_build_targets.id"), index=True)
+    copr_build = relationship("CoprBuildTargetModel", back_populates="runs")
+    copr_build_group_id = Column(
+        Integer, ForeignKey("copr_build_groups.id"), index=True
+    )
+    copr_build_group = relationship("CoprBuildGroupModel", back_populates="runs")
+    koji_build_id = Column(Integer, ForeignKey("koji_build_targets.id"), index=True)
+    koji_build = relationship("KojiBuildTargetModel", back_populates="runs")
+    test_run_group_id = Column(
+        Integer, ForeignKey("tft_test_run_groups.id"), index=True
+    )
+    test_run_group = relationship("TFTTestRunGroupModel", back_populates="runs")
+    sync_release_run_id = Column(
+        Integer, ForeignKey("sync_release_runs.id"), index=True
+    )
+    sync_release_run = relationship("SyncReleaseModel", back_populates="runs")
+
+
+class TestingFarmResult(str, enum.Enum):
+    __test__ = False
+
+    new = "new"
+    queued = "queued"
+    running = "running"
+    passed = "passed"
+    failed = "failed"
+    skipped = "skipped"
+    error = "error"
+    unknown = "unknown"
+    needs_inspection = "needs_inspection"
+
+
+class TFTTestRunTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "tft_test_run_targets"
+    id = Column(Integer, primary_key=True)
+    pipeline_id = Column(String, index=True)
+    identifier = Column(String)
+    commit_sha = Column(String)
+    status = Column(Enum(TestingFarmResult))
+    target = Column(String)
+    web_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the model is initiated, not when the table is made
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    data = Column(JSON)
+    tft_test_run_group_id = Column(Integer, ForeignKey("tft_test_run_groups.id"))
+    copr_builds = relationship(
+        "CoprBuildTargetModel",
+        secondary=tf_copr_association_table,
+        backref="tft_test_run_targets",
+    )
+
+    group_of_targets = relationship(
+        "TFTTestRunGroupModel", back_populates="tft_test_run_targets"
+    )
+
+
+class BuildStatus(str, enum.Enum):
+    success = "success"
+    pending = "pending"
+    failure = "failure"
+    error = "error"
+    waiting_for_srpm = "waiting_for_srpm"
+
+
+class CoprBuildTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "copr_build_targets"
+    id = Column(Integer, primary_key=True)
+    build_id = Column(String, index=True)  # copr build id
+
+    # commit sha of the PR (or a branch, release) we used for a build
+    commit_sha = Column(String, index=True)
+    # what's the build status?
+    status = Column(Enum(BuildStatus))
+    # chroot, but we use the word target in our docs
+    target = Column(String)
+    # URL to copr web ui for the particular build
+    web_url = Column(String)
+    # url to copr build logs
+    build_logs_url = Column(String)
+    # for monitoring: time when we set the status about accepted task
+    task_accepted_time = Column(DateTime)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the copr build is initiated, not when the table is made
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+
+    # project name as shown in copr
+    project_name = Column(String)
+    owner = Column(String)
+
+    # metadata for the build which didn't make it to schema yet
+    # metadata is reserved to sqlalch
+    data = Column(JSON)
+
+    # info about built packages we get from Copr, e.g.
+    # [
+    #   {
+    #       "arch": "noarch",
+    #       "epoch": 0,
+    #       "name": "python3-packit",
+    #       "release": "1.20210930124525726166.main.0.g0b7b36b.fc36",
+    #       "version": "0.38.0",
+    #   }
+    # ]
+    built_packages = Column(JSON)
+    copr_build_group_id = Column(Integer, ForeignKey("copr_build_groups.id"))
+
+    group_of_targets = relationship(
+        "CoprBuildGroupModel", back_populates="copr_build_targets"
+    )
+    runs = relationship("PipelineModel", back_populates="copr_build")
+
+
+class SRPMBuildModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "srpm_builds"
+    id = Column(Integer, primary_key=True)
+    status = Column(Enum(BuildStatus))
+    # our logs we want to show to the user
+    logs = Column(Text)
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+    commit_sha = Column(String)
+    # url for downloading the SRPM
+    url = Column(Text)
+    # attributes for SRPM built by Copr
+    logs_url = Column(Text)
+    copr_build_id = Column(String, index=True)
+    copr_web_url = Column(Text)
+
+    runs = relationship("PipelineModel", back_populates="srpm_build")
+
+
+class KojiBuildTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "koji_build_targets"
+    id = Column(Integer, primary_key=True)
+    build_id = Column(String, index=True)  # koji build id
+
+    # commit sha of the PR (or a branch, release) we used for a build
+    commit_sha = Column(String)
+    # what's the build status?
+    status = Column(String)
+    # chroot, but we use the word target in our docs
+    target = Column(String)
+    # URL to koji web ui for the particular build
+    web_url = Column(String)
+    # url to koji build logs
+    build_logs_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the koji build is initiated, not when the table is made
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+
+    # metadata for the build which didn't make it to schema yet
+    # metadata is reserved to sqlalch
+    data = Column(JSON)
+
+    # it is a scratch build?
+    scratch = Column(Boolean)
+
+    runs = relationship("PipelineModel", back_populates="koji_build")
+
+
+class SyncReleaseTargetStatus(str, enum.Enum):
+    queued = "queued"
+    running = "running"
+    error = "error"
+    retry = "retry"
+    submitted = "submitted"
+
+
+class SyncReleaseTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "sync_release_run_targets"
+    id = Column(Integer, primary_key=True)
+    branch = Column(String, default="unknown")
+    downstream_pr_url = Column(String)
+    status = Column(Enum(SyncReleaseTargetStatus))
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    start_time = Column(DateTime)
+    finished_time = Column(DateTime)
+    logs = Column(Text)
+    sync_release_id = Column(Integer, ForeignKey("sync_release_runs.id"))
+
+    sync_release = relationship(
+        "SyncReleaseModel", back_populates="sync_release_targets"
+    )
+
+
+class SyncReleaseStatus(str, enum.Enum):
+    running = "running"
+    finished = "finished"
+    error = "error"
+
+
+class SyncReleaseJobType(str, enum.Enum):
+    pull_from_upstream = "pull_from_upstream"
+    propose_downstream = "propose_downstream"
+
+
+class SyncReleaseModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "sync_release_runs"
+    id = Column(Integer, primary_key=True)
+    status = Column(Enum(SyncReleaseStatus))
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    job_type = Column(
+        Enum(SyncReleaseJobType), default=SyncReleaseJobType.propose_downstream
+    )
+
+    runs = relationship("PipelineModel", back_populates="sync_release_run")
+    sync_release_targets = relationship(
+        "SyncReleaseTargetModel", back_populates="sync_release"
+    )
+
+
+class GroupModel:
+    @property
+    def grouped_targets(self):
+        raise NotImplementedError
+
+
+class TFTTestRunGroupModel(ProjectAndTriggersConnector, GroupModel, Base):
+    __tablename__ = "tft_test_run_groups"
+    id = Column(Integer, primary_key=True)
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+
+    runs = relationship("PipelineModel", back_populates="test_run_group")
+    tft_test_run_targets = relationship(
+        "TFTTestRunTargetModel", back_populates="group_of_targets"
+    )
+
+    @property
+    def grouped_targets(self) -> List["TFTTestRunTargetModel"]:
+        return self.tft_test_run_targets
+
+
+class CoprBuildGroupModel(ProjectAndTriggersConnector, GroupModel, Base):
+    __tablename__ = "copr_build_groups"
+    id = Column(Integer, primary_key=True)
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+
+    runs = relationship("PipelineModel", back_populates="copr_build_group")
+    copr_build_targets = relationship(
+        "CoprBuildTargetModel", back_populates="group_of_targets"
+    )
+
+    @property
+    def grouped_targets(self) -> List["CoprBuildTargetModel"]:
+        return self.copr_build_targets
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+
+    op.create_table(
+        "copr_build_groups",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("submitted_time", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "copr_build_targets",
+        sa.Column("copr_build_group_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        None,
+        "copr_build_targets",
+        "copr_build_groups",
+        ["copr_build_group_id"],
+        ["id"],
+    )
+    op.add_column(
+        "pipelines", sa.Column("copr_build_group_id", sa.Integer(), nullable=True)
+    )
+    op.create_foreign_key(
+        None, "pipelines", "copr_build_groups", ["copr_build_group_id"], ["id"]
+    )
+
+    groups = collections.defaultdict(list)
+    for copr_build in session.query(CoprBuildTargetModel):
+        groups[copr_build.build_id].append(copr_build.id)
+
+    for _, ids in groups.items():
+        group = CoprBuildGroupModel()
+
+        for copr_model_id in ids:
+            copr_build = (
+                session.query(CoprBuildTargetModel)
+                .filter(CoprBuildTargetModel.id == copr_model_id)
+                .one()
+            )
+            group.grouped_targets.append(copr_build)
+            # Link the pipeline to groups
+            # TODO: should we merge the groups? This would result in deletion and possibly some mess
+            for pipeline in session.query(PipelineModel).filter(
+                PipelineModel.copr_build_id == copr_model_id
+            ):
+                pipeline.copr_build_group = group
+                session.add(pipeline)
+
+        session.add(group)
+
+    op.drop_constraint("runs_copr_build_id_fkey", "pipelines")
+    op.drop_column("pipelines", "copr_build_id")
+    session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+
+    op.add_column("pipelines", sa.Column("copr_build_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "runs_copr_build_id_fkey",
+        "pipelines",
+        "copr_build_targets",
+        ["copr_build_id"],
+        ["id"],
+    )
+
+    # Split the groups back, this may not fully produce the same thing.
+    for group in session.query(CoprBuildGroupModel):
+        for pipeline, copr_build in itertools.zip_longest(
+            group.runs, group.copr_build_targets
+        ):
+            if not pipeline:
+                # Not enough pipelines, create a new one
+                pipeline = PipelineModel()
+            if not copr_build:
+                continue
+            pipeline.copr_build = copr_build
+            session.add(pipeline)
+
+    op.drop_constraint(
+        "copr_build_targets_copr_build_group_id_fkey", "copr_build_targets"
+    )
+    op.drop_column("copr_build_targets", "copr_build_group_id")
+    op.drop_constraint("pipelines_copr_build_group_id_fkey", "pipelines")
+    op.drop_column("pipelines", "copr_build_group_id")
+    op.drop_table("copr_build_groups")
+    session.commit()

--- a/alembic/versions/a9c49475e9c7_add_testing_farm_groups.py
+++ b/alembic/versions/a9c49475e9c7_add_testing_farm_groups.py
@@ -1,0 +1,427 @@
+"""Add Testing Farm groups
+
+Revision ID: a9c49475e9c7
+Revises: 70c369f7ba80
+Create Date: 2022-11-28 13:25:09.535246
+
+"""
+import collections
+import enum
+import itertools
+from datetime import datetime
+from typing import TYPE_CHECKING, List
+
+from packit_service.models import ProjectAndTriggersConnector
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy.orm
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Enum,
+    Table,
+    ForeignKey,
+    JSON,
+    Text,
+    Boolean,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.ext.declarative import declarative_base
+
+if TYPE_CHECKING:
+    Base = object
+else:
+    Base = declarative_base()
+
+
+# revision identifiers, used by Alembic.
+revision = "a9c49475e9c7"
+down_revision = "70c369f7ba80"
+branch_labels = None
+depends_on = None
+
+tf_copr_association_table = Table(
+    "tf_copr_build_association_table",
+    Base.metadata,  # type: ignore
+    Column("copr_id", ForeignKey("copr_build_targets.id"), primary_key=True),
+    Column("tft_id", ForeignKey("tft_test_run_targets.id"), primary_key=True),
+)
+
+
+class JobTriggerModelType(str, enum.Enum):
+    pull_request = "pull_request"
+    branch_push = "branch_push"
+    release = "release"
+    issue = "issue"
+
+
+class JobTriggerModel(Base):
+    __tablename__ = "job_triggers"
+    id = Column(Integer, primary_key=True)  # our database PK
+    type = Column(Enum(JobTriggerModelType))
+    trigger_id = Column(Integer, index=True)
+
+    runs = relationship("PipelineModel", back_populates="job_trigger")
+
+
+class PipelineModel(Base):
+    __tablename__ = "pipelines"
+    id = Column(Integer, primary_key=True)  # our database PK
+    # datetime.utcnow instead of datetime.utcnow() because it's an argument to the function,
+    # so it will run when the model is initiated, not when the table is made
+    datetime = Column(DateTime, default=datetime.utcnow)
+
+    job_trigger_id = Column(Integer, ForeignKey("job_triggers.id"))
+    job_trigger = relationship("JobTriggerModel", back_populates="runs")
+
+    srpm_build_id = Column(Integer, ForeignKey("srpm_builds.id"), index=True)
+    srpm_build = relationship("SRPMBuildModel", back_populates="runs")
+    copr_build_id = Column(Integer, ForeignKey("copr_build_targets.id"), index=True)
+    copr_build = relationship("CoprBuildTargetModel", back_populates="runs")
+    koji_build_id = Column(Integer, ForeignKey("koji_build_targets.id"), index=True)
+    koji_build = relationship("KojiBuildTargetModel", back_populates="runs")
+    test_run_id = Column(Integer, ForeignKey("tft_test_run_targets.id"), index=True)
+    test_run = relationship("TFTTestRunTargetModel", back_populates="runs")
+    test_run_group_id = Column(
+        Integer, ForeignKey("tft_test_run_groups.id"), index=True
+    )
+    test_run_group = relationship("TFTTestRunGroupModel", back_populates="runs")
+    sync_release_run_id = Column(
+        Integer, ForeignKey("sync_release_runs.id"), index=True
+    )
+    sync_release_run = relationship("SyncReleaseModel", back_populates="runs")
+
+
+class TestingFarmResult(str, enum.Enum):
+    __test__ = False
+
+    new = "new"
+    queued = "queued"
+    running = "running"
+    passed = "passed"
+    failed = "failed"
+    skipped = "skipped"
+    error = "error"
+    unknown = "unknown"
+    needs_inspection = "needs_inspection"
+
+
+class TFTTestRunTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "tft_test_run_targets"
+    id = Column(Integer, primary_key=True)
+    pipeline_id = Column(String, index=True)
+    identifier = Column(String)
+    commit_sha = Column(String)
+    status = Column(Enum(TestingFarmResult))
+    target = Column(String)
+    web_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the model is initiated, not when the table is made
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    data = Column(JSON)
+    tft_test_run_group_id = Column(Integer, ForeignKey("tft_test_run_groups.id"))
+    copr_builds = relationship(
+        "CoprBuildTargetModel",
+        secondary=tf_copr_association_table,
+        backref="tft_test_run_targets",
+    )
+
+    runs = relationship("PipelineModel", back_populates="test_run")
+    group_of_targets = relationship(
+        "TFTTestRunGroupModel", back_populates="tft_test_run_targets"
+    )
+
+
+class BuildStatus(str, enum.Enum):
+    success = "success"
+    pending = "pending"
+    failure = "failure"
+    error = "error"
+    waiting_for_srpm = "waiting_for_srpm"
+
+
+class CoprBuildTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "copr_build_targets"
+    id = Column(Integer, primary_key=True)
+    build_id = Column(String, index=True)  # copr build id
+
+    # commit sha of the PR (or a branch, release) we used for a build
+    commit_sha = Column(String, index=True)
+    # what's the build status?
+    status = Column(Enum(BuildStatus))
+    # chroot, but we use the word target in our docs
+    target = Column(String)
+    # URL to copr web ui for the particular build
+    web_url = Column(String)
+    # url to copr build logs
+    build_logs_url = Column(String)
+    # for monitoring: time when we set the status about accepted task
+    task_accepted_time = Column(DateTime)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the copr build is initiated, not when the table is made
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+
+    # project name as shown in copr
+    project_name = Column(String)
+    owner = Column(String)
+
+    # metadata for the build which didn't make it to schema yet
+    # metadata is reserved to sqlalch
+    data = Column(JSON)
+
+    # info about built packages we get from Copr, e.g.
+    # [
+    #   {
+    #       "arch": "noarch",
+    #       "epoch": 0,
+    #       "name": "python3-packit",
+    #       "release": "1.20210930124525726166.main.0.g0b7b36b.fc36",
+    #       "version": "0.38.0",
+    #   }
+    # ]
+    built_packages = Column(JSON)
+
+    runs = relationship("PipelineModel", back_populates="copr_build")
+
+
+class SRPMBuildModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "srpm_builds"
+    id = Column(Integer, primary_key=True)
+    status = Column(Enum(BuildStatus))
+    # our logs we want to show to the user
+    logs = Column(Text)
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+    commit_sha = Column(String)
+    # url for downloading the SRPM
+    url = Column(Text)
+    # attributes for SRPM built by Copr
+    logs_url = Column(Text)
+    copr_build_id = Column(String, index=True)
+    copr_web_url = Column(Text)
+
+    runs = relationship("PipelineModel", back_populates="srpm_build")
+
+
+class KojiBuildTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "koji_build_targets"
+    id = Column(Integer, primary_key=True)
+    build_id = Column(String, index=True)  # koji build id
+
+    # commit sha of the PR (or a branch, release) we used for a build
+    commit_sha = Column(String)
+    # what's the build status?
+    status = Column(String)
+    # chroot, but we use the word target in our docs
+    target = Column(String)
+    # URL to koji web ui for the particular build
+    web_url = Column(String)
+    # url to koji build logs
+    build_logs_url = Column(String)
+    # datetime.utcnow instead of datetime.utcnow() because its an argument to the function
+    # so it will run when the koji build is initiated, not when the table is made
+    build_submitted_time = Column(DateTime, default=datetime.utcnow)
+    build_start_time = Column(DateTime)
+    build_finished_time = Column(DateTime)
+
+    # metadata for the build which didn't make it to schema yet
+    # metadata is reserved to sqlalch
+    data = Column(JSON)
+
+    # it is a scratch build?
+    scratch = Column(Boolean)
+
+    runs = relationship("PipelineModel", back_populates="koji_build")
+
+
+class SyncReleaseTargetStatus(str, enum.Enum):
+    queued = "queued"
+    running = "running"
+    error = "error"
+    retry = "retry"
+    submitted = "submitted"
+
+
+class SyncReleaseTargetModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "sync_release_run_targets"
+    id = Column(Integer, primary_key=True)
+    branch = Column(String, default="unknown")
+    downstream_pr_url = Column(String)
+    status = Column(Enum(SyncReleaseTargetStatus))
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    start_time = Column(DateTime)
+    finished_time = Column(DateTime)
+    logs = Column(Text)
+    sync_release_id = Column(Integer, ForeignKey("sync_release_runs.id"))
+
+    sync_release = relationship(
+        "SyncReleaseModel", back_populates="sync_release_targets"
+    )
+
+
+class SyncReleaseStatus(str, enum.Enum):
+    running = "running"
+    finished = "finished"
+    error = "error"
+
+
+class SyncReleaseJobType(str, enum.Enum):
+    pull_from_upstream = "pull_from_upstream"
+    propose_downstream = "propose_downstream"
+
+
+class SyncReleaseModel(ProjectAndTriggersConnector, Base):
+    __tablename__ = "sync_release_runs"
+    id = Column(Integer, primary_key=True)
+    status = Column(Enum(SyncReleaseStatus))
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+    job_type = Column(
+        Enum(SyncReleaseJobType), default=SyncReleaseJobType.propose_downstream
+    )
+
+    runs = relationship("PipelineModel", back_populates="sync_release_run")
+    sync_release_targets = relationship(
+        "SyncReleaseTargetModel", back_populates="sync_release"
+    )
+
+
+class GroupModel:
+    @property
+    def grouped_targets(self):
+        raise NotImplementedError
+
+
+class TFTTestRunGroupModel(ProjectAndTriggersConnector, GroupModel, Base):
+    __tablename__ = "tft_test_run_groups"
+    id = Column(Integer, primary_key=True)
+    submitted_time = Column(DateTime, default=datetime.utcnow)
+
+    runs = relationship("PipelineModel", back_populates="test_run_group")
+    tft_test_run_targets = relationship(
+        "TFTTestRunTargetModel", back_populates="group_of_targets"
+    )
+
+    @property
+    def grouped_targets(self) -> List["TFTTestRunTargetModel"]:
+        return self.tft_test_run_targets
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+
+    op.create_table(
+        "tft_test_run_groups",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("submitted_time", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "tft_test_run_targets",
+        sa.Column("tft_test_run_group_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        None,
+        "tft_test_run_targets",
+        "tft_test_run_groups",
+        ["tft_test_run_group_id"],
+        ["id"],
+    )
+    op.add_column(
+        "pipelines", sa.Column("test_run_group_id", sa.Integer(), nullable=True)
+    )
+    op.create_foreign_key(
+        None, "pipelines", "tft_test_run_groups", ["test_run_group_id"], ["id"]
+    )
+
+    # We group by the same SRPM. If there is no SRPM (testing without building), we just
+    # create a new group with a single target (while not ideal, this is the best we can do).
+    srpm_ids = collections.defaultdict(list)
+    for pipeline in (
+        session.query(PipelineModel)
+        .filter(PipelineModel.srpm_build_id.is_not(None))
+        .filter(PipelineModel.test_run_id.is_not(None))
+    ):
+        srpm_ids[pipeline.srpm_build_id].append(pipeline.test_run_id)
+
+    # Group by SRPMs
+    for srpm_id, tests in srpm_ids.items():
+        group = TFTTestRunGroupModel()
+        for test_id in tests:
+            test = (
+                session.query(TFTTestRunTargetModel)
+                .filter(TFTTestRunTargetModel.id == test_id)
+                .one()
+            )
+            group.grouped_targets.append(test)
+
+        session.add(group)
+
+        # Link the pipeline to groups
+        # TODO: should we merge the groups? This would result in deletion and possibly some mess
+        for pipeline in (
+            session.query(PipelineModel)
+            .filter(PipelineModel.srpm_build_id == srpm_id)
+            .filter(PipelineModel.test_run_id.is_not(None))
+        ):
+            pipeline.test_run_group = group
+            session.add(pipeline)
+
+    # Create a separate group for those which have no SRPM to group by
+    for pipeline in (
+        session.query(PipelineModel)
+        .filter(PipelineModel.test_run_id.is_not(None))
+        .filter(PipelineModel.srpm_build_id.is_(None))
+    ):
+        group = TFTTestRunGroupModel()
+        group.grouped_targets.append(pipeline.test_run)
+        pipeline.test_run_group = group
+
+        session.add(group)
+        session.add(pipeline)
+
+    op.drop_constraint("runs_test_run_id_fkey", "pipelines")
+    op.drop_column("pipelines", "test_run_id")
+
+    session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = sa.orm.Session(bind=bind)
+
+    op.add_column("pipelines", sa.Column("test_run_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "runs_test_run_id_fkey",
+        "pipelines",
+        "tft_test_run_targets",
+        ["test_run_id"],
+        ["id"],
+    )
+
+    # Split the groups back, this may not fully produce the same thing.
+    for group in session.query(TFTTestRunGroupModel):
+        for pipeline, test_run in itertools.zip_longest(
+            group.runs, group.tft_test_run_targets
+        ):
+            if not pipeline:
+                # Not enough pipelines, create a new one
+                pipeline = PipelineModel()
+            if not test_run:
+                continue
+            pipeline.test_run = test_run
+            session.add(pipeline)
+
+    op.drop_constraint(
+        "tft_test_run_targets_tft_test_run_group_id_fkey", "tft_test_run_targets"
+    )
+    op.drop_column("tft_test_run_targets", "tft_test_run_group_id")
+    op.drop_constraint("pipelines_test_run_group_id_fkey", "pipelines")
+    op.drop_column("pipelines", "test_run_group_id")
+    op.drop_table("tft_test_run_groups")
+    session.commit()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       POSTGRESQL_DATABASE: packit
     volumes:
       - ./packit_service:/src/packit_service:ro,z
-      - ./alembic:/src/alembic:ro,z
+      - ./alembic:/src/alembic:rw,z
       # There's no secrets/ by default. You have to create (or symlink to other dir) it yourself.
       # Make sure to set `command_handler: local` since there is no kube in d-c
       - ./secrets/packit/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -330,7 +330,7 @@ class BuildsAndTestsConnector:
 
 class ProjectAndTriggersConnector:
     """
-    Abstract class that is inherited by build/test models
+    Abstract class that is inherited by build/test group models
     to share methods for accessing project and trigger models.
     """
 
@@ -370,6 +370,36 @@ class ProjectAndTriggersConnector:
         if isinstance(trigger_object, ProjectReleaseModel):
             return trigger_object.tag_name
         return None
+
+
+class GroupAndTargetModelConnector:
+    """
+    Abstract class that is inherited by build/test models
+    to share methods for accessing project and trigger models.
+    """
+
+    group_of_targets: ProjectAndTriggersConnector
+
+    def get_job_trigger_model(self) -> Optional["JobTriggerModel"]:
+        return self.group_of_targets.get_job_trigger_model()
+
+    def get_trigger_object(self) -> Optional["AbstractTriggerDbType"]:
+        return self.group_of_targets.get_trigger_object()
+
+    def get_project(self) -> Optional["GitProjectModel"]:
+        return self.group_of_targets.get_project()
+
+    def get_pr_id(self) -> Optional[int]:
+        return self.group_of_targets.get_pr_id()
+
+    def get_issue_id(self) -> Optional[int]:
+        return self.group_of_targets.get_issue_id()
+
+    def get_branch_name(self) -> Optional[str]:
+        return self.group_of_targets.get_branch_name()
+
+    def get_release_tag(self) -> Optional[str]:
+        return self.group_of_targets.get_release_tag()
 
 
 class GitProjectModel(Base):

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1480,7 +1480,10 @@ class CoprBuildTargetModel(ProjectAndTriggersConnector, Base):
         return cls.get_by_build_id(build_id, target)
 
     def __repr__(self):
-        return f"COPRBuildModel(id={self.id}, build_submitted_time={self.build_submitted_time})"
+        return (
+            f"CoprBuildTargetModel(id={self.id}, "
+            f"build_submitted_time={self.build_submitted_time})"
+        )
 
 
 class KojiBuildTargetModel(ProjectAndTriggersConnector, Base):

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1581,6 +1581,10 @@ class KojiBuildGroupModel(ProjectAndTriggersConnector, GroupModel, Base):
         )
 
     @classmethod
+    def get_by_id(cls, id_: int) -> Optional["KojiBuildGroupModel"]:
+        return sa_session().query(KojiBuildGroupModel).filter_by(id=id_).first()
+
+    @classmethod
     def create(cls, run_model: "PipelineModel") -> "KojiBuildGroupModel":
         with sa_session_transaction() as session:
             build_group = cls()

--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -95,7 +95,7 @@ class CoprBuildItem(Resource):
             "copr_project": build.project_name,
             "copr_owner": build.owner,
             "srpm_build_id": build.get_srpm_build().id,
-            "run_ids": sorted(run.id for run in build.runs),
+            "run_ids": sorted(run.id for run in build.group_of_targets.runs),
             "built_packages": build.built_packages,
         }
 

--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -6,7 +6,12 @@ from logging import getLogger
 
 from flask_restx import Namespace, Resource
 
-from packit_service.models import CoprBuildTargetModel, optional_timestamp, BuildStatus
+from packit_service.models import (
+    CoprBuildTargetModel,
+    optional_timestamp,
+    BuildStatus,
+    CoprBuildGroupModel,
+)
 from packit_service.service.api.parsers import indices, pagination_arguments
 from packit_service.service.api.utils import get_project_info_from_build, response_maker
 
@@ -101,3 +106,32 @@ class CoprBuildItem(Resource):
 
         build_dict.update(get_project_info_from_build(build))
         return response_maker(build_dict)
+
+
+@ns.route("/groups/<int:id>")
+@ns.param("id", "Packit id of the copr build group")
+class CoprBuildGroup(Resource):
+    @ns.response(HTTPStatus.OK, "OK, copr build group details follow")
+    @ns.response(
+        HTTPStatus.NOT_FOUND.value, "No info about koji build group stored in DB"
+    )
+    def get(self, id):
+        """A specific test run details."""
+        group_model = CoprBuildGroupModel.get_by_id(int(id))
+
+        if not group_model:
+            return response_maker(
+                {"error": "No info about group stored in DB"},
+                status=HTTPStatus.NOT_FOUND,
+            )
+
+        group_dict = {
+            "submitted_time": optional_timestamp(group_model.submitted_time),
+            "run_ids": sorted(run.id for run in group_model.runs),
+            "build_target_ids": sorted(
+                build.id for build in group_model.grouped_targets
+            ),
+        }
+
+        group_dict.update(get_project_info_from_build(group_model))
+        return response_maker(group_dict)

--- a/packit_service/service/api/runs.py
+++ b/packit_service/service/api/runs.py
@@ -8,7 +8,7 @@ from typing import Dict
 from flask_restx import Namespace, Resource
 
 from packit_service.models import (
-    CoprBuildTargetModel,
+    CoprBuildGroupModel,
     KojiBuildTargetModel,
     PipelineModel,
     SyncReleaseModel,
@@ -86,7 +86,7 @@ def process_runs(runs):
             response_dict["trigger"] = get_project_info_from_build(srpm_build)
 
         for model_type, Model, packit_ids in (
-            ("copr", CoprBuildTargetModel, pipeline.copr_build_id),
+            ("copr", CoprBuildGroupModel, pipeline.copr_build_group_id),
             ("koji", KojiBuildTargetModel, pipeline.koji_build_id),
             ("test_run", TFTTestRunGroupModel, pipeline.test_run_group_id),
         ):
@@ -180,7 +180,7 @@ class Run(Resource):
                 run.srpm_build or run.sync_release_run
             ),
             "srpm_build_id": run.srpm_build_id,
-            "copr_build_id": run.copr_build_id,
+            "copr_build_group_id": run.copr_build_group_id,
             "koji_build_id": run.koji_build_id,
             "test_run_group_id": run.test_run_group_id,
         }

--- a/packit_service/service/api/runs.py
+++ b/packit_service/service/api/runs.py
@@ -16,6 +16,8 @@ from packit_service.models import (
     TFTTestRunTargetModel,
     optional_timestamp,
     BuildStatus,
+    GroupModel,
+    TFTTestRunGroupModel,
 )
 from packit_service.service.api.parsers import indices, pagination_arguments
 from packit_service.service.api.utils import (
@@ -86,27 +88,35 @@ def process_runs(runs):
         for model_type, Model, packit_ids in (
             ("copr", CoprBuildTargetModel, pipeline.copr_build_id),
             ("koji", KojiBuildTargetModel, pipeline.koji_build_id),
-            ("test_run", TFTTestRunTargetModel, pipeline.test_run_id),
+            ("test_run", TFTTestRunGroupModel, pipeline.test_run_group_id),
         ):
             for packit_id in set(flatten_and_remove_none(packit_ids)):
-                row = Model.get_by_id(packit_id)
-                if row.status == BuildStatus.waiting_for_srpm:
-                    continue
-                response_dict[model_type].append(
-                    {
-                        "packit_id": packit_id,
-                        "target": row.target,
-                        "status": row.status,
-                    }
+                group_row = Model.get_by_id(packit_id)
+                target_models = (
+                    group_row.grouped_targets
+                    if isinstance(group_row, GroupModel)
+                    else [group_row]
                 )
-                if "trigger" not in response_dict:
-                    submitted_time = (
-                        row.submitted_time
-                        if isinstance(row, TFTTestRunTargetModel)
-                        else row.build_submitted_time
+                for row in target_models:
+                    if row.status == BuildStatus.waiting_for_srpm:
+                        continue
+                    response_dict[model_type].append(
+                        {
+                            "packit_id": packit_id,
+                            "target": row.target,
+                            "status": row.status,
+                        }
                     )
-                    response_dict["time_submitted"] = optional_timestamp(submitted_time)
-                    response_dict["trigger"] = get_project_info_from_build(row)
+                    if "trigger" not in response_dict:
+                        submitted_time = (
+                            row.submitted_time
+                            if isinstance(row, TFTTestRunTargetModel)
+                            else row.build_submitted_time
+                        )
+                        response_dict["time_submitted"] = optional_timestamp(
+                            submitted_time
+                        )
+                        response_dict["trigger"] = get_project_info_from_build(row)
 
         # handle propose-downstream and pull-from-upstream
         if sync_release := list(flatten_and_remove_none(pipeline.sync_release_run_id)):
@@ -172,6 +182,6 @@ class Run(Resource):
             "srpm_build_id": run.srpm_build_id,
             "copr_build_id": run.copr_build_id,
             "koji_build_id": run.koji_build_id,
-            "test_run_id": run.test_run_id,
+            "test_run_group_id": run.test_run_group_id,
         }
         return response_maker(result)

--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -156,7 +156,7 @@ class TestingFarmResult(Resource):
             "chroot": test_run_model.target,
             "commit_sha": test_run_model.commit_sha,
             "web_url": test_run_model.web_url,
-            "copr_build_ids": [run.copr_build_id for run in test_run_model.runs],
+            "copr_build_ids": [build.id for build in test_run_model.copr_builds],
             "run_ids": sorted(run.id for run in test_run_model.runs),
             "submitted_time": optional_timestamp(test_run_model.submitted_time),
         }

--- a/packit_service/service/api/usage.py
+++ b/packit_service/service/api/usage.py
@@ -12,7 +12,7 @@ from packit_service.models import (
     CoprBuildGroupModel,
     GitProjectModel,
     JobTriggerModelType,
-    KojiBuildTargetModel,
+    KojiBuildGroupModel,
     SRPMBuildModel,
     SyncReleaseModel,
     TFTTestRunGroupModel,
@@ -280,7 +280,7 @@ def get_usage_data(datetime_from=None, datetime_to=None, top=10):
     for job_model in [
         SRPMBuildModel,
         CoprBuildGroupModel,
-        KojiBuildTargetModel,
+        KojiBuildGroupModel,
         VMImageBuildTargetModel,
         TFTTestRunGroupModel,
         SyncReleaseModel,
@@ -483,7 +483,7 @@ def get_project_usage_data(project: str, datetime_from=None, datetime_to=None):
     for job_model in [
         SRPMBuildModel,
         CoprBuildGroupModel,
-        KojiBuildTargetModel,
+        KojiBuildGroupModel,
         VMImageBuildTargetModel,
         TFTTestRunGroupModel,
         SyncReleaseModel,

--- a/packit_service/service/api/usage.py
+++ b/packit_service/service/api/usage.py
@@ -9,7 +9,7 @@ from flask import request
 from flask_restx import Namespace, Resource
 
 from packit_service.models import (
-    CoprBuildTargetModel,
+    CoprBuildGroupModel,
     GitProjectModel,
     JobTriggerModelType,
     KojiBuildTargetModel,
@@ -279,7 +279,7 @@ def get_usage_data(datetime_from=None, datetime_to=None, top=10):
     jobs = {}
     for job_model in [
         SRPMBuildModel,
-        CoprBuildTargetModel,
+        CoprBuildGroupModel,
         KojiBuildTargetModel,
         VMImageBuildTargetModel,
         TFTTestRunGroupModel,
@@ -482,7 +482,7 @@ def get_project_usage_data(project: str, datetime_from=None, datetime_to=None):
     jobs: dict[str, Any] = {}
     for job_model in [
         SRPMBuildModel,
-        CoprBuildTargetModel,
+        CoprBuildGroupModel,
         KojiBuildTargetModel,
         VMImageBuildTargetModel,
         TFTTestRunGroupModel,

--- a/packit_service/service/api/usage.py
+++ b/packit_service/service/api/usage.py
@@ -15,7 +15,7 @@ from packit_service.models import (
     KojiBuildTargetModel,
     SRPMBuildModel,
     SyncReleaseModel,
-    TFTTestRunTargetModel,
+    TFTTestRunGroupModel,
     VMImageBuildTargetModel,
 )
 from packit_service.service.api.utils import response_maker
@@ -282,7 +282,7 @@ def get_usage_data(datetime_from=None, datetime_to=None, top=10):
         CoprBuildTargetModel,
         KojiBuildTargetModel,
         VMImageBuildTargetModel,
-        TFTTestRunTargetModel,
+        TFTTestRunGroupModel,
         SyncReleaseModel,
     ]:
         jobs[job_model.__tablename__] = dict(
@@ -485,7 +485,7 @@ def get_project_usage_data(project: str, datetime_from=None, datetime_to=None):
         CoprBuildTargetModel,
         KojiBuildTargetModel,
         VMImageBuildTargetModel,
-        TFTTestRunTargetModel,
+        TFTTestRunGroupModel,
         SyncReleaseModel,
     ]:
         job_name: str = job_model.__tablename__  # type: ignore

--- a/packit_service/service/api/utils.py
+++ b/packit_service/service/api/utils.py
@@ -9,9 +9,12 @@ from flask import make_response
 
 from packit_service.models import (
     CoprBuildTargetModel,
+    CoprBuildGroupModel,
     KojiBuildTargetModel,
+    KojiBuildGroupModel,
     SRPMBuildModel,
     TFTTestRunTargetModel,
+    TFTTestRunGroupModel,
     SyncReleaseModel,
 )
 
@@ -28,8 +31,11 @@ def get_project_info_from_build(
     build: Union[
         SRPMBuildModel,
         CoprBuildTargetModel,
+        CoprBuildGroupModel,
         KojiBuildTargetModel,
+        KojiBuildGroupModel,
         TFTTestRunTargetModel,
+        TFTTestRunGroupModel,
         SyncReleaseModel,
     ]
 ) -> Dict[str, Any]:

--- a/packit_service/worker/celery_task.py
+++ b/packit_service/worker/celery_task.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Optional, Any, Dict
 
 from celery import Task
 
@@ -42,6 +42,7 @@ class CeleryTask:
         ex: Optional[Exception] = None,
         delay: Optional[int] = None,
         max_retries: Optional[int] = None,
+        kargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Retries the celery task.
@@ -56,11 +57,12 @@ class CeleryTask:
             delay: Number of seconds the task will wait before being run again.
             max_retries: Maximum number of retries to use instead of the default within
                 HandlerTaskWithRetry.
+            kargs: Extra keyword arguments to pass to the task when retrying.
         """
         retries = self.retries
         delay = delay if delay is not None else 60 * 2**retries
         logger.info(f"Will retry for the {retries + 1}. time in {delay}s.")
-        kargs = self.task.request.kwargs.copy()
+        kargs = (kargs or self.task.request.kwargs).copy()
         self.task.retry(
             exc=ex,
             countdown=delay,

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -3,7 +3,7 @@
 
 import logging
 from datetime import datetime, timezone
-from typing import Tuple, Type
+from typing import Tuple, Type, Optional
 
 from celery import signature, Task
 from ogr.services.github import GithubProject
@@ -97,6 +97,7 @@ class CoprBuildHandler(
         job_config: JobConfig,
         event: dict,
         celery_task: Task,
+        copr_build_group_id: Optional[int] = None,
     ):
         super().__init__(
             package_config=package_config,
@@ -104,6 +105,7 @@ class CoprBuildHandler(
             event=event,
             celery_task=celery_task,
         )
+        self._copr_build_group_id = copr_build_group_id
 
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker], ...]:

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -137,7 +137,7 @@ class TestingFarmHandler(
                 trigger_id=self.db_trigger.id,
             )
             if self.testing_farm_job_helper.skip_build or not copr_build
-            else copr_build.runs[-1]
+            else copr_build.group_of_targets.runs[-1]
         )
         group = TFTTestRunGroupModel.create([run_model])
         for i, target in enumerate(targets):

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -760,7 +760,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         self,
         target: str,
         chroot: str,
-        build: CoprBuildTargetModel,
+        build: Optional[CoprBuildTargetModel],
         additional_build: Optional[CoprBuildTargetModel],
     ) -> TaskResults:
         """
@@ -893,7 +893,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         self,
         response: RequestResponse,
         target: str,
-        build: CoprBuildTargetModel,
+        build: Optional[CoprBuildTargetModel],
         additional_build: Optional[CoprBuildTargetModel],
     ):
         """
@@ -912,8 +912,12 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             else build.runs[-1]
         ]
 
+        builds = []
+        if build:
+            builds.append(build)
         if additional_build:
             run_models.append(additional_build.runs[-1])
+            builds.append(additional_build)
 
         created_model = TFTTestRunTargetModel.create(
             pipeline_id=pipeline_id,
@@ -923,6 +927,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             target=target,
             web_url=None,
             run_models=run_models,
+            copr_build_targets=builds,
             # In _payload() we ask TF to test commit_sha of fork (PR's source).
             # Store original url. If this proves to work, make it a separate column.
             data={"base_project_url": self.project.get_web_url()},

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -23,7 +23,6 @@ from packit_service.models import (
     CoprBuildTargetModel,
     TFTTestRunTargetModel,
     TestingFarmResult,
-    PipelineModel,
     PullRequestModel,
     filter_most_recent_target_models_by_status,
     BuildStatus,
@@ -687,20 +686,24 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         return artifacts
 
     def run_testing_farm(
-        self, target: str, build: Optional["CoprBuildTargetModel"]
+        self,
+        test_run: TFTTestRunTargetModel,
+        build: Optional["CoprBuildTargetModel"],
     ) -> TaskResults:
-        if target not in self.tests_targets_for_test_job(self.job_config):
+        if test_run.target not in self.tests_targets_for_test_job(self.job_config):
             # Leaving here just to be sure that we will discover this situation if it occurs.
             # Currently not possible to trigger this situation.
-            msg = f"Target '{target}' not defined for tests but triggered."
+            msg = f"Target '{test_run.target}' not defined for tests but triggered."
             logger.error(msg)
             send_to_sentry(PackitConfigException(msg))
             return TaskResults(
                 success=False,
                 details={"msg": msg},
             )
-        chroot = self.test_target2build_target(target)
-        logger.debug(f"Running testing farm for target {target}, chroot={chroot}.")
+        chroot = self.test_target2build_target(test_run.target)
+        logger.debug(
+            f"Running testing farm for target {test_run.target}, chroot={chroot}."
+        )
 
         if not self.skip_build and chroot not in self.build_targets:
             self.report_missing_build_chroot(chroot)
@@ -720,7 +723,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             self.report_status_to_tests_for_test_target(
                 state=BaseCommitStatus.neutral,
                 description="Internal TF not allowed for this project. Let us know.",
-                target=target,
+                target=test_run.target,
                 url=CONTACTS_URL,
             )
             return TaskResults(
@@ -735,7 +738,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             self.report_status_to_tests_for_test_target(
                 state=BaseCommitStatus.failure,
                 description="No latest successful Copr build from the other PR found.",
-                target=target,
+                target=test_run.target,
                 url="",
             )
             return TaskResults(
@@ -749,16 +752,19 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             state=BaseCommitStatus.running,
             description=f"{'Build succeeded. ' if not self.skip_build else ''}"
             f"Submitting the tests ...",
-            target=target,
+            target=test_run.target,
         )
 
         return self.prepare_and_send_tf_request(
-            target=target, chroot=chroot, build=build, additional_build=additional_build
+            test_run=test_run,
+            chroot=chroot,
+            build=build,
+            additional_build=additional_build,
         )
 
     def prepare_and_send_tf_request(
         self,
-        target: str,
+        test_run: TFTTestRunTargetModel,
         chroot: str,
         build: Optional[CoprBuildTargetModel],
         additional_build: Optional[CoprBuildTargetModel],
@@ -770,7 +776,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         """
         logger.info("Preparing testing farm request...")
 
-        compose = self.distro2compose(target)
+        compose = self.distro2compose(test_run.target)
 
         if not compose:
             msg = "We were not able to map distro to TF compose."
@@ -778,21 +784,21 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
         if self.is_fmf_configured():
             payload = self._payload(
-                target=target,
+                target=test_run.target,
                 compose=compose,
                 artifacts=self._get_artifacts(chroot, build, additional_build),
                 build=build,
             )
         elif not self.is_fmf_configured() and not self.skip_build:
             payload = self._payload_install_test(
-                build_id=int(build.build_id), target=target, compose=compose
+                build_id=int(build.build_id), target=test_run.target, compose=compose
             )
         else:
             self.report_status_to_tests_for_test_target(
                 state=BaseCommitStatus.neutral,
                 description="No FMF metadata found. Please, initialize the metadata tree "
                 "with `fmf init`.",
-                target=target,
+                target=test_run.target,
             )
             return TaskResults(success=True, details={"msg": "No FMF metadata found."})
 
@@ -805,17 +811,18 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         )
 
         if not response:
-            return self._handle_tf_submit_no_response(target=target, payload=payload)
+            return self._handle_tf_submit_no_response(
+                test_run=test_run, target=test_run.target, payload=payload
+            )
 
         if response.status_code != 200:
             return self._handle_tf_submit_failure(
-                response=response, target=target, payload=payload
+                test_run=test_run, response=response, payload=payload
             )
 
         return self._handle_tf_submit_successful(
+            test_run=test_run,
             response=response,
-            target=target,
-            build=build,
             additional_build=additional_build,
         )
 
@@ -891,9 +898,8 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
     def _handle_tf_submit_successful(
         self,
+        test_run: TFTTestRunTargetModel,
         response: RequestResponse,
-        target: str,
-        build: Optional[CoprBuildTargetModel],
         additional_build: Optional[CoprBuildTargetModel],
     ):
         """
@@ -902,53 +908,29 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         """
         pipeline_id = response.json()["id"]
         logger.info(f"Request {pipeline_id} submitted to testing farm.")
+        test_run.set_pipeline_id(pipeline_id)
 
-        run_models = [
-            PipelineModel.create(
-                type=self.db_trigger.job_trigger_model_type,
-                trigger_id=self.db_trigger.id,
-            )
-            if self.skip_build
-            else build.runs[-1]
-        ]
-
-        builds = []
-        if build:
-            builds.append(build)
         if additional_build:
-            run_models.append(additional_build.runs[-1])
-            builds.append(additional_build)
-
-        created_model = TFTTestRunTargetModel.create(
-            pipeline_id=pipeline_id,
-            identifier=self.job_config.identifier,
-            commit_sha=self.metadata.commit_sha,
-            status=TestingFarmResult.new,
-            target=target,
-            web_url=None,
-            run_models=run_models,
-            copr_build_targets=builds,
-            # In _payload() we ask TF to test commit_sha of fork (PR's source).
-            # Store original url. If this proves to work, make it a separate column.
-            data={"base_project_url": self.project.get_web_url()},
-        )
+            test_run.add_copr_build(additional_build)
 
         self.report_status_to_tests_for_test_target(
             state=BaseCommitStatus.running,
             description="Tests have been submitted ...",
-            url=get_testing_farm_info_url(created_model.id),
-            target=target,
+            url=get_testing_farm_info_url(test_run.id),
+            target=test_run.target,
         )
 
         return TaskResults(success=True, details={})
 
-    def _handle_tf_submit_no_response(self, target: str, payload: dict):
+    def _handle_tf_submit_no_response(
+        self, test_run: TFTTestRunTargetModel, target: str, payload: dict
+    ):
         """
         Retry the task and report it to user or report the error state to user.
         """
         msg = "Failed to post request to testing farm API."
         if not self.celery_task.is_last_try():
-            return self._retry_on_submit_failure(msg)
+            return self._retry_on_submit_failure(test_run, msg)
 
         logger.error(f"{msg} {self._payload_without_token(payload)}")
         self.report_status_to_tests_for_test_target(
@@ -959,7 +941,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         return TaskResults(success=False, details={"msg": msg})
 
     def _handle_tf_submit_failure(
-        self, response: RequestResponse, target: str, payload: dict
+        self, test_run: TFTTestRunTargetModel, response: RequestResponse, payload: dict
     ) -> TaskResults:
         """
         Retry the task and report it to user or report the failure state to user.
@@ -973,23 +955,27 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         else:
             msg = f"Failed to submit tests: {response.reason}."
             if not self.celery_task.is_last_try():
-                return self._retry_on_submit_failure(response.reason)
+                return self._retry_on_submit_failure(test_run, response.reason)
 
+        test_run.set_status(TestingFarmResult.error)
         logger.error(f"{msg}, {self._payload_without_token(payload)}")
         self.report_status_to_tests_for_test_target(
             state=BaseCommitStatus.failure,
             description=msg,
-            target=target,
+            target=test_run.target,
         )
         return TaskResults(success=False, details={"msg": msg})
 
-    def _retry_on_submit_failure(self, message: str) -> TaskResults:
+    def _retry_on_submit_failure(
+        self, test_run: TFTTestRunTargetModel, message: str
+    ) -> TaskResults:
         """
         Retry when there was a failure when submitting TF tests.
 
         Args:
             message: message to report to the user
         """
+        test_run.set_status(TestingFarmResult.retry)
         interval = (
             BASE_RETRY_INTERVAL_IN_MINUTES_FOR_OUTAGES * 2**self.celery_task.retries
         )
@@ -1000,7 +986,9 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             f" retried in {interval} {'minute' if interval == 1 else 'minutes'}.",
             markdown_content=message,
         )
-        self.celery_task.retry(delay=interval * 60)
+        kargs = self.celery_task.task.request.kwargs.copy()
+        kargs["testing_farm_group_id"] = test_run.group_of_targets.id
+        self.celery_task.retry(delay=interval * 60, kargs=kargs)
         return TaskResults(
             success=True,
             details={

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -219,6 +219,7 @@ def run_testing_farm_handler(
     package_config: dict,
     job_config: dict,
     build_id: Optional[int] = None,
+    testing_farm_group_id: Optional[int] = None,
 ):
     handler = TestingFarmHandler(
         package_config=load_package_config(package_config),
@@ -226,6 +227,7 @@ def run_testing_farm_handler(
         event=event,
         build_id=build_id,
         celery_task=self,
+        testing_farm_group_id=testing_farm_group_id,
     )
     return get_handlers_task_results(handler.run_job(), event)
 

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -184,12 +184,19 @@ def run_copr_build_end_handler(event: dict, package_config: dict, job_config: di
 @celery_app.task(
     bind=True, name=TaskName.copr_build, base=HandlerTaskWithRetry, queue="long-running"
 )
-def run_copr_build_handler(self, event: dict, package_config: dict, job_config: dict):
+def run_copr_build_handler(
+    self,
+    event: dict,
+    package_config: dict,
+    job_config: dict,
+    copr_build_group_id: Optional[int] = None,
+):
     handler = CoprBuildHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,
         celery_task=self,
+        copr_build_group_id=copr_build_group_id,
     )
     return get_handlers_task_results(handler.run_job(), event)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,7 +187,7 @@ def copr_build_model(
         web_url="https://some-url",
         target="some-target",
         status="some-status",
-        runs=runs,
+        group_of_targets=flexmock(runs=runs),
         set_status=lambda x: None,
         set_built_packages=lambda x: None,
         built_packages=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,6 +178,7 @@ def copr_build_model(
 
     runs = []
     srpm_build = flexmock(logs="asdsdf", url=None, runs=runs)
+    copr_group = flexmock(runs=runs)
     copr_build = flexmock(
         id=1,
         build_id="1",
@@ -187,7 +188,7 @@ def copr_build_model(
         web_url="https://some-url",
         target="some-target",
         status="some-status",
-        group_of_targets=flexmock(runs=runs),
+        group_of_targets=copr_group,
         set_status=lambda x: None,
         set_built_packages=lambda x: None,
         built_packages=[
@@ -220,7 +221,11 @@ def copr_build_model(
     copr_build.get_srpm_build = lambda: srpm_build
 
     run_model = flexmock(
-        id=3, job_trigger=trigger_model, srpm_build=srpm_build, copr_build=copr_build
+        id=3,
+        job_trigger=trigger_model,
+        srpm_build=srpm_build,
+        copr_build_group=copr_group,
+        test_run_group=None,
     )
     runs.append(run_model)
 

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -228,7 +228,7 @@ def test_check_rerun_pr_testing_farm_handler(
 ):
 
     run = flexmock()
-    build = flexmock(status=BuildStatus.success, runs=[run])
+    build = flexmock(status=BuildStatus.success, group_of_targets=flexmock(runs=[run]))
     test = flexmock(
         copr_builds=[build],
         status=TestingFarmResult.new,
@@ -425,7 +425,7 @@ def test_check_rerun_push_testing_farm_handler(
 ):
 
     run = flexmock()
-    build = flexmock(status=BuildStatus.success, runs=[run])
+    build = flexmock(status=BuildStatus.success, group_of_targets=flexmock(runs=[run]))
     test = flexmock(
         copr_builds=[build],
         status=TestingFarmResult.new,
@@ -444,7 +444,7 @@ def test_check_rerun_push_testing_farm_handler(
     )
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
-        flexmock(status=BuildStatus.success, runs=[run])
+        flexmock(status=BuildStatus.success, group_of_targets=flexmock(runs=[run]))
     )
     flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64", "fedora-34-x86_64"}

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -21,6 +21,9 @@ from packit_service.models import (
     ProjectReleaseModel,
     PullRequestModel,
     BuildStatus,
+    TFTTestRunGroupModel,
+    TFTTestRunTargetModel,
+    TestingFarmResult,
 )
 from packit_service.service.db_triggers import (
     AddBranchPushDbTrigger,
@@ -224,6 +227,17 @@ def test_check_rerun_pr_testing_farm_handler(
     mock_pr_functionality, check_rerun_event_testing_farm
 ):
 
+    run = flexmock()
+    build = flexmock(status=BuildStatus.success, runs=[run])
+    test = flexmock(
+        copr_builds=[build],
+        status=TestingFarmResult.new,
+        target="fedora-rawhide-x86_64",
+    )
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args([run]).and_return(
+        flexmock(grouped_targets=[test])
+    )
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test)
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=True, details={})
     )
@@ -233,7 +247,7 @@ def test_check_rerun_pr_testing_farm_handler(
     )
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
-        flexmock(status=BuildStatus.success)
+        build
     )
     flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64", "fedora-34-x86_64"}
@@ -410,6 +424,17 @@ def test_check_rerun_push_testing_farm_handler(
     mock_push_functionality, check_rerun_event_testing_farm
 ):
 
+    run = flexmock()
+    build = flexmock(status=BuildStatus.success, runs=[run])
+    test = flexmock(
+        copr_builds=[build],
+        status=TestingFarmResult.new,
+        target="fedora-rawhide-x86_64",
+    )
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args([run]).and_return(
+        flexmock(grouped_targets=[test])
+    )
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test)
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=True, details={})
     )
@@ -419,7 +444,7 @@ def test_check_rerun_push_testing_farm_handler(
     )
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
-        flexmock(status=BuildStatus.success)
+        flexmock(status=BuildStatus.success, runs=[run])
     )
     flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64", "fedora-34-x86_64"}

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -227,7 +227,7 @@ def test_check_rerun_pr_testing_farm_handler(
     mock_pr_functionality, check_rerun_event_testing_farm
 ):
 
-    run = flexmock()
+    run = flexmock(test_run_group=None)
     build = flexmock(status=BuildStatus.success, group_of_targets=flexmock(runs=[run]))
     test = flexmock(
         copr_builds=[build],
@@ -424,7 +424,7 @@ def test_check_rerun_push_testing_farm_handler(
     mock_push_functionality, check_rerun_event_testing_farm
 ):
 
-    run = flexmock()
+    run = flexmock(test_run_group=None)
     build = flexmock(status=BuildStatus.success, group_of_targets=flexmock(runs=[run]))
     test = flexmock(
         copr_builds=[build],

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -658,6 +658,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         target="fedora-rawhide-x86_64",
         web_url=None,
         run_models=[copr_build_pr.runs[0]],
+        copr_build_targets=[copr_build_pr],
         data={"base_project_url": "https://github.com/foo/bar"},
     ).and_return(tft_test_run_model)
 

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -664,7 +664,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     )
     group = flexmock(grouped_targets=[tft_test_run_model])
     flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
-        [copr_build_pr.runs[-1]]
+        [copr_build_pr.group_of_targets.runs[-1]]
     ).and_return(group)
     flexmock(TFTTestRunTargetModel).should_receive("create").with_args(
         pipeline_id=None,
@@ -984,7 +984,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     )
     flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test)
     flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
-        [copr_build_pr.runs[-1]]
+        [copr_build_pr.group_of_targets.runs[-1]]
     ).and_return(flexmock(grouped_targets=[test]))
     flexmock(TestingFarmJobHelper).should_receive("is_fmf_configured").and_return(True)
     flexmock(TestingFarmJobHelper).should_receive("distro2compose").with_args(
@@ -1159,7 +1159,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         .mock()
     )
     flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
-        [copr_build_pr.runs[-1]]
+        [copr_build_pr.group_of_targets.runs[-1]]
     ).and_return(flexmock(grouped_targets=[test]))
     flexmock(TFTTestRunTargetModel).should_receive("create").and_return(
         flexmock(status=test)

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -30,6 +30,7 @@ from packit_service.models import (
     KojiBuildTargetModel,
     SRPMBuildModel,
     TFTTestRunTargetModel,
+    TFTTestRunGroupModel,
     TestingFarmResult,
     BuildStatus,
 )
@@ -649,15 +650,30 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         "https://github.com/foo/bar"
     )
 
-    tft_test_run_model = flexmock(id=5)
+    tft_test_run_model = (
+        flexmock(
+            id=5,
+            copr_builds=[copr_build_pr],
+            status=TestingFarmResult.new,
+            target="fedora-rawhide-x86_64",
+        )
+        .should_receive("set_pipeline_id")
+        .with_args(pipeline_id)
+        .once()
+        .mock()
+    )
+    group = flexmock(grouped_targets=[tft_test_run_model])
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
+        [copr_build_pr.runs[-1]]
+    ).and_return(group)
     flexmock(TFTTestRunTargetModel).should_receive("create").with_args(
-        pipeline_id=pipeline_id,
+        pipeline_id=None,
         identifier=None,
         commit_sha="0011223344",
         status=TestingFarmResult.new,
         target="fedora-rawhide-x86_64",
         web_url=None,
-        run_models=[copr_build_pr.runs[0]],
+        test_run_group=group,
         copr_build_targets=[copr_build_pr],
         data={"base_project_url": "https://github.com/foo/bar"},
     ).and_return(tft_test_run_model)
@@ -956,6 +972,20 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         markdown_content=None,
     ).once()
 
+    test = (
+        flexmock(
+            status=TestingFarmResult.new,
+            copr_builds=[copr_build_pr],
+            target="fedora-rawhide-x86_64",
+        )
+        .should_receive("set_status")
+        .with_args(TestingFarmResult.error)
+        .mock()
+    )
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test)
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
+        [copr_build_pr.runs[-1]]
+    ).and_return(flexmock(grouped_targets=[test]))
     flexmock(TestingFarmJobHelper).should_receive("is_fmf_configured").and_return(True)
     flexmock(TestingFarmJobHelper).should_receive("distro2compose").with_args(
         "fedora-rawhide-x86_64"
@@ -1118,6 +1148,22 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         markdown_content=None,
     ).once()
 
+    test = (
+        flexmock(
+            status=TestingFarmResult.new,
+            copr_builds=[copr_build_pr],
+            target="fedora-rawhide-x86_64",
+        )
+        .should_receive("set_status")
+        .with_args(TestingFarmResult.error)
+        .mock()
+    )
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
+        [copr_build_pr.runs[-1]]
+    ).and_return(flexmock(grouped_targets=[test]))
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(
+        flexmock(status=test)
+    )
     flexmock(TestingFarmJobHelper).should_receive("is_fmf_configured").and_return(True)
     flexmock(TestingFarmJobHelper).should_receive("distro2compose").with_args(
         "fedora-rawhide-x86_64"

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -571,7 +571,7 @@ def test_pr_test_command_handler(pr_embedded_command_comment_event):
         flexmock(grouped_targets=[test_run])
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
-        flexmock(status=BuildStatus.success, runs=[run])
+        flexmock(status=BuildStatus.success, group_of_targets=flexmock(runs=[run]))
     )
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=True, details={})
@@ -677,7 +677,9 @@ def test_pr_test_command_handler_identifiers(pr_embedded_command_comment_event):
         commit_sha="12345",
         owner=None,
         target="test-target",
-    ).and_return([flexmock(status=BuildStatus.success, runs=[run])])
+    ).and_return(
+        [flexmock(status=BuildStatus.success, group_of_targets=flexmock(runs=[run]))]
+    )
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=True, details={})
     )
@@ -991,7 +993,8 @@ def test_pr_test_command_handler_retries(
     task = run_testing_farm_handler.__wrapped__.__func__
     task(
         flexmock(
-            request=flexmock(retries=retry_number, kwargs={}), max_retries=DEFAULT_RETRY_LIMIT
+            request=flexmock(retries=retry_number, kwargs={}),
+            max_retries=DEFAULT_RETRY_LIMIT,
         ),
         package_config=package_config,
         event=event_dict,
@@ -2259,7 +2262,7 @@ def test_pr_test_command_handler_multiple_builds(pr_embedded_command_comment_eve
         owner="mf",
         project_name="tree",
         status=BuildStatus.success,
-        runs=[run_model],
+        group_of_targets=flexmock(runs=[run_model]),
     )
     build.should_receive("get_srpm_build").and_return(flexmock(url=None))
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -1116,6 +1116,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
         target="fedora-rawhide-x86_64",
         web_url=None,
         run_models=[run_model],
+        copr_build_targets=[],
         data={"base_project_url": "https://github.com/packit-service/hello-world"},
     ).and_return(tft_test_run_model)
 
@@ -2292,6 +2293,7 @@ def test_pr_test_command_handler_multiple_builds(pr_embedded_command_comment_eve
         target="fedora-rawhide-x86_64",
         web_url=None,
         run_models=[run_model, run_model2],
+        copr_build_targets=[build, additional_copr_build],
         data={"base_project_url": "https://github.com/packit-service/hello-world"},
     ).and_return(tft_test_run_model)
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -37,6 +37,7 @@ from packit_service.models import (
     PipelineModel,
     PullRequestModel,
     TFTTestRunTargetModel,
+    TFTTestRunGroupModel,
     TestingFarmResult,
     BuildStatus,
 )
@@ -557,8 +558,20 @@ def test_pr_test_command_handler(pr_embedded_command_comment_event):
     flexmock(CoprHelper).should_receive("get_valid_build_targets").times(5).and_return(
         {"test-target"}
     )
+    run = flexmock()
+    test_run = flexmock(
+        id=1,
+        status=TestingFarmResult.new,
+        copr_builds=[flexmock(status=BuildStatus.success)],
+        target="fedora-rawhide-x86_64",
+    )
+    flexmock(PipelineModel).should_receive("create").and_return(run)
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args([run]).and_return(
+        flexmock(grouped_targets=[test_run])
+    )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
-        flexmock(status=BuildStatus.success)
+        flexmock(status=BuildStatus.success, runs=[run])
     )
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=True, details={})
@@ -647,12 +660,24 @@ def test_pr_test_command_handler_identifiers(pr_embedded_command_comment_event):
     flexmock(CoprHelper).should_receive("get_valid_build_targets").times(5).and_return(
         {"test-target"}
     )
+    run = flexmock()
+    test_run = flexmock(
+        id=1,
+        status=TestingFarmResult.new,
+        copr_builds=[flexmock(status=BuildStatus.success)],
+        target="fedora-rawhide-x86_64",
+    )
+    flexmock(PipelineModel).should_receive("create").and_return(run)
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args([run]).and_return(
+        flexmock(grouped_targets=[test_run])
+    )
     flexmock(CoprBuildTargetModel).should_receive("get_all_by").with_args(
         project_name="packit-service-hello-world-9",
         commit_sha="12345",
         owner=None,
         target="test-target",
-    ).and_return([flexmock(status=BuildStatus.success)])
+    ).and_return([flexmock(status=BuildStatus.success, runs=[run])])
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=True, details={})
     )
@@ -917,8 +942,30 @@ def test_pr_test_command_handler_retries(
         "https://github.com/packit-service/hello-world"
     )
 
-    flexmock(PipelineModel).should_receive("create").never()
-    flexmock(TFTTestRunTargetModel).should_receive("create").never()
+    # On first run, we create the model, afterwards, we should get it from the DB
+    test_run = flexmock(
+        id=1, target="fedora-rawhide-x86_64", status=TestingFarmResult.new
+    )
+    group = flexmock(id=1, grouped_targets=[test_run])
+    test_run.group_of_targets = group
+    if retry_number > 0:
+        flexmock(PipelineModel).should_receive("create").never()
+        flexmock(TFTTestRunGroupModel).should_receive("create").never()
+        flexmock(TFTTestRunTargetModel).should_receive("create").never()
+        flexmock(TFTTestRunGroupModel).should_receive("get_by_id").and_return(group)
+    else:
+        flexmock(PipelineModel).should_receive("create").and_return(flexmock())
+        flexmock(TFTTestRunGroupModel).should_receive("create").and_return(group)
+        flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
+
+    if retry_number == 2:
+        flexmock(test_run).should_receive("set_status").with_args(
+            TestingFarmResult.error
+        )
+    else:
+        flexmock(test_run).should_receive("set_status").with_args(
+            TestingFarmResult.retry
+        )
 
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=status,
@@ -936,17 +983,20 @@ def test_pr_test_command_handler_retries(
     )
 
     if delay is not None:
-        flexmock(CeleryTask).should_receive("retry").with_args(delay=delay).once()
+        flexmock(CeleryTask).should_receive("retry").with_args(
+            delay=delay, kargs={"testing_farm_group_id": group.id}
+        ).once()
 
     assert json.dumps(event_dict)
     task = run_testing_farm_handler.__wrapped__.__func__
     task(
         flexmock(
-            request=flexmock(retries=retry_number), max_retries=DEFAULT_RETRY_LIMIT
+            request=flexmock(retries=retry_number, kwargs={}), max_retries=DEFAULT_RETRY_LIMIT
         ),
         package_config=package_config,
         event=event_dict,
         job_config=job_config,
+        testing_farm_group_id=None if retry_number == 0 else group.id,
     )
 
 
@@ -1105,20 +1155,29 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
         "https://github.com/packit-service/hello-world"
     )
 
-    tft_test_run_model = flexmock(id=5)
+    tft_test_run_model = flexmock(
+        id=5, status=TestingFarmResult.new, target="fedora-rawhide-x86_64"
+    )
     run_model = flexmock()
     flexmock(PipelineModel).should_receive("create").and_return(run_model)
+    group = flexmock(grouped_targets=[tft_test_run_model])
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
+        [run_model]
+    ).and_return(group)
     flexmock(TFTTestRunTargetModel).should_receive("create").with_args(
-        pipeline_id=pipeline_id,
+        pipeline_id=None,
         identifier=None,
         commit_sha="0011223344",
         status=TestingFarmResult.new,
         target="fedora-rawhide-x86_64",
         web_url=None,
-        run_models=[run_model],
+        test_run_group=group,
         copr_build_targets=[],
         data={"base_project_url": "https://github.com/packit-service/hello-world"},
     ).and_return(tft_test_run_model)
+    flexmock(tft_test_run_model).should_receive("set_pipeline_id").with_args(
+        pipeline_id
+    ).once()
 
     urls.DASHBOARD_URL = "https://dashboard.localhost"
     flexmock(StatusReporter).should_receive("report").with_args(
@@ -1195,6 +1254,19 @@ def test_pr_test_command_handler_compose_not_present(
     flexmock(PullRequestModel).should_receive("get_by_id").with_args(123).and_return(
         trigger
     )
+
+    run_model = flexmock()
+    test_run = flexmock(
+        id=1,
+        status=TestingFarmResult.new,
+        copr_builds=[flexmock(status=BuildStatus.success)],
+        target="fedora-rawhide-x86_64",
+    )
+    flexmock(PipelineModel).should_receive("create").and_return(run_model)
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
+        [run_model]
+    ).and_return(flexmock(grouped_targets=[test_run]))
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Allowlist, check_and_report=True)
     pr_model = flexmock(
@@ -1323,6 +1395,18 @@ def test_pr_test_command_handler_composes_not_available(
     flexmock(PullRequestModel).should_receive("get_by_id").with_args(123).and_return(
         trigger
     )
+    run_model = flexmock()
+    test_run = flexmock(
+        id=1,
+        status=TestingFarmResult.new,
+        copr_builds=[flexmock(status=BuildStatus.success)],
+        target="fedora-rawhide-x86_64",
+    )
+    flexmock(PipelineModel).should_receive("create").and_return(run_model)
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
+        [run_model]
+    ).and_return(flexmock(grouped_targets=[test_run]))
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Allowlist, check_and_report=True)
     pr_model = flexmock(
@@ -1450,6 +1534,18 @@ def test_pr_test_command_handler_missing_build(pr_embedded_command_comment_event
     flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"test-target", "test-target-without-build"}
     )
+    run_model = flexmock()
+    test_run = flexmock(
+        id=1,
+        status=TestingFarmResult.new,
+        copr_builds=[flexmock(status=BuildStatus.success)],
+        target="test-target",
+    )
+    flexmock(PipelineModel).should_receive("create").and_return(run_model)
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
+        [run_model]
+    ).and_return(flexmock(grouped_targets=[test_run]))
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
         flexmock(status=BuildStatus.success)
     ).and_return()
@@ -1540,6 +1636,18 @@ def test_pr_test_command_handler_missing_build_trigger_with_build_job_config(
     flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
         type=JobTriggerModelType.pull_request, trigger_id=9
     ).and_return(trigger)
+    run_model = flexmock()
+    test_run = flexmock(
+        id=1,
+        status=TestingFarmResult.new,
+        copr_builds=[flexmock(status=BuildStatus.success)],
+        target="test-target",
+    )
+    flexmock(PipelineModel).should_receive("create").and_return(run_model)
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
+        [run_model]
+    ).and_return(flexmock(grouped_targets=[test_run]))
 
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(GithubProject, get_files="foo.spec")
@@ -1791,8 +1899,17 @@ def test_retest_failed(
         repo_name="hello-world",
         project_url="https://github.com/packit-service/hello-world",
     ).and_return(
-        flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
+        flexmock(
+            id=9,
+            job_config_trigger_type=JobConfigTriggerType.pull_request,
+            job_trigger_model_type=JobTriggerModelType.pull_request,
+        )
     )
+    run_model = flexmock()
+    flexmock(PipelineModel).should_receive("create").and_return(run_model)
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
+        [run_model]
+    ).and_return(flexmock())
 
     pr_embedded_command_comment_event["comment"]["body"] = "/packit retest-failed"
     flexmock(GithubProject, get_files="foo.spec")
@@ -1925,6 +2042,16 @@ def test_pr_test_command_handler_skip_build_option_no_fmf_metadata(
     flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64"}
     )
+    run_model = flexmock()
+    test_run = flexmock(
+        id=1, target="fedora-rawhide-x86_64", status=TestingFarmResult.new
+    )
+    flexmock(PipelineModel).should_receive("create").and_return(run_model)
+    group_model = flexmock(grouped_targets=[test_run])
+    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
+        [run_model]
+    ).and_return(group_model)
+    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
     flexmock(Pushgateway).should_receive("push").twice().and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
@@ -2244,7 +2371,18 @@ def test_pr_test_command_handler_multiple_builds(pr_embedded_command_comment_eve
         "https://github.com/packit-service/hello-world"
     )
 
-    tft_test_run_model = flexmock(id=5)
+    tft_test_run_model_rawhide = flexmock(
+        id=5,
+        copr_builds=[build],
+        status=TestingFarmResult.new,
+        target="fedora-rawhide-x86_64",
+    )
+    tft_test_run_model_35 = flexmock(
+        id=6,
+        copr_builds=[build],
+        status=TestingFarmResult.new,
+        target="fedora-35-x86_64",
+    )
 
     run_model2 = flexmock(PipelineModel)
     additional_copr_build = flexmock(
@@ -2285,17 +2423,34 @@ def test_pr_test_command_handler_multiple_builds(pr_embedded_command_comment_eve
         2
     )
 
-    flexmock(TFTTestRunTargetModel).should_receive("create").with_args(
-        pipeline_id=pipeline_id,
-        identifier=None,
-        commit_sha="0011223344",
-        status=TestingFarmResult.new,
-        target="fedora-rawhide-x86_64",
-        web_url=None,
-        run_models=[run_model, run_model2],
-        copr_build_targets=[build, additional_copr_build],
-        data={"base_project_url": "https://github.com/packit-service/hello-world"},
-    ).and_return(tft_test_run_model)
+    group = flexmock(
+        id=1,
+        runs=[run_model],
+        grouped_targets=[tft_test_run_model_rawhide, tft_test_run_model_35],
+    )
+    run_model = flexmock(run_model, test_run_group=group)
+    flexmock(TFTTestRunGroupModel).should_receive("create").and_return(group)
+    for t, model in (
+        ("fedora-35-x86_64", tft_test_run_model_35),
+        ("fedora-rawhide-x86_64", tft_test_run_model_rawhide),
+    ):
+        flexmock(TFTTestRunTargetModel).should_receive("create").with_args(
+            pipeline_id=None,
+            identifier=None,
+            commit_sha="0011223344",
+            status=TestingFarmResult.new,
+            target=t,
+            web_url=None,
+            test_run_group=group,
+            copr_build_targets=[build],
+            data={"base_project_url": "https://github.com/packit-service/hello-world"},
+        ).and_return(model)
+    flexmock(tft_test_run_model_rawhide).should_receive("add_copr_build").with_args(
+        additional_copr_build
+    )
+    flexmock(tft_test_run_model_rawhide).should_receive("set_pipeline_id").with_args(
+        pipeline_id
+    )
 
     urls.DASHBOARD_URL = "https://dashboard.localhost"
     flexmock(StatusReporter).should_receive("report").with_args(

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -22,6 +22,7 @@ from packit_service.config import ServiceConfig
 from packit_service.models import (
     SRPMBuildModel,
     KojiBuildTargetModel,
+    KojiBuildGroupModel,
     JobTriggerModel,
     JobTriggerModelType,
     BuildStatus,
@@ -165,7 +166,14 @@ def test_koji_build_check_names(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(KojiBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(KojiBuildGroupModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(KojiBuildTargetModel).should_receive("create").and_return(
+        flexmock(id=1)
+        .should_receive("set_build_id")
+        .mock()
+        .should_receive("set_web_url")
+        .mock()
+    )
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     # koji build
@@ -316,6 +324,7 @@ def test_koji_build_target_not_supported(github_pr_event):
             flexmock(),
         )
     )
+    flexmock(KojiBuildGroupModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(KojiBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
@@ -371,9 +380,20 @@ def test_koji_build_with_multiple_targets(github_pr_event):
             flexmock(),
         )
     )
+    flexmock(KojiBuildGroupModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(KojiBuildTargetModel).should_receive("create").and_return(
         flexmock(id=1)
-    ).and_return(flexmock(id=2))
+        .should_receive("set_build_id")
+        .mock()
+        .should_receive("set_web_url")
+        .mock()
+    ).and_return(
+        flexmock(id=2)
+        .should_receive("set_build_id")
+        .mock()
+        .should_receive("set_web_url")
+        .mock()
+    )
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     # koji build
@@ -454,7 +474,10 @@ def test_koji_build_failed(github_pr_event):
             flexmock(),
         )
     )
-    flexmock(KojiBuildTargetModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(KojiBuildGroupModel).should_receive("create").and_return(flexmock(id=1))
+    flexmock(KojiBuildTargetModel).should_receive("create").and_return(
+        flexmock(id=1).should_receive("set_status").with_args("error").mock()
+    )
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     # koji build
@@ -576,9 +599,20 @@ def test_koji_build_targets_override(github_pr_event):
             flexmock(),
         )
     )
+    flexmock(KojiBuildGroupModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(KojiBuildTargetModel).should_receive("create").and_return(
         flexmock(id=1)
-    ).and_return(flexmock(id=2))
+        .should_receive("set_build_id")
+        .mock()
+        .should_receive("set_web_url")
+        .mock()
+    ).and_return(
+        flexmock(id=2)
+        .should_receive("set_build_id")
+        .mock()
+        .should_receive("set_web_url")
+        .mock()
+    )
     flexmock(PackitAPI).should_receive("create_srpm").and_return("my.srpm")
 
     # koji build

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -931,7 +931,7 @@ def test_get_request_details():
             flexmock(
                 commit_sha="1111111111111111111111111111111111111111",
                 status=BuildStatus.success,
-                group_of_targets=flexmock(runs=[flexmock()]),
+                group_of_targets=flexmock(runs=[flexmock(test_run_group=None)]),
             ),
             False,
             False,
@@ -941,7 +941,7 @@ def test_get_request_details():
                 id=1,
                 commit_sha="1111111111111111111111111111111111111111",
                 status=BuildStatus.pending,
-                group_of_targets=flexmock(runs=[flexmock()]),
+                group_of_targets=flexmock(runs=[flexmock(test_run_group=None)]),
             ),
             False,
             True,

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -931,7 +931,7 @@ def test_get_request_details():
             flexmock(
                 commit_sha="1111111111111111111111111111111111111111",
                 status=BuildStatus.success,
-                runs=[flexmock()],
+                group_of_targets=flexmock(runs=[flexmock()]),
             ),
             False,
             False,
@@ -941,7 +941,7 @@ def test_get_request_details():
                 id=1,
                 commit_sha="1111111111111111111111111111111111111111",
                 status=BuildStatus.pending,
-                runs=[flexmock()],
+                group_of_targets=flexmock(runs=[flexmock()]),
             ),
             False,
             True,

--- a/tests_openshift/conftest.py
+++ b/tests_openshift/conftest.py
@@ -33,6 +33,7 @@ from packit_service.models import (
     PipelineModel,
     JobTriggerModelType,
     KojiBuildTargetModel,
+    KojiBuildGroupModel,
     TFTTestRunTargetModel,
     TFTTestRunGroupModel,
     TestingFarmResult,
@@ -714,6 +715,7 @@ def copr_builds_with_different_triggers(
 @pytest.fixture()
 def a_koji_build_for_pr(srpm_build_model_with_new_run_for_pr):
     _, run_model = srpm_build_model_with_new_run_for_pr
+    group = KojiBuildGroupModel.create(run_model)
     koji_build_model = KojiBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
@@ -721,7 +723,7 @@ def a_koji_build_for_pr(srpm_build_model_with_new_run_for_pr):
         target=SampleValues.target,
         status=SampleValues.status_pending,
         scratch=True,
-        run_model=run_model,
+        koji_build_group=group,
     )
     koji_build_model.set_build_logs_url(
         "https://koji.somewhere/results/owner/package/target/build.logs"
@@ -732,6 +734,7 @@ def a_koji_build_for_pr(srpm_build_model_with_new_run_for_pr):
 @pytest.fixture()
 def a_koji_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
     _, run_model = srpm_build_model_with_new_run_for_branch
+    group = KojiBuildGroupModel.create(run_model)
 
     yield KojiBuildTargetModel.create(
         build_id=SampleValues.build_id,
@@ -740,13 +743,14 @@ def a_koji_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
         target=SampleValues.target,
         status=SampleValues.status_pending,
         scratch=True,
-        run_model=run_model,
+        koji_build_group=group,
     )
 
 
 @pytest.fixture()
 def a_koji_build_for_release(srpm_build_model_with_new_run_for_release):
     _, run_model = srpm_build_model_with_new_run_for_release
+    group = KojiBuildGroupModel.create(run_model)
 
     yield KojiBuildTargetModel.create(
         build_id=SampleValues.build_id,
@@ -755,7 +759,7 @@ def a_koji_build_for_release(srpm_build_model_with_new_run_for_release):
         target=SampleValues.target,
         status=SampleValues.status_pending,
         scratch=True,
-        run_model=run_model,
+        koji_build_group=group,
     )
 
 
@@ -764,12 +768,15 @@ def multiple_koji_builds(pr_model, different_pr_model):
     _, run_model_for_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=pr_model, commit_sha=SampleValues.commit_sha
     )
+    group_for_pr = KojiBuildGroupModel.create(run_model_for_pr)
     _, run_model_for_same_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=pr_model, commit_sha=SampleValues.commit_sha
     )
+    group_for_same_pr = KojiBuildGroupModel.create(run_model_for_same_pr)
     _, run_model_for_a_different_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=different_pr_model, commit_sha=SampleValues.commit_sha
     )
+    group_for_a_different_pr = KojiBuildGroupModel.create(run_model_for_a_different_pr)
 
     yield [
         # Two builds for same run
@@ -780,7 +787,7 @@ def multiple_koji_builds(pr_model, different_pr_model):
             target=SampleValues.target,
             status=SampleValues.status_pending,
             scratch=True,
-            run_model=run_model_for_pr,
+            koji_build_group=group_for_pr,
         ),
         KojiBuildTargetModel.create(
             build_id=SampleValues.different_build_id,
@@ -789,7 +796,7 @@ def multiple_koji_builds(pr_model, different_pr_model):
             target=SampleValues.different_target,
             status=SampleValues.status_pending,
             scratch=True,
-            run_model=run_model_for_pr,
+            koji_build_group=group_for_pr,
         ),
         # Same PR, different run
         KojiBuildTargetModel.create(
@@ -799,7 +806,7 @@ def multiple_koji_builds(pr_model, different_pr_model):
             target=SampleValues.different_target,
             status=SampleValues.status_pending,
             scratch=True,
-            run_model=run_model_for_same_pr,
+            koji_build_group=group_for_same_pr,
         ),
         # Completely different build
         KojiBuildTargetModel.create(
@@ -809,7 +816,7 @@ def multiple_koji_builds(pr_model, different_pr_model):
             target=SampleValues.target,
             status=SampleValues.status_pending,
             scratch=True,
-            run_model=run_model_for_a_different_pr,
+            koji_build_group=group_for_a_different_pr,
         ),
     ]
 

--- a/tests_openshift/conftest.py
+++ b/tests_openshift/conftest.py
@@ -20,6 +20,7 @@ from ogr import GithubService, GitlabService, PagureService
 from packit_service.config import ServiceConfig
 from packit_service.models import (
     CoprBuildTargetModel,
+    CoprBuildGroupModel,
     JobTriggerModel,
     sa_session_transaction,
     SRPMBuildModel,
@@ -450,6 +451,7 @@ def different_issue_model():
 @pytest.fixture()
 def a_copr_build_for_pr(srpm_build_model_with_new_run_for_pr):
     _, run_model = srpm_build_model_with_new_run_for_pr
+    group = CoprBuildGroupModel.create(run_model)
     copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
@@ -458,7 +460,7 @@ def a_copr_build_for_pr(srpm_build_model_with_new_run_for_pr):
         web_url=SampleValues.copr_web_url,
         target=SampleValues.target,
         status=SampleValues.status_pending,
-        run_model=run_model,
+        copr_build_group=group,
     )
     copr_build_model.set_build_logs_url(
         "https://copr.somewhere/results/owner/package/target/build.logs"
@@ -470,6 +472,7 @@ def a_copr_build_for_pr(srpm_build_model_with_new_run_for_pr):
 @pytest.fixture()
 def a_copr_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
     _, run_model = srpm_build_model_with_new_run_for_branch
+    group = CoprBuildGroupModel.create(run_model)
     copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
@@ -478,7 +481,7 @@ def a_copr_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
         web_url=SampleValues.copr_web_url,
         target=SampleValues.target,
         status=SampleValues.status_pending,
-        run_model=run_model,
+        copr_build_group=group,
     )
     copr_build_model.set_build_logs_url(
         "https://copr.somewhere/results/owner/package/target/build.logs"
@@ -489,6 +492,7 @@ def a_copr_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
 @pytest.fixture()
 def a_copr_build_for_release(srpm_build_model_with_new_run_for_release):
     _, run_model = srpm_build_model_with_new_run_for_release
+    group = CoprBuildGroupModel.create(run_model)
     copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
@@ -497,7 +501,7 @@ def a_copr_build_for_release(srpm_build_model_with_new_run_for_release):
         web_url=SampleValues.copr_web_url,
         target=SampleValues.target,
         status=SampleValues.status_pending,
-        run_model=run_model,
+        copr_build_group=group,
     )
     copr_build_model.set_build_logs_url(
         "https://copr.somewhere/results/owner/package/target/build.logs"
@@ -508,6 +512,7 @@ def a_copr_build_for_release(srpm_build_model_with_new_run_for_release):
 @pytest.fixture()
 def a_copr_build_waiting_for_srpm(srpm_build_in_copr_model):
     _, run_model = srpm_build_in_copr_model
+    group = CoprBuildGroupModel.create(run_model)
     copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         commit_sha=SampleValues.commit_sha,
@@ -516,7 +521,7 @@ def a_copr_build_waiting_for_srpm(srpm_build_in_copr_model):
         web_url=SampleValues.copr_web_url,
         target=SampleValues.target,
         status=SampleValues.status_waiting_for_srpm,
-        run_model=run_model,
+        copr_build_group=group,
     )
     copr_build_model.set_build_logs_url(
         "https://copr.somewhere/results/owner/package/target/build.logs"
@@ -530,12 +535,15 @@ def multiple_copr_builds(pr_model, different_pr_model):
     _, run_model_for_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=pr_model, commit_sha=SampleValues.commit_sha
     )
+    group_for_pr = CoprBuildGroupModel.create(run_model_for_pr)
     _, run_model_for_same_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=pr_model, commit_sha=SampleValues.commit_sha
     )
+    group_for_same_pr = CoprBuildGroupModel.create(run_model_for_same_pr)
     _, run_model_for_a_different_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=different_pr_model, commit_sha=SampleValues.commit_sha
     )
+    group_for_a_different_pr = CoprBuildGroupModel.create(run_model_for_a_different_pr)
 
     yield [
         # Two chroots for one run model
@@ -547,7 +555,7 @@ def multiple_copr_builds(pr_model, different_pr_model):
             web_url=SampleValues.copr_web_url,
             target=SampleValues.target,
             status=SampleValues.status_success,
-            run_model=run_model_for_pr,
+            copr_build_group=group_for_pr,
         ),
         CoprBuildTargetModel.create(
             build_id=SampleValues.build_id,
@@ -557,7 +565,7 @@ def multiple_copr_builds(pr_model, different_pr_model):
             web_url=SampleValues.copr_web_url,
             target=SampleValues.different_target,
             status=SampleValues.status_pending,
-            run_model=run_model_for_pr,
+            copr_build_group=group_for_pr,
         ),
         # Same PR, same ref, but different run model
         CoprBuildTargetModel.create(
@@ -568,7 +576,7 @@ def multiple_copr_builds(pr_model, different_pr_model):
             web_url=SampleValues.copr_web_url,
             target=SampleValues.target,
             status=SampleValues.status_success,
-            run_model=run_model_for_same_pr,
+            copr_build_group=group_for_same_pr,
         ),
         # Different PR
         CoprBuildTargetModel.create(
@@ -579,7 +587,7 @@ def multiple_copr_builds(pr_model, different_pr_model):
             web_url=SampleValues.copr_web_url,
             target=SampleValues.target,
             status=SampleValues.status_success,
-            run_model=run_model_for_a_different_pr,
+            copr_build_group=group_for_a_different_pr,
         ),
     ]
 
@@ -593,11 +601,16 @@ def too_many_copr_builds(pr_model, different_pr_model):
         _, run_model_for_pr = SRPMBuildModel.create_with_new_run(
             trigger_model=pr_model, commit_sha=SampleValues.commit_sha
         )
+        group_for_pr = CoprBuildGroupModel.create(run_model_for_pr)
         _, run_model_for_same_pr = SRPMBuildModel.create_with_new_run(
             trigger_model=pr_model, commit_sha=SampleValues.commit_sha
         )
+        group_for_same_pr = CoprBuildGroupModel.create(run_model_for_same_pr)
         _, run_model_for_a_different_pr = SRPMBuildModel.create_with_new_run(
             trigger_model=different_pr_model, commit_sha=SampleValues.commit_sha
+        )
+        group_for_a_different_pr = CoprBuildGroupModel.create(
+            run_model_for_a_different_pr
         )
 
         builds_list += [
@@ -610,7 +623,7 @@ def too_many_copr_builds(pr_model, different_pr_model):
                 web_url=SampleValues.copr_web_url + str(i),
                 target=SampleValues.target,
                 status=SampleValues.status_success,
-                run_model=run_model_for_pr,
+                copr_build_group=group_for_pr,
             ),
             CoprBuildTargetModel.create(
                 build_id=SampleValues.build_id + str(i),
@@ -620,7 +633,7 @@ def too_many_copr_builds(pr_model, different_pr_model):
                 web_url=SampleValues.copr_web_url + str(i),
                 target=SampleValues.different_target,
                 status=SampleValues.status_pending,
-                run_model=run_model_for_pr,
+                copr_build_group=group_for_pr,
             ),
             # Same PR, different run model
             CoprBuildTargetModel.create(
@@ -631,7 +644,7 @@ def too_many_copr_builds(pr_model, different_pr_model):
                 web_url=SampleValues.copr_web_url + str(i),
                 target=SampleValues.target,
                 status=SampleValues.status_success,
-                run_model=run_model_for_same_pr,
+                copr_build_group=group_for_same_pr,
             ),
             # Different PR:
             CoprBuildTargetModel.create(
@@ -642,7 +655,7 @@ def too_many_copr_builds(pr_model, different_pr_model):
                 web_url=SampleValues.copr_web_url + str(i),
                 target=SampleValues.different_target,
                 status=SampleValues.status_success,
-                run_model=run_model_for_a_different_pr,
+                copr_build_group=group_for_a_different_pr,
             ),
         ]
     yield builds_list
@@ -657,6 +670,9 @@ def copr_builds_with_different_triggers(
     _, run_model_for_pr = srpm_build_model_with_new_run_for_pr
     _, run_model_for_branch = srpm_build_model_with_new_run_for_branch
     _, run_model_for_release = srpm_build_model_with_new_run_for_release
+    group_for_pr = CoprBuildGroupModel.create(run_model_for_pr)
+    group_for_branch = CoprBuildGroupModel.create(run_model_for_branch)
+    group_for_release = CoprBuildGroupModel.create(run_model_for_release)
 
     yield [
         # pull request trigger
@@ -668,7 +684,7 @@ def copr_builds_with_different_triggers(
             web_url=SampleValues.copr_web_url,
             target=SampleValues.target,
             status=SampleValues.status_success,
-            run_model=run_model_for_pr,
+            copr_build_group=group_for_pr,
         ),
         # branch push trigger
         CoprBuildTargetModel.create(
@@ -679,7 +695,7 @@ def copr_builds_with_different_triggers(
             web_url=SampleValues.copr_web_url,
             target=SampleValues.target,
             status=SampleValues.status_success,
-            run_model=run_model_for_branch,
+            copr_build_group=group_for_branch,
         ),
         # release trigger
         CoprBuildTargetModel.create(
@@ -690,7 +706,7 @@ def copr_builds_with_different_triggers(
             web_url=SampleValues.copr_web_url,
             target=SampleValues.target,
             status=SampleValues.status_success,
-            run_model=run_model_for_release,
+            copr_build_group=group_for_release,
         ),
     ]
 
@@ -833,15 +849,22 @@ def multiple_new_test_runs(pr_model, different_pr_model):
     _, run_model_for_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=pr_model, commit_sha=SampleValues.commit_sha
     )
-    group_for_pr = TFTTestRunGroupModel.create([run_model_for_pr])
+    test_group_for_pr = TFTTestRunGroupModel.create([run_model_for_pr])
+    build_group_for_pr = CoprBuildGroupModel.create(run_model_for_pr)
     _, run_model_for_same_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=pr_model, commit_sha=SampleValues.commit_sha
     )
-    group_for_same_pr = TFTTestRunGroupModel.create([run_model_for_same_pr])
+    test_group_for_same_pr = TFTTestRunGroupModel.create([run_model_for_same_pr])
+    build_group_for_same_pr = CoprBuildGroupModel.create(run_model_for_same_pr)
     _, run_model_for_a_different_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=different_pr_model, commit_sha=SampleValues.commit_sha
     )
-    group_for_different_pr = TFTTestRunGroupModel.create([run_model_for_a_different_pr])
+    build_group_for_a_different_pr = CoprBuildGroupModel.create(
+        run_model_for_a_different_pr
+    )
+    test_group_for_different_pr = TFTTestRunGroupModel.create(
+        [run_model_for_a_different_pr]
+    )
 
     CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
@@ -851,7 +874,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
         web_url=SampleValues.copr_web_url,
         target=SampleValues.target,
         status=SampleValues.status_success,
-        run_model=run_model_for_pr,
+        copr_build_group=build_group_for_pr,
     )
 
     # Same PR, same ref, but different run model
@@ -863,7 +886,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
         web_url=SampleValues.copr_web_url,
         target=SampleValues.target,
         status=SampleValues.status_success,
-        run_model=run_model_for_same_pr,
+        copr_build_group=build_group_for_same_pr,
     )
 
     # Different PR
@@ -875,7 +898,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
         web_url=SampleValues.copr_web_url,
         target=SampleValues.target,
         status=SampleValues.status_success,
-        run_model=run_model_for_a_different_pr,
+        copr_build_group=build_group_for_a_different_pr,
     )
 
     yield [
@@ -885,7 +908,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
             web_url=SampleValues.testing_farm_url,
             target=SampleValues.target,
             status=TestingFarmResult.new,
-            test_run_group=group_for_pr,
+            test_run_group=test_group_for_pr,
         ),
         # Same commit_sha but different chroot and pipeline_id
         TFTTestRunTargetModel.create(
@@ -894,7 +917,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
             web_url=SampleValues.testing_farm_url,
             target=SampleValues.different_target,
             status=TestingFarmResult.new,
-            test_run_group=group_for_pr,
+            test_run_group=test_group_for_pr,
         ),
         # Same PR, different run model
         TFTTestRunTargetModel.create(
@@ -903,7 +926,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
             web_url=SampleValues.testing_farm_url,
             target=SampleValues.different_target,
             status=TestingFarmResult.new,
-            test_run_group=group_for_same_pr,
+            test_run_group=test_group_for_same_pr,
         ),
         # Completely different build
         TFTTestRunTargetModel.create(
@@ -912,7 +935,7 @@ def multiple_new_test_runs(pr_model, different_pr_model):
             web_url=SampleValues.testing_farm_url,
             target=SampleValues.different_target,
             status=TestingFarmResult.running,
-            test_run_group=group_for_different_pr,
+            test_run_group=test_group_for_different_pr,
         ),
     ]
 
@@ -1921,6 +1944,7 @@ def few_runs(pr_model, different_pr_model):
     _, run_model_for_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=pr_model, commit_sha=SampleValues.commit_sha
     )
+    build_group = CoprBuildGroupModel.create(run_model_for_pr)
     TFTTestRunGroupModel.create([run_model_for_pr])
 
     for target in (SampleValues.target, SampleValues.different_target):
@@ -1932,7 +1956,7 @@ def few_runs(pr_model, different_pr_model):
             web_url=SampleValues.copr_web_url,
             target=target,
             status=SampleValues.status_success,
-            run_model=run_model_for_pr,
+            copr_build_group=build_group,
         )
 
         TFTTestRunTargetModel.create(
@@ -1941,12 +1965,14 @@ def few_runs(pr_model, different_pr_model):
             web_url=SampleValues.testing_farm_url,
             target=target,
             status=TestingFarmResult.new,
-            test_run_group=copr_build.runs[0].test_run_group,
+            test_run_group=copr_build.group_of_targets.runs[0].test_run_group,
         )
 
     _, run_model_for_different_pr = SRPMBuildModel.create_with_new_run(
         trigger_model=different_pr_model, commit_sha=SampleValues.commit_sha
     )
+    TFTTestRunGroupModel.create([run_model_for_different_pr])
+    build_group = CoprBuildGroupModel.create(run_model_for_different_pr)
 
     runs = []
     for target in (SampleValues.target, SampleValues.different_target):
@@ -1958,9 +1984,9 @@ def few_runs(pr_model, different_pr_model):
             web_url=SampleValues.copr_web_url,
             target=target,
             status=SampleValues.status_success,
-            run_model=run_model_for_different_pr,
+            copr_build_group=build_group,
         )
-        runs.append(copr_build.runs[0])
+        runs.append(copr_build.group_of_targets.runs[0])
 
         TFTTestRunTargetModel.create(
             pipeline_id=SampleValues.pipeline_id,

--- a/tests_openshift/database/test_models.py
+++ b/tests_openshift/database/test_models.py
@@ -14,6 +14,7 @@ from packit_service.models import (
     GithubInstallationModel,
     JobTriggerModelType,
     KojiBuildTargetModel,
+    KojiBuildGroupModel,
     ProjectAuthenticationIssueModel,
     ProjectReleaseModel,
     PullRequestModel,
@@ -422,6 +423,7 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
     srpm_build_for_koji, run_model_for_koji = SRPMBuildModel.create_with_new_run(
         trigger_model=pr1, commit_sha="687abc76d67d"
     )
+    koji_group = KojiBuildGroupModel.create(run_model_for_koji)
     srpm_build_for_copr.set_logs("asd\nqwe\n")
     srpm_build_for_copr.set_status(BuildStatus.success)
 
@@ -442,7 +444,7 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
         target=SampleValues.target,
         status="pending",
         scratch=True,
-        run_model=run_model_for_koji,
+        koji_build_group=koji_group,
     )
 
     assert copr_build in pr1.get_copr_builds()
@@ -458,8 +460,8 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
     assert copr_build.get_trigger_object() == pr1
     assert koji_build.get_trigger_object() == pr1
 
-    assert len(koji_build.runs) == 1
-    assert koji_build.runs[0] == run_model_for_koji
+    assert len(koji_build.group_of_targets.runs) == 1
+    assert koji_build.group_of_targets.runs[0] == run_model_for_koji
     assert len(copr_build.group_of_targets.runs) == 1
     assert copr_build.group_of_targets.runs[0] == run_model_for_copr
 

--- a/tests_openshift/database/test_tasks.py
+++ b/tests_openshift/database/test_tasks.py
@@ -17,6 +17,7 @@ from packit.config import (
 )
 from packit_service.models import (
     CoprBuildTargetModel,
+    CoprBuildGroupModel,
     SRPMBuildModel,
     PullRequestModel,
     BuildStatus,
@@ -65,6 +66,7 @@ def packit_build_752():
     srpm_build, run_model = SRPMBuildModel.create_with_new_run(
         trigger_model=pr_model, commit_sha="687abc76d67d"
     )
+    group = CoprBuildGroupModel.create(run_model)
     srpm_build.set_logs("asd\nqwe\n")
     srpm_build.set_status("success")
     yield CoprBuildTargetModel.create(
@@ -78,7 +80,7 @@ def packit_build_752():
         ),
         target="fedora-rawhide-x86_64",
         status=BuildStatus.pending,
-        run_model=run_model,
+        copr_build_group=group,
     )
 
 

--- a/tests_openshift/service/test_api.py
+++ b/tests_openshift/service/test_api.py
@@ -587,10 +587,10 @@ def test_detailed_propose_info_issue(
         "events/release/events_handled",
         "jobs/srpm_builds/job_runs",
         "jobs/srpm_builds/top_projects_by_job_runs",
-        "jobs/copr_build_targets/job_runs",
-        "jobs/copr_build_targets/top_projects_by_job_runs",
-        "jobs/copr_build_targets/per_event/pull_request/job_runs",
-        "jobs/copr_build_targets/per_event/pull_request/top_projects_by_job_runs",
+        "jobs/copr_build_groups/job_runs",
+        "jobs/copr_build_groups/top_projects_by_job_runs",
+        "jobs/copr_build_groups/per_event/pull_request/job_runs",
+        "jobs/copr_build_groups/per_event/pull_request/top_projects_by_job_runs",
     ],
 )
 def test_usage_info_structure(
@@ -644,18 +644,18 @@ def test_usage_info_top(client, clean_before_and_after, full_database):
             "jobs/srpm_builds/top_projects_by_job_runs",
             {"https://github.com/the-namespace/the-repo-name": 13},
         ),
-        ("jobs/copr_build_targets/job_runs", 14),
+        ("jobs/copr_build_groups/job_runs", 13),
         (
-            "jobs/copr_build_targets/top_projects_by_job_runs",
-            {"https://github.com/the-namespace/the-repo-name": 14},
+            "jobs/copr_build_groups/top_projects_by_job_runs",
+            {"https://github.com/the-namespace/the-repo-name": 13},
         ),
         (
-            "jobs/copr_build_targets/per_event/pull_request/job_runs",
-            10,
+            "jobs/copr_build_groups/per_event/pull_request/job_runs",
+            9,
         ),
         (
-            "jobs/copr_build_targets/per_event/pull_request/top_projects_by_job_runs",
-            {"https://github.com/the-namespace/the-repo-name": 10},
+            "jobs/copr_build_groups/per_event/pull_request/top_projects_by_job_runs",
+            {"https://github.com/the-namespace/the-repo-name": 9},
         ),
     ],
 )
@@ -706,24 +706,24 @@ def test_project_usage_info(
         )
         == 1
     )
-    assert nested_get(response_dict, "jobs", "tft_test_run_targets", "job_runs") == 6
-    assert nested_get(response_dict, "jobs", "tft_test_run_targets", "position") == 1
+    assert nested_get(response_dict, "jobs", "tft_test_run_groups", "job_runs") == 5
+    assert nested_get(response_dict, "jobs", "tft_test_run_groups", "position") == 1
     assert (
         nested_get(
             response_dict,
             "jobs",
-            "tft_test_run_targets",
+            "tft_test_run_groups",
             "per_event",
             "pull_request",
             "job_runs",
         )
-        == 5
+        == 4
     )
     assert (
         nested_get(
             response_dict,
             "jobs",
-            "tft_test_run_targets",
+            "tft_test_run_groups",
             "per_event",
             "pull_request",
             "position",


### PR DESCRIPTION
This is a good candidate for a pair review, here are just some pointers:
- The diff looks scary but a lot of it is just tests and migrations which contain definition of models
- We now create a model before sending a request to TF/Copr/Koji, the model will have an empty pipeline ID/web url since it is not known yet. This will be filled in later, once the request succeeds. For handling retries, the handlers now accept a group ID which they fetch rather than creating a new model to avoid creating unnecessary models on failures.
- As discussed at last arch, I added an explicit M:N mapping between copr and TF. This was necessary because by introducing groups, a pipeline now contains a group of runs and a group of tests and mapping a test to a single build (e.g. f35 test to f35 build) would otherwise be impossible.
- Testing farm changes are probably the most prone to breaking (lots of merge conflicts, I tried to make groups work with Laura's recent work), koji and copr seemed a lot less complex.
- I also made some changes to documentation and some other improvements along the way
- The migrations are not really backwards compatible, even though I tried my best. When you merge something, splitting it back is complicated. Also see my TODO comment in the migrations `            # TODO: should we merge the groups? This would result in deletion and possibly some mess`. I feel like removing existing pipelines is not the way to go so I rather went with "duplicating data"

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`. [nothing to document]
- [x] Add API endpoints for getting group data by ID (may not be necessary for now, the existing API should be more-or-less unimpacted, but it may be useful for the future)
- [x] Try running the migration on production data to see how fast it runs and if there is any need for trying to optimize (the 4 migrations take roughly a minute for stage data on my local machine).
- [x] Openshift tests?


Fixes:  #1327 
Fixes: #1665 

---

RELEASE NOTES BEGIN
Packit now groups related builds and test runs (e.g. triggered by the same event, just different chroots) together. In the future, this will allow better presentation of the overall pipelines (e.g. in the dashboard). We now also create database entries before sending requests to external service (e.g. Testing Farm), therefore failures will be more visible in the dashboard.
RELEASE NOTES END
