### PR TITLE
link documentation when emiting comment that project is not whitelisted

### DIFF
--- a/packit_service/worker/allowlist.py
+++ b/packit_service/worker/allowlist.py
@@ -329,7 +329,8 @@ class Allowlist:
             return True
 
         msg = (
-            f"Project {project_url} is not on our allowlist!"
+            f"Project {project_url} is not on our allowlist! "
+            "See https://packit.dev/docs/guide/#2-approval"
             if not namespace_approved
             else f"Account {actor_name} has no write access nor is author of PR!"
         )
@@ -395,7 +396,8 @@ class Allowlist:
             return True
 
         msg = (
-            f"Project {project_url} is not on our allowlist!"
+            f"Project {project_url} is not on our allowlist! "
+            "See https://packit.dev/docs/guide/#2-approval"
             if not namespace_approved
             else f"Account {actor_name} has no write access!"
         )

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -300,7 +300,8 @@ def test_check_and_report_calls_method(allowlist, event, mocked_model, approved)
     else:
         flexmock(gp).should_receive("get_pr").and_return(mocked_pr_or_issue)
     expectation = mocked_pr_or_issue.should_receive("comment").with_args(
-        "Project github.com/foo/bar.git is not on our allowlist!"
+        "Project github.com/foo/bar.git is not on our allowlist! "
+        "See https://packit.dev/docs/guide/#2-approval"
     )
     expectation.never() if approved else expectation.once()
 


### PR DESCRIPTION
RELEASE NOTES BEGIN
When a project is not alowlisted, then packit-service posts a comment in PR about it. Previously it was just plain comment. Now we put there a link to Packit's documentation about approvals.
RELEASE NOTES END

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [-] Update doc-strings where appropriate.
- [-] Update or write new documentation in `packit/packit.dev`.

Real world example:
https://gitlab.com/fedora/legal/fedora-license-data/-/merge_requests/146#note_1227080750