### PR TITLE
Bump the Fedora version in test messages

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,8 +385,8 @@ def koji_build_start_rawhide():
 
 
 @pytest.fixture()
-def koji_build_start_f35():
-    with open(DATA_DIR / "fedmsg" / "koji_build_start_f35.json") as outfile:
+def koji_build_start_f36():
+    with open(DATA_DIR / "fedmsg" / "koji_build_start_f36.json") as outfile:
         return load_the_message_from_file(outfile)
 
 
@@ -409,8 +409,8 @@ def koji_build_completed_rawhide():
 
 
 @pytest.fixture()
-def koji_build_completed_f35():
-    with open(DATA_DIR / "fedmsg" / "koji_build_completed_f35.json") as outfile:
+def koji_build_completed_f36():
+    with open(DATA_DIR / "fedmsg" / "koji_build_completed_f36.json") as outfile:
         return load_the_message_from_file(outfile)
 
 

--- a/tests/data/fedmsg/koji_build_completed_f36.json
+++ b/tests/data/fedmsg/koji_build_completed_f36.json
@@ -5,22 +5,22 @@
     "epoch": null,
     "instance": "primary",
     "name": "python-ogr",
-    "new": 0,
-    "old": null,
+    "new": 1,
+    "old": 0,
     "owner": "packit",
-    "release": "1.fc35",
+    "release": "1.fc36",
     "request": [
       "git+https://src.fedoraproject.org/rpms/python-ogr.git#51b57ec04f5e6e9066ac859a1408cfbf1ead307e",
-      "f35-candidate",
+      "f36-candidate",
       {}
     ],
     "task_id": 80860789,
     "version": "0.34.0"
   },
   "headers": {
-    "sent-at": "2022-01-05T09:38:50+00:00"
+    "sent-at": "2022-01-05T09:40:59+00:00"
   },
-  "id": "2022-71048d11-737b-4207-8306-4800b1394096",
+  "id": "2022-7912a0f6-5909-44fc-aac4-d944535e6a53",
   "queue": null,
   "topic": "org.fedoraproject.prod.buildsys.build.state.change"
 }

--- a/tests/data/fedmsg/koji_build_start_f36.json
+++ b/tests/data/fedmsg/koji_build_start_f36.json
@@ -5,22 +5,22 @@
     "epoch": null,
     "instance": "primary",
     "name": "python-ogr",
-    "new": 1,
-    "old": 0,
+    "new": 0,
+    "old": null,
     "owner": "packit",
-    "release": "1.fc35",
+    "release": "1.fc36",
     "request": [
       "git+https://src.fedoraproject.org/rpms/python-ogr.git#51b57ec04f5e6e9066ac859a1408cfbf1ead307e",
-      "f35-candidate",
+      "f36-candidate",
       {}
     ],
     "task_id": 80860789,
     "version": "0.34.0"
   },
   "headers": {
-    "sent-at": "2022-01-05T09:40:59+00:00"
+    "sent-at": "2022-01-05T09:38:50+00:00"
   },
-  "id": "2022-7912a0f6-5909-44fc-aac4-d944535e6a53",
+  "id": "2022-71048d11-737b-4207-8306-4800b1394096",
   "queue": null,
   "topic": "org.fedoraproject.prod.buildsys.build.state.change"
 }

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -719,11 +719,11 @@ def test_bodhi_update_for_not_configured_branch(koji_build_completed_old_format)
     assert len(processing_results)
 
 
-def test_bodhi_update_fedora_stable_by_default(koji_build_completed_f35):
+def test_bodhi_update_fedora_stable_by_default(koji_build_completed_f36):
     """(Known build scenario.)"""
     packit_yaml = (
         "{'specfile_path': 'python-ogr.spec', 'synced_files': [],"
-        "'jobs': [{'trigger': 'commit', 'job': 'bodhi_update', 'dist_git_branches': ['f35']}],"
+        "'jobs': [{'trigger': 'commit', 'job': 'bodhi_update', 'dist_git_branches': ['f36']}],"
         "'downstream_package_name': 'python-ogr'}"
     )
     pagure_project = flexmock(
@@ -747,9 +747,9 @@ def test_bodhi_update_fedora_stable_by_default(koji_build_completed_f35):
     flexmock(Signature).should_receive("apply_async").times(2)
     flexmock(Pushgateway).should_receive("push").once().and_return()
     flexmock(PackitAPI).should_receive("create_update").with_args(
-        dist_git_branch="f35",
+        dist_git_branch="f36",
         update_type="enhancement",
-        koji_builds=["python-ogr-0.34.0-1.fc35"],
+        koji_builds=["python-ogr-0.34.0-1.fc36"],
     ).once()
 
     # Database not touched
@@ -757,7 +757,7 @@ def test_bodhi_update_fedora_stable_by_default(koji_build_completed_f35):
         build_id=1874070
     ).times(0)
 
-    processing_results = SteveJobs().process_message(koji_build_completed_f35)
+    processing_results = SteveJobs().process_message(koji_build_completed_f36)
     # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
     assert len(processing_results) == 2
     processing_results.pop()

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1142,8 +1142,8 @@ class TestEvents:
 
         assert event_object.package_config
 
-    def test_parse_koji_build_event_start_f35(self, koji_build_start_f35, mock_config):
-        event_object = Parser.parse_event(koji_build_start_f35)
+    def test_parse_koji_build_event_start_f36(self, koji_build_start_f36, mock_config):
+        event_object = Parser.parse_event(koji_build_start_f36)
 
         assert isinstance(event_object, KojiBuildEvent)
         assert event_object.build_id == 1874070
@@ -1152,12 +1152,12 @@ class TestEvents:
         assert event_object.rpm_build_task_id == 80860789
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "51b57ec04f5e6e9066ac859a1408cfbf1ead307e"
-        assert event_object.branch_name == "f35"
-        assert event_object.git_ref == "f35"
+        assert event_object.branch_name == "f36"
+        assert event_object.git_ref == "f36"
         assert event_object.epoch is None
         assert event_object.version == "0.34.0"
-        assert event_object.release == "1.fc35"
-        assert event_object.nvr == "python-ogr-0.34.0-1.fc35"
+        assert event_object.release == "1.fc36"
+        assert event_object.nvr == "python-ogr-0.34.0-1.fc36"
         assert (
             event_object.project_url == "https://src.fedoraproject.org/rpms/python-ogr"
         )
@@ -1297,10 +1297,10 @@ class TestEvents:
 
         assert event_object.package_config
 
-    def test_parse_koji_build_event_completed_f35(
-        self, koji_build_completed_f35, mock_config
+    def test_parse_koji_build_event_completed_f36(
+        self, koji_build_completed_f36, mock_config
     ):
-        event_object = Parser.parse_event(koji_build_completed_f35)
+        event_object = Parser.parse_event(koji_build_completed_f36)
 
         assert isinstance(event_object, KojiBuildEvent)
         assert event_object.build_id == 1874070
@@ -1309,12 +1309,12 @@ class TestEvents:
         assert event_object.rpm_build_task_id == 80860789
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "51b57ec04f5e6e9066ac859a1408cfbf1ead307e"
-        assert event_object.branch_name == "f35"
-        assert event_object.git_ref == "f35"
+        assert event_object.branch_name == "f36"
+        assert event_object.git_ref == "f36"
         assert event_object.epoch is None
         assert event_object.version == "0.34.0"
-        assert event_object.release == "1.fc35"
-        assert event_object.nvr == "python-ogr-0.34.0-1.fc35"
+        assert event_object.release == "1.fc36"
+        assert event_object.nvr == "python-ogr-0.34.0-1.fc36"
         assert (
             event_object.project_url == "https://src.fedoraproject.org/rpms/python-ogr"
         )


### PR DESCRIPTION
Signed-off-by: Frantisek Lachman <flachman@redhat.com>

Fixes the reverse-dep tests in Packit.

e.g. https://softwarefactory-project.io/zuul/t/packit-service/build/20372f4534794001abdba097403a1237/console