### PR TITLE
Create an error state when SRPMs are still built by us

### DIFF
--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -411,7 +411,7 @@ class BaseBuildJobHelper(BaseJobHelper):
             Task results if job is done because of merge conflicts, `None`
         otherwise.
         """
-        # we want to get packit logs from the SRPM creation process
+        # We want to get packit logs from the SRPM creation process,
         # so we stuff them into a StringIO buffer
         stream = StringIO()
         handler = logging.StreamHandler(stream)

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -195,7 +195,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
     @property
     def additional_repos(self) -> Optional[List[str]]:
         """
-        Additional repos that will be enable for copr build.
+        Additional repos that will be enabled for copr build.
         """
         return self.job_build.additional_repos if self.job_build else None
 
@@ -535,6 +535,18 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         """
         Run copr build using SRPM built by us.
         """
+        self._report(
+            state=BaseCommitStatus.error,
+            description="`srpm_build_deps` not defined",
+            url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+            check_names="srpm_build_deps-not-defined",
+            markdown_content="All SRPMs will be built in Copr since January 2023. "
+            "Please use [srpm_build_deps]"
+            "(https://packit.dev/docs/configuration/#srpm_build_deps) "
+            "to be sure that we don't break your workflow once we switch "
+            "to building all SRPMs in Copr.",
+        )
+
         self.report_status_to_all(
             description="Building SRPM ...",
             state=BaseCommitStatus.running,

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -223,7 +223,7 @@ class SteveJobs:
 
         if handler_kls == ProposeDownstreamHandler:
             propose_downstream_helper = ProposeDownstreamJobHelper
-            params.update({"branches_override": self.event.branches_override})
+            params["branches_override"] = self.event.branches_override
             return propose_downstream_helper(**params)
 
         helper_kls: Type[

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -203,6 +203,18 @@ def test_copr_build_check_names(github_pr_event):
         "https://test.url"
     )
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
+        state=BaseCommitStatus.error,
+        description="`srpm_build_deps` not defined",
+        check_name="srpm_build_deps-not-defined",
+        url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+        links_to_external_services=None,
+        markdown_content="All SRPMs will be built in Copr since January 2023. "
+        "Please use [srpm_build_deps]"
+        "(https://packit.dev/docs/configuration/#srpm_build_deps) "
+        "to be sure that we don't break your workflow once we switch "
+        "to building all SRPMs in Copr.",
+    ).and_return()
+    flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
         check_name="rpm-build:bright-future-x86_64",
@@ -320,6 +332,18 @@ def test_copr_build_copr_outage_retry(
     flexmock(copr_build).should_receive("get_copr_build_info_url").and_return(
         "https://test.url"
     )
+    flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
+        state=BaseCommitStatus.error,
+        description="`srpm_build_deps` not defined",
+        check_name="srpm_build_deps-not-defined",
+        url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+        links_to_external_services=None,
+        markdown_content="All SRPMs will be built in Copr since January 2023. "
+        "Please use [srpm_build_deps]"
+        "(https://packit.dev/docs/configuration/#srpm_build_deps) "
+        "to be sure that we don't break your workflow once we switch "
+        "to building all SRPMs in Copr.",
+    ).and_return()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
@@ -450,7 +474,18 @@ def test_copr_build_check_names_invalid_chroots(github_pr_event):
     flexmock(copr_build).should_receive("get_srpm_build_info_url").and_return(
         "https://test.url"
     )
-
+    flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
+        state=BaseCommitStatus.error,
+        description="`srpm_build_deps` not defined",
+        check_name="srpm_build_deps-not-defined",
+        url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+        links_to_external_services=None,
+        markdown_content="All SRPMs will be built in Copr since January 2023. "
+        "Please use [srpm_build_deps]"
+        "(https://packit.dev/docs/configuration/#srpm_build_deps) "
+        "to be sure that we don't break your workflow once we switch "
+        "to building all SRPMs in Copr.",
+    ).and_return()
     for target in build_targets:
         flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
             state=BaseCommitStatus.running,
@@ -616,6 +651,18 @@ def test_copr_build_check_names_multiple_jobs(github_pr_event):
         "https://test.url"
     )
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
+        state=BaseCommitStatus.error,
+        description="`srpm_build_deps` not defined",
+        check_name="srpm_build_deps-not-defined",
+        url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+        links_to_external_services=None,
+        markdown_content="All SRPMs will be built in Copr since January 2023. "
+        "Please use [srpm_build_deps]"
+        "(https://packit.dev/docs/configuration/#srpm_build_deps) "
+        "to be sure that we don't break your workflow once we switch "
+        "to building all SRPMs in Copr.",
+    ).and_return()
+    flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
         check_name="rpm-build:fedora-32-x86_64",
@@ -718,6 +765,18 @@ def test_copr_build_check_names_custom_owner(github_pr_event):
     flexmock(copr_build).should_receive("get_copr_build_info_url").and_return(
         "https://test.url"
     )
+    flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
+        state=BaseCommitStatus.error,
+        description="`srpm_build_deps` not defined",
+        check_name="srpm_build_deps-not-defined",
+        url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+        links_to_external_services=None,
+        markdown_content="All SRPMs will be built in Copr since January 2023. "
+        "Please use [srpm_build_deps]"
+        "(https://packit.dev/docs/configuration/#srpm_build_deps) "
+        "to be sure that we don't break your workflow once we switch "
+        "to building all SRPMs in Copr.",
+    ).and_return()
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
@@ -826,7 +885,7 @@ def test_copr_build_success_set_test_check(github_pr_event):
         event=github_pr_event,
         db_trigger=trigger,
     )
-    flexmock(GithubProject).should_receive("create_check_run").and_return().times(4)
+    flexmock(GithubProject).should_receive("create_check_run").and_return().times(5)
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
@@ -911,7 +970,7 @@ def test_copr_build_for_branch(branch_push_event):
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(GithubProject).should_receive("create_check_run").and_return().times(8)
+    flexmock(GithubProject).should_receive("create_check_run").and_return().times(9)
     flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
         (
             flexmock(status="success")
@@ -994,7 +1053,7 @@ def test_copr_build_for_branch_failed(branch_push_event):
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(GithubProject).should_receive("create_check_run").and_return().times(8)
+    flexmock(GithubProject).should_receive("create_check_run").and_return().times(9)
     flexmock(GithubProject).should_receive("commit_comment").and_return(flexmock())
     flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
         (
@@ -1078,7 +1137,7 @@ def test_copr_build_for_release(release_event):
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(GithubProject).should_receive("create_check_run").and_return().times(8)
+    flexmock(GithubProject).should_receive("create_check_run").and_return().times(9)
     flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
         (
             flexmock(status="success")
@@ -1146,7 +1205,7 @@ def test_copr_build_success(github_pr_event):
     flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
         type=JobTriggerModelType.pull_request, trigger_id=123
     ).and_return(flexmock(id=2, type=JobTriggerModelType.pull_request))
-    flexmock(GithubProject).should_receive("create_check_run").and_return().times(8)
+    flexmock(GithubProject).should_receive("create_check_run").and_return().times(9)
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
@@ -1223,6 +1282,26 @@ def test_copr_build_fails_in_packit(github_pr_event):
     flexmock(copr_build).should_receive("get_srpm_build_info_url").and_return(
         "https://test.url"
     )
+    flexmock(GithubProject).should_receive("create_check_run").with_args(
+        name="srpm_build_deps-not-defined",
+        commit_sha="528b803be6f93e19ca4130bf4976f2800a3004c4",
+        url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+        external_id="2",
+        status=GithubCheckRunStatus.completed,
+        conclusion=GithubCheckRunResult.failure,
+        output=create_github_check_run_output(
+            "`srpm_build_deps` not defined",
+            create_table_content(
+                url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+                links_to_external_services=None,
+            )
+            + "All SRPMs will be built in Copr since January 2023. "
+            "Please use [srpm_build_deps]"
+            "(https://packit.dev/docs/configuration/#srpm_build_deps) "
+            "to be sure that we don't break your workflow once we switch "
+            "to building all SRPMs in Copr.",
+        ),
+    ).and_return().once()
     for v in ["31", "rawhide"]:
         flexmock(GithubProject).should_receive("create_check_run").with_args(
             name=templ.format(ver=v),
@@ -1308,6 +1387,26 @@ def test_copr_build_fails_to_update_copr_project(github_pr_event):
     flexmock(packit_service.worker.helpers.build.copr_build).should_receive(
         "get_valid_build_targets"
     ).and_return({"fedora-31-x86_64", "fedora-rawhide-x86_64"})
+    flexmock(GithubProject).should_receive("create_check_run").with_args(
+        name="srpm_build_deps-not-defined",
+        commit_sha="528b803be6f93e19ca4130bf4976f2800a3004c4",
+        url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+        external_id="2",
+        status=GithubCheckRunStatus.completed,
+        conclusion=GithubCheckRunResult.failure,
+        output=create_github_check_run_output(
+            "`srpm_build_deps` not defined",
+            create_table_content(
+                url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+                links_to_external_services=None,
+            )
+            + "All SRPMs will be built in Copr since January 2023. "
+            "Please use [srpm_build_deps]"
+            "(https://packit.dev/docs/configuration/#srpm_build_deps) "
+            "to be sure that we don't break your workflow once we switch "
+            "to building all SRPMs in Copr.",
+        ),
+    ).and_return().once()
     for v in ["31", "rawhide"]:
         flexmock(GithubProject).should_receive("create_check_run").with_args(
             name=templ.format(ver=v),
@@ -1506,7 +1605,7 @@ def test_copr_build_no_targets(github_pr_event):
     flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
         {"fedora-32-x86_64", "fedora-31-x86_64"}
     )
-    flexmock(GithubProject).should_receive("create_check_run").and_return().times(4)
+    flexmock(GithubProject).should_receive("create_check_run").and_return().times(5)
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
@@ -1585,7 +1684,18 @@ def test_copr_build_check_names_gitlab(gitlab_mr_event):
     flexmock(copr_build).should_receive("get_copr_build_info_url").and_return(
         "https://test.url"
     )
-
+    flexmock(StatusReporterGitlab).should_receive("set_status").with_args(
+        state=BaseCommitStatus.error,
+        description="`srpm_build_deps` not defined",
+        check_name="srpm_build_deps-not-defined",
+        url="https://packit.dev/posts/copr-srpms/#deployment-phases",
+        links_to_external_services=None,
+        markdown_content="All SRPMs will be built in Copr since January 2023. "
+        "Please use [srpm_build_deps]"
+        "(https://packit.dev/docs/configuration/#srpm_build_deps) "
+        "to be sure that we don't break your workflow once we switch "
+        "to building all SRPMs in Copr.",
+    ).and_return()
     flexmock(StatusReporterGitlab).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Building SRPM ...",
@@ -1709,7 +1819,7 @@ def test_copr_build_success_set_test_check_gitlab(gitlab_mr_event):
     mr = flexmock(source_project=flexmock())
     flexmock(GitlabProject).should_receive("get_pr").and_return(mr)
     flexmock(mr.source_project).should_receive("set_commit_status").and_return().times(
-        4
+        5
     )
 
     flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
@@ -1792,7 +1902,7 @@ def test_copr_build_for_branch_gitlab(branch_push_event_gitlab):
         db_trigger=trigger,
         project_type=GitlabProject,
     )
-    flexmock(GitlabProject).should_receive("set_commit_status").and_return().times(8)
+    flexmock(GitlabProject).should_receive("set_commit_status").and_return().times(9)
     flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
         (
             flexmock(status="success")
@@ -1866,7 +1976,7 @@ def test_copr_build_success_gitlab(gitlab_mr_event):
     mr = flexmock(source_project=flexmock())
     flexmock(GitlabProject).should_receive("get_pr").and_return(mr)
     flexmock(mr.source_project).should_receive("set_commit_status").and_return().times(
-        8
+        9
     )
 
     flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
@@ -1952,6 +2062,14 @@ def test_copr_build_fails_in_packit_gitlab(gitlab_mr_event):
     mr = flexmock(source_project=flexmock())
     flexmock(GitlabProject).should_receive("get_pr").and_return(mr)
 
+    flexmock(mr.source_project).should_receive("set_commit_status").with_args(
+        "1f6a716aa7a618a9ffe56970d77177d99d100022",
+        CommitStatus.failure,
+        "https://packit.dev/posts/copr-srpms/#deployment-phases",
+        "`srpm_build_deps` not defined",
+        "srpm_build_deps-not-defined",
+        trim=True,
+    ).and_return().once()
     for v in ["31", "rawhide"]:
         flexmock(mr.source_project).should_receive("set_commit_status").with_args(
             "1f6a716aa7a618a9ffe56970d77177d99d100022",
@@ -2120,7 +2238,7 @@ def test_copr_build_no_targets_gitlab(gitlab_mr_event):
     mr = flexmock(source_project=flexmock())
     flexmock(GitlabProject).should_receive("get_pr").and_return(mr)
     flexmock(mr.source_project).should_receive("set_commit_status").and_return().times(
-        4
+        5
     )
     flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
         (
@@ -2205,7 +2323,7 @@ def test_copr_build_targets_override(github_pr_event):
         db_trigger=trigger,
         build_targets_override={"bright-future-x86_64"},
     )
-    flexmock(GithubProject).should_receive("create_check_run").and_return().times(2)
+    flexmock(GithubProject).should_receive("create_check_run").and_return().times(3)
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover the new functionality.
- [x] Update or write new documentation in `packit/packit.dev`. (packit/packit.dev#571)

Fixes #1801

---

RELEASE NOTES BEGIN
If you still don't build SRPMs in Copr you'll get a warning status that you should use `srpm_build_deps` to be sure that we don't break your workflow once we switch to building all SRPMs in Copr in January.
RELEASE NOTES END
