### PR TITLE
Specify use_downstream_specfile in sync_release

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -165,6 +165,8 @@ class AbstractSyncReleaseHandler(
                 tag=self.data.tag_name,
                 create_pr=True,
                 local_pr_branch_suffix=branch_suffix,
+                use_downstream_specfile=self.sync_release_job_type
+                == SyncReleaseJobType.pull_from_upstream,
             )
         except PackitDownloadFailedException as ex:
             # the archive has not been uploaded to PyPI yet

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -133,6 +133,7 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         tag="7.0.3",
         create_pr=True,
         local_pr_branch_suffix="update-pull_from_upstream",
+        use_downstream_specfile=True,
     ).and_return(flexmock(url="some_url")).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -138,6 +138,7 @@ def test_dist_git_push_release_handle(github_release_webhook, propose_downstream
         tag="0.3.0",
         create_pr=True,
         local_pr_branch_suffix="update-propose_downstream",
+        use_downstream_specfile=False,
     ).and_return(flexmock(url="some_url")).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -246,6 +247,7 @@ def test_dist_git_push_release_handle_multiple_branches(
             tag="0.3.0",
             create_pr=True,
             local_pr_branch_suffix="update-propose_downstream",
+            use_downstream_specfile=False,
         ).and_return(flexmock(url="some_url")).once()
     for model in propose_downstream_target_models:
         flexmock(model).should_receive("set_status").with_args(
@@ -364,6 +366,7 @@ def test_dist_git_push_release_handle_one_failed(
                 tag="0.3.0",
                 create_pr=True,
                 local_pr_branch_suffix="update-propose_downstream",
+                use_downstream_specfile=False,
             ).and_raise(Exception, f"Failed {branch}").once()
         else:
             flexmock(PackitAPI).should_receive("sync_release").with_args(
@@ -371,6 +374,7 @@ def test_dist_git_push_release_handle_one_failed(
                 tag="0.3.0",
                 create_pr=True,
                 local_pr_branch_suffix="update-propose_downstream",
+                use_downstream_specfile=False,
             ).and_return(flexmock(url="some_url")).once()
     for model in propose_downstream_target_models:
         url = get_propose_downstream_info_url(model.id)
@@ -639,6 +643,7 @@ def test_retry_propose_downstream_task(
         tag="0.3.0",
         create_pr=True,
         local_pr_branch_suffix="update-propose_downstream",
+        use_downstream_specfile=False,
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()
@@ -741,6 +746,7 @@ def test_dont_retry_propose_downstream_task(
         tag="0.3.0",
         create_pr=True,
         local_pr_branch_suffix="update-propose_downstream",
+        use_downstream_specfile=False,
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -148,6 +148,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
         tag="1.2.3",
         create_pr=True,
         local_pr_branch_suffix="update-propose_downstream",
+        use_downstream_specfile=False,
     ).and_return(flexmock(url="some_url")).times(1 if success else 0)
     flexmock(shutil).should_receive("rmtree").with_args("")
 


### PR DESCRIPTION
So that the pull from upstream can work if the upstream doesn't have any specfile.

Merge after packit/packit#1805

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
