### PR TITLE
Measure time after Copr build end is reported

### DIFF
--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -367,6 +367,9 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
     def get_build(self, build_id: int):
         return self.api.copr_helper.copr_client.build_proxy.get(build_id)
 
+    def get_build_chroot(self, build_id: int, chroot: str):
+        return self.api.copr_helper.copr_client.build_chroot_proxy.get(build_id, chroot)
+
     def monitor_not_submitted_copr_builds(self, number_of_builds: int, reason: str):
         """
         Measure the time it took to set the failed status in case of event (e.g. failed SRPM)

--- a/packit_service/worker/monitoring.py
+++ b/packit_service/worker/monitoring.py
@@ -84,6 +84,23 @@ class Pushgateway:
             ),
         )
 
+        self.copr_build_end_reported_after_time = Histogram(
+            "copr_build_end_reported_after_time",
+            "Time it takes from Copr build being finished to reporting the status to user",
+            registry=self.registry,
+            buckets=(
+                60,
+                120,
+                180,
+                300,
+                480,
+                600,
+                1800,
+                3600,
+                float("inf"),
+            ),
+        )
+
         self.copr_build_not_submitted_time = Histogram(
             "copr_build_not_submitted_time",
             "Time it takes from setting accepted status for Copr build to failed status "

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -323,6 +323,17 @@ def test_copr_build_end(
         .at_least()
         .once()
     )
+
+    (
+        flexmock(CoprBuildJobHelper)
+        .should_receive("get_build_chroot")
+        .with_args(1, "some-target")
+        .and_return(flexmock(ended_on=1666889710))
+        .at_least()
+        .once()
+    )
+
+    # fix SRPM url since it touches multiple classes
     flexmock(copr_build_pr._srpm_build_for_mocking).should_receive("set_url").with_args(
         "https://my.host/my.srpm"
     ).mock()
@@ -382,6 +393,15 @@ def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build_branch_pu
     # skip SRPM url since it touches multiple classes
     flexmock(CoprBuildEndHandler).should_receive("set_srpm_url").and_return(None)
 
+    (
+        flexmock(CoprBuildJobHelper)
+        .should_receive("get_build_chroot")
+        .with_args(1, "some-target")
+        .and_return(flexmock(ended_on=1666889710))
+        .at_least()
+        .once()
+    )
+
     flexmock(Pushgateway).should_receive("push").once().and_return()
 
     processing_results = SteveJobs().process_message(copr_build_end)
@@ -433,6 +453,10 @@ def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build_rel
     ).once()
 
     flexmock(Signature).should_receive("apply_async").once()
+
+    flexmock(CoprBuildJobHelper).should_receive("get_build_chroot").with_args(
+        1, "some-target"
+    ).and_return(flexmock(ended_on=1666889710)).once()
 
     # skip SRPM url since it touches multiple classes
     flexmock(CoprBuildEndHandler).should_receive("set_srpm_url").and_return(None)
@@ -646,6 +670,15 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     # skip SRPM url since it touches multiple classes
     flexmock(CoprBuildEndHandler).should_receive("set_srpm_url").and_return(None)
 
+    (
+        flexmock(CoprBuildJobHelper)
+        .should_receive("get_build_chroot")
+        .with_args(1, "some-target")
+        .and_return(flexmock(ended_on=1666889710))
+        .at_least()
+        .once()
+    )
+
     flexmock(Pushgateway).should_receive("push").twice().and_return()
 
     processing_results = SteveJobs().process_message(copr_build_end)
@@ -803,6 +836,15 @@ def test_copr_build_end_report_multiple_testing_farm_jobs(
     # skip SRPM url since it touches multiple classes
     flexmock(CoprBuildEndHandler).should_receive("set_srpm_url").and_return(None)
 
+    (
+        flexmock(CoprBuildJobHelper)
+        .should_receive("get_build_chroot")
+        .with_args(1, "some-target")
+        .and_return(flexmock(ended_on=1666889710))
+        .at_least()
+        .once()
+    )
+
     flexmock(Pushgateway).should_receive("push").once().and_return()
 
     processing_results = SteveJobs().process_message(copr_build_end)
@@ -941,6 +983,16 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     ).once()
 
     flexmock(Signature).should_receive("apply_async").twice()
+
+    (
+        flexmock(CoprBuildJobHelper)
+        .should_receive("get_build_chroot")
+        .with_args(1, "some-target")
+        .and_return(flexmock(ended_on=1666889710))
+        .at_least()
+        .once()
+    )
+
     flexmock(Pushgateway).should_receive("push").twice().and_return()
 
     # skip SRPM url since it touches multiple classes
@@ -1097,6 +1149,15 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     ).once()
 
     flexmock(Signature).should_receive("apply_async").twice()
+
+    (
+        flexmock(CoprBuildJobHelper)
+        .should_receive("get_build_chroot")
+        .with_args(1, "some-target")
+        .and_return(flexmock(ended_on=1666889710))
+        .at_least()
+        .once()
+    )
     flexmock(Pushgateway).should_receive("push").twice().and_return()
 
     # skip SRPM url since it touches multiple classes
@@ -1279,6 +1340,16 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_bui
 
     flexmock(CoprBuildJobHelper).should_receive("get_built_packages").and_return([])
     flexmock(Signature).should_receive("apply_async").once()
+
+    (
+        flexmock(CoprBuildJobHelper)
+        .should_receive("get_build_chroot")
+        .with_args(1, "some-target")
+        .and_return(flexmock(ended_on=1666889710))
+        .at_least()
+        .once()
+    )
+
     flexmock(Pushgateway).should_receive("push").once().and_return()
 
     # skip SRPM url since it touches multiple classes


### PR DESCRIPTION
Measure the time from the Copr build being finished (ended_on attribute from Copr API) and the time we report the end state to the user.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.


Related to #1803

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
