### PR TITLE
Fix response codes in Swagger UI

### DIFF
--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -35,9 +35,9 @@ payload = ns.model(
 
 @ns.route("/results")
 class TestingFarmResults(Resource):
-    @ns.response(HTTPStatus.OK, "Notification has been accepted")
-    @ns.response(HTTPStatus.BAD_REQUEST, "Bad request data")
-    @ns.response(HTTPStatus.UNAUTHORIZED, "Testing farm secret validation failed")
+    @ns.response(HTTPStatus.OK.value, "Notification has been accepted")
+    @ns.response(HTTPStatus.BAD_REQUEST.value, "Bad request data")
+    @ns.response(HTTPStatus.UNAUTHORIZED.value, "Testing farm secret validation failed")
     @ns.expect(payload)
     def post(self):
         """
@@ -138,7 +138,7 @@ class TestingFarmResults(Resource):
 @ns.route("/<int:id>")
 @ns.param("id", "Packit id of the test run")
 class TestingFarmResult(Resource):
-    @ns.response(HTTPStatus.OK, "OK, test run details follow")
+    @ns.response(HTTPStatus.OK.value, "OK, test run details follow")
     @ns.response(HTTPStatus.NOT_FOUND.value, "No info about test run stored in DB")
     def get(self, id):
         """A specific test run details."""

--- a/packit_service/service/api/webhooks.py
+++ b/packit_service/service/api/webhooks.py
@@ -56,9 +56,11 @@ github_webhook_calls = Counter(
 @ns.route("/github")
 class GithubWebhook(Resource):
     @ns.response(HTTPStatus.OK.value, "Webhook accepted, returning reply")
-    @ns.response(HTTPStatus.ACCEPTED, "Webhook accepted, request is being processed")
-    @ns.response(HTTPStatus.BAD_REQUEST, "Bad request data")
-    @ns.response(HTTPStatus.UNAUTHORIZED, "X-Hub-Signature validation failed")
+    @ns.response(
+        HTTPStatus.ACCEPTED.value, "Webhook accepted, request is being processed"
+    )
+    @ns.response(HTTPStatus.BAD_REQUEST.value, "Bad request data")
+    @ns.response(HTTPStatus.UNAUTHORIZED.value, "X-Hub-Signature validation failed")
     # Just to be able to specify some payload in Swagger UI
     @ns.expect(ping_payload)
     def post(self):
@@ -163,9 +165,11 @@ class GithubWebhook(Resource):
 @ns.route("/gitlab")
 class GitlabWebhook(Resource):
     @ns.response(HTTPStatus.OK.value, "Webhook accepted, returning reply")
-    @ns.response(HTTPStatus.ACCEPTED, "Webhook accepted, request is being processed")
-    @ns.response(HTTPStatus.BAD_REQUEST, "Bad request data")
-    @ns.response(HTTPStatus.UNAUTHORIZED, "X-Gitlab-Token validation failed")
+    @ns.response(
+        HTTPStatus.ACCEPTED.value, "Webhook accepted, request is being processed"
+    )
+    @ns.response(HTTPStatus.BAD_REQUEST.value, "Bad request data")
+    @ns.response(HTTPStatus.UNAUTHORIZED.value, "X-Gitlab-Token validation failed")
     # Just to be able to specify some payload in Swagger UI
     @ns.expect(ping_payload_gitlab)
     def post(self):


### PR DESCRIPTION
By passing actual values to `namespace.response()`
It works without it as well because the method just creates a string out of it anyway, but the generated Swagger UI shows for example `HTTPStatus.PARTIAL_CONTENT` in a list of possible response codes and then `206 Undocumented` as a real response from the server.