### PR TITLE
Fix make check-db to run compose down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,6 @@ check-db: build-test-image compose-for-db-up
 		-w /src \
 		--network packit-service_default \
 		$(TEST_IMAGE) make check "TEST_TARGET=tests_openshift/database"
-		$(COMPproject=OSE) down
+		$(COMPOSE) down
 
 .PHONY: build-revdep-test-image


### PR DESCRIPTION
I don't really see any reason for `project=` something to be in the Makefile, I believe that it may have been an unfortunate paste from the clipboard :)