### PR TITLE
change(celery): retry backoff 3 → 7

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -72,11 +72,14 @@ COPR_FAILED_STATE = "failed"
 COPR_API_SUCC_STATE = 1
 COPR_API_FAIL_STATE = 2
 
+# Retry 2 times
 DEFAULT_RETRY_LIMIT = 2
 # Retry more times for outages
 DEFAULT_RETRY_LIMIT_OUTAGE = 5
-# retry in 3s, 6s
-DEFAULT_RETRY_BACKOFF = 3
+# retry in 0-7s, 0-14s, 0-28s, 0-48s, 0-96s
+# because jitter is enabled by default, celery makes these retries random:
+# https://docs.celeryq.dev/en/latest/userguide/tasks.html#Task.retry_jitter
+DEFAULT_RETRY_BACKOFF = 7
 RETRY_INTERVAL_IN_MINUTES_WHEN_USER_ACTION_IS_NEEDED = 10
 BASE_RETRY_INTERVAL_IN_MINUTES_FOR_OUTAGES = 1
 BASE_RETRY_INTERVAL_IN_SECONDS_FOR_INTERNAL_ERRORS = 10

--- a/packit_service/worker/celery_task.py
+++ b/packit_service/worker/celery_task.py
@@ -1,10 +1,8 @@
 import logging
-from os import getenv
 from typing import Optional
 
 from celery import Task
 
-from packit_service.constants import DEFAULT_RETRY_LIMIT
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +17,9 @@ class CeleryTask:
 
     @property
     def retries(self):
+        """
+        This is the retry number:
+        """
         return self.task.request.retries
 
     def is_last_try(self) -> bool:
@@ -31,11 +32,10 @@ class CeleryTask:
 
     def get_retry_limit(self) -> int:
         """
-        Returns the limit of the celery task retries.
-        (Packit uses this env.var. in HandlerTaskWithRetry base class
-        to set `max_retries` in `retry_kwargs`.)
+        Returns the limit of the celery task retries. These are configured
+        in task.py in the specific Task definitions
         """
-        return int(getenv("CELERY_RETRY_LIMIT", DEFAULT_RETRY_LIMIT))
+        return self.task.max_retries
 
     def retry(
         self,

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -172,7 +172,7 @@ class RetriggerBodhiUpdateHandler(
     BodhiUpdateHandler, GetKojiBuildDataFromKojiServiceMixin
 ):
     """
-    This handler can re-trigger a bodhi update if any successfull Koji build.
+    This handler can re-trigger a bodhi update if any successful Koji build.
     """
 
     task_name = TaskName.retrigger_bodhi_update

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -336,7 +336,10 @@ def test_downstream_koji_build_failure_issue_created():
             job_config=load_job_config(job_config),
             event=event_dict,
             # Needs to be the last try to inform user
-            celery_task=flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
+            celery_task=flexmock(
+                request=flexmock(retries=DEFAULT_RETRY_LIMIT),
+                max_retries=DEFAULT_RETRY_LIMIT,
+            ),
         ).run_job()
 
 
@@ -407,7 +410,10 @@ def test_downstream_koji_build_failure_issue_comment():
             job_config=load_job_config(job_config),
             event=event_dict,
             # Needs to be the last try to inform user
-            celery_task=flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
+            celery_task=flexmock(
+                request=flexmock(retries=DEFAULT_RETRY_LIMIT),
+                max_retries=DEFAULT_RETRY_LIMIT,
+            ),
         ).run_job()
 
 

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -1122,7 +1122,10 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     event_dict["tests_targets_override"] = ["fedora-rawhide-x86_64"]
     task = run_testing_farm_handler.__wrapped__.__func__
     task(
-        flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT)),
+        flexmock(
+            request=flexmock(retries=DEFAULT_RETRY_LIMIT),
+            max_retries=DEFAULT_RETRY_LIMIT,
+        ),
         package_config=package_config,
         event=event_dict,
         job_config=job_config,

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -29,6 +29,7 @@ from packit_service.constants import (
     DATE_OF_DEFAULT_SRPM_BUILD_IN_COPR,
     DOCS_HOW_TO_CONFIGURE_URL,
     TASK_ACCEPTED,
+    DEFAULT_RETRY_LIMIT,
 )
 from packit_service.models import (
     CoprBuildTargetModel,
@@ -1191,7 +1192,9 @@ def test_pr_test_command_handler_retries(
     assert json.dumps(event_dict)
     task = run_testing_farm_handler.__wrapped__.__func__
     task(
-        flexmock(request=flexmock(retries=retry_number)),
+        flexmock(
+            request=flexmock(retries=retry_number), max_retries=DEFAULT_RETRY_LIMIT
+        ),
         package_config=package_config,
         event=event_dict,
         job_config=job_config,

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -307,7 +307,11 @@ def test_copr_build_copr_outage_retry(
         _targets=["bright-future-x86_64"],
         owner="packit",
         db_trigger=trigger,
-        task=CeleryTask(flexmock(request=flexmock(retries=retry_number))),
+        task=CeleryTask(
+            flexmock(
+                request=flexmock(retries=retry_number), max_retries=DEFAULT_RETRY_LIMIT
+            )
+        ),
     )
     # we need to make sure that pr_id is set
     # so we can check it out and add it to spec's release field
@@ -786,7 +790,7 @@ def test_copr_build_check_names_custom_owner(github_pr_event):
             mock_chroot_proxy=flexmock()
             .should_receive("get_list")
             .and_return({"bright-future-x86_64": "", "bright-future-aarch64": ""})
-            .mock,
+            .mock(),
         )
     )
 
@@ -1289,7 +1293,10 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
         ),
     )
     helper.celery_task = CeleryTask(
-        flexmock(request=flexmock(retries=DEFAULT_RETRY_LIMIT))
+        flexmock(
+            request=flexmock(retries=DEFAULT_RETRY_LIMIT),
+            max_retries=DEFAULT_RETRY_LIMIT,
+        )
     )
     flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
         type=JobTriggerModelType.pull_request, trigger_id=123
@@ -2388,7 +2395,12 @@ def test_run_copr_build_from_source_script_github_outage_retry(
             id=123,
             job_trigger_model_type=JobTriggerModelType.pull_request,
         ),
-        task=CeleryTask(flexmock(request=flexmock(retries=retry_number))),
+        task=CeleryTask(
+            flexmock(
+                request=flexmock(retries=retry_number, kwargs={}),
+                max_retries=DEFAULT_RETRY_LIMIT,
+            )
+        ),
     )
     helper.job_config.srpm_build_deps = ["make", "findutils"]
     flexmock(JobTriggerModel).should_receive("get_or_create").with_args(


### PR DESCRIPTION
This also changes retry setup for creation of bodhi updates to 5.
All other tasks are still on 2.
    
When will the retrying happen?
    
    0-7s, 0-14s, 0-28s, 0-48s, 0-96s
    
We have jitter on (celery's default) so it's actual `random(0, value)`.
    
This is done mainly to account for koji build tagging as it can take
tenths of seconds easily. We also wanted to increase the backoff since
it makes more sense to retry later: the initial condition may not be
resolved right away.
    
Brutally related #1615

// meant to be a oneliner

---

RELEASE NOTES BEGIN
We've increased internal task retry backoff time in Packit GitHub app from 3 to 7 seconds. We hope this will increase success for network flakes and *random* infrastructure issues. Creation of bodhi updates should be now more reliable too as Packit will try more times (from 2 to 5).
RELEASE NOTES END