### PR TITLE
Fix test issues with flexmock >= 0.11.0

### DIFF
--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -605,7 +605,7 @@ def test_strip_protocol_and_add_git(url: str, expected_url: str) -> None:
         ("me", "me-fas", {"github_username": "me"}, None, True),
         ("you", "you", {"github_username": None}, None, False),
         ("she", "she", {"github_username": "me"}, None, False),
-        ("they", "they", {}, APIError, False),
+        ("they", "they", {}, (APIError, "Failure", 42), False),
     ],
 )
 def test_is_github_username_from_fas_account_matching(
@@ -628,7 +628,7 @@ def test_is_github_username_from_fas_account_matching(
     if person_object is not None:
         fas.and_return(flexmock(result=person_object))
     if raises is not None:
-        fas.and_raise(raises)
+        fas.and_raise(*raises)
 
     assert (
         Allowlist(

--- a/tests/unit/test_srpm_logs.py
+++ b/tests/unit/test_srpm_logs.py
@@ -139,6 +139,6 @@ def test_build_srpm_log_format(github_pr_event):
         .mock()
     )
     flexmock(SRPMBuildModel).should_receive("create_with_new_run").and_return(
-        (srpm_model_mock, None)
+        (srpm_model_mock(), None)
     )
     helper._create_srpm()


### PR DESCRIPTION
With flexmock 0.11.3 in Fedora 37 a few test issues popped up. Fix them.

Merge after https://github.com/packit/deployment/pull/421.