### PR TITLE
Call run_job() for handlers instead of run() only when babysitting

### DIFF
--- a/packit_service/worker/helpers/build/babysit.py
+++ b/packit_service/worker/helpers/build/babysit.py
@@ -134,7 +134,7 @@ def check_pending_testing_farm_runs() -> None:
             )
             # check for identifiers equality
             if handler.pre_check(package_config, job_config, event_dict):
-                handler.run()
+                handler.run_job()
 
 
 def check_pending_copr_builds() -> None:
@@ -294,7 +294,7 @@ def update_copr_build_state(
             event=event_dict,
         )
         if handler.pre_check(package_config, job_config, event_dict):
-            handler.run()
+            handler.run_job()
 
 
 class UpdateImageBuildHelper(ConfigFromUrlMixin, GetVMImageBuilderMixin):
@@ -413,7 +413,7 @@ def update_vm_image_build(build_id: int, build: "VMImageBuildTargetModel"):
         )
 
     if handler.pre_check(package_config, job_config, event_dict):
-        handler.run()
+        handler.run_job()
         return True
 
     build.set_status(status)

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -167,7 +167,7 @@ def test_check_copr_build_updated(build_status):
             packages={"package": CommonPackageConfig()},
         )
     )
-    flexmock(CoprBuildEndHandler).should_receive("run").and_return().once()
+    flexmock(CoprBuildEndHandler).should_receive("run_job").and_return().once()
     assert check_copr_build(build_id=1)
 
 
@@ -251,7 +251,7 @@ def test_check_copr_build_waiting_started():
             packages={"package": CommonPackageConfig()},
         )
     )
-    flexmock(CoprBuildStartHandler).should_receive("run").and_return().once()
+    flexmock(CoprBuildStartHandler).should_receive("run_job").and_return().once()
     assert not check_copr_build(build_id=1)
 
 
@@ -335,7 +335,7 @@ def test_check_copr_build_waiting_already_started():
             packages={"package": CommonPackageConfig()},
         )
     )
-    flexmock(CoprBuildStartHandler).should_receive("run").and_return().never()
+    flexmock(CoprBuildStartHandler).should_receive("run_job").and_return().never()
     assert not check_copr_build(build_id=1)
 
 
@@ -496,7 +496,7 @@ def test_check_pending_testing_farm_runs(created):
             packages={"package": CommonPackageConfig()},
         )
     )
-    flexmock(TestingFarmResultsHandler).should_receive("run").and_return().once()
+    flexmock(TestingFarmResultsHandler).should_receive("run_job").and_return().once()
     check_pending_testing_farm_runs()
 
 
@@ -596,5 +596,5 @@ def test_check_pending_testing_farm_runs_identifiers(identifier):
             packages={"package": CommonPackageConfig()},
         )
     )
-    flexmock(TestingFarmResultsHandler).should_receive("run").and_return().once()
+    flexmock(TestingFarmResultsHandler).should_receive("run_job").and_return().once()
     check_pending_testing_farm_runs()

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -577,7 +577,7 @@ def test_check_rerun_release_koji_build_handler(
 def test_check_rerun_release_propose_downstream_handler(
     mock_release_functionality, check_rerun_event_propose_downstream
 ):
-    flexmock(ProposeDownstreamHandler).should_receive("run").and_return(
+    flexmock(ProposeDownstreamHandler).should_receive("run_job").and_return(
         TaskResults(success=True, details={})
     )
     flexmock(GithubProject).should_receive("get_files").and_return(["foo.spec"])

--- a/tests/unit/test_babysit_vm_image.py
+++ b/tests/unit/test_babysit_vm_image.py
@@ -7,6 +7,7 @@ from requests import HTTPError
 from flexmock import flexmock
 from flexmock import Mock
 from packit.config.job_config import JobConfigTriggerType, JobType
+from packit_service.config import ServiceConfig
 from packit_service.models import (
     VMImageBuildTargetModel,
     VMImageBuildStatus,
@@ -19,6 +20,7 @@ from packit_service.worker.helpers.build.babysit import (
 )
 from packit_service.worker.events import VMImageBuildResultEvent
 from packit_service.worker.handlers import VMImageBuildResultHandler
+from packit_service.worker.monitoring import Pushgateway
 
 
 def test_check_pending_vm_image_builds():
@@ -139,6 +141,9 @@ def test_update_vm_image_build(stop_babysitting, build_status, vm_image_builder_
     )
 
     flexmock(VMImageBuildResultHandler).should_receive("report_status")
+    flexmock(ServiceConfig).should_receive("get_project").and_return()
+    if stop_babysitting:
+        flexmock(Pushgateway).should_receive("push").once().and_return()
     assert (
         update_vm_image_build(
             1,

--- a/tests_openshift/database/test_tasks.py
+++ b/tests_openshift/database/test_tasks.py
@@ -23,6 +23,7 @@ from packit_service.models import (
 )
 from packit_service.worker.events import AbstractCoprBuildEvent
 from packit_service.worker.helpers.build.babysit import check_copr_build
+from packit_service.worker.monitoring import Pushgateway
 
 BUILD_ID = 1300329
 
@@ -211,6 +212,7 @@ def test_check_copr_build(clean_before_and_after, packit_build_752):
             "fedora-rawhide-x86_64",
         }
     )
+    flexmock(Pushgateway).should_receive("push").once().and_return()
 
     check_copr_build(BUILD_ID)
     assert packit_build_752.status == BuildStatus.success


### PR DESCRIPTION
run_job method wraps the run method and besides that also
 e.g. logs info about the handler, sends things to Sentry and pushes metrics in the end.

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
