### PR TITLE
fix(image-builder): provide RPM repo URL

### DIFF
--- a/packit_service/worker/handlers/vm_image.py
+++ b/packit_service/worker/handlers/vm_image.py
@@ -72,12 +72,17 @@ class VMImageBuildHandler(
                 },
             )
 
+        repo_url = self.packit_api.copr_helper.get_repo_download_url(
+            owner=self.job_config.owner,
+            project=self.job_config.project,
+            chroot=self.job_config.copr_chroot,
+        )
         image_id = self.vm_image_builder.create_image(
             self.image_distribution,
             self.image_name,
             self.image_request,
             self.image_customizations,
-            self.project_url,
+            repo_url,
         )
 
         run_model = PipelineModel.create(

--- a/tests/integration/test_vm_image_build.py
+++ b/tests/integration/test_vm_image_build.py
@@ -94,7 +94,21 @@ def test_vm_image_build(github_vm_image_build_comment):
     )
     flexmock(Signature).should_receive("apply_async").times(1)
     flexmock(VMImageBuildHandler).should_receive("vm_image_builder").and_return(
-        flexmock().should_receive("create_image").mock()
+        flexmock()
+        .should_receive("create_image")
+        .with_args(
+            "fedora-36",
+            "mmassari/knx-stack/21",
+            {
+                "architecture": "x86_64",
+                "image_type": "aws",
+                "upload_request": {"type": "aws", "options": {}},
+            },
+            {"packages": ["python-knx-stack"]},
+            "https://download.copr.fedorainfracloud.org/"
+            "results/mmassari/knx-stack/fedora-36-x86_64/",
+        )
+        .mock()
     )
     flexmock(VMImageBuildHandler).should_receive("report_status")
     flexmock(PipelineModel).should_receive("create").and_return(flexmock())

--- a/tests/unit/test_handler_vm_image.py
+++ b/tests/unit/test_handler_vm_image.py
@@ -127,7 +127,8 @@ def test_vm_image_build_handler(fake_package_config_job_config_project_db_trigge
                 "upload_request": {"type": "aws", "options": {}},
             },
             {"packages": ["python-knx-stack"]},
-            "https://github.com/majamassarini/knx-stack",
+            "https://download.copr.fedorainfracloud.org/"
+            "results/mmassari/knx-stack/fedora-36-x86_64/",
         )
         .mock()
     )


### PR DESCRIPTION
...instead of passing https://github...

Fixes:
```
..."payload_repositories":[{"rhsm":false,"baseurl":"https://github.com/TomasTomecek/aws-cli","check_gpg":false}]}
```

TODO:

- [x] Write new tests or update the old ones to cover new functionality.

More info https://github.com/TomasTomecek/aws-cli/pull/1/checks?check_run_id=9797079104