### PR TITLE
Enforce HTTPS with HSTS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       - ./secrets/packit/dev/fedora.keytab:/secrets/fedora.keytab:ro,z
       - ./secrets/packit/dev/fullchain.pem:/secrets/fullchain.pem:ro,z
       - ./secrets/packit/dev/privkey.pem:/secrets/privkey.pem:ro,z
+      - ./files/run_httpd.sh:/usr/bin/run_httpd.sh:ro,z
     user: "1024"
 
   fedora-messaging:

--- a/files/run_httpd.sh
+++ b/files/run_httpd.sh
@@ -26,10 +26,14 @@ HTTPS_PORT=$(sed -nr 's/^server_name: ([^:]+)(:([0-9]+))?$/\3/p' "$PACKIT_SERVIC
 # See "mod_wsgi-express-3 start-server --help" for details on
 # these options, and the configuration documentation of mod_wsgi:
 # https://modwsgi.readthedocs.io/en/master/configuration.html
+# For the HSTS policy see
+# https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
 exec mod_wsgi-express-3 start-server \
-    --https-port "${HTTPS_PORT:-8443}" \
     --access-log \
     --log-to-terminal \
+    --https-port "${HTTPS_PORT:-8443}" \
+    --https-only \
+    --hsts-policy "max-age=31536000;includeSubDomains" \
     --ssl-certificate-file /secrets/fullchain.pem \
     --ssl-certificate-key-file /secrets/privkey.pem \
     --server-name "${SERVER_NAME}" \


### PR DESCRIPTION
```
$ mod_wsgi-express-3 start-server --help
--https-only          Flag indicating whether any requests made using a HTTP
                      request over the non secure connection should be
                      redirected automatically to use a HTTPS request over
                      the secure connection.
--hsts-policy PARAMS  Specify the HSTS policy that should be applied when
                      HTTPS only connections are being enforced.
```
https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html

Enterprise Security Standard (ESSv9) requirement.