### PR TITLE
Pip-install gevent & greenlet

### DIFF
--- a/files/docker/Dockerfile.worker
+++ b/files/docker/Dockerfile.worker
@@ -15,7 +15,8 @@ ENV USER=packit \
 # Ansible doesn't like /tmp
 WORKDIR /src
 
-COPY files/ ./files/
+COPY files/install-deps-worker.yaml ./files/
+COPY files/tasks/ ./files/tasks/
 RUN ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
     && dnf clean all
 
@@ -24,6 +25,7 @@ COPY setup.* .git_archival.txt .gitattributes ./
 COPY .git/ .git/
 COPY packit_service/ packit_service/
 
+COPY files/recipe-worker.yaml files/setup_env_in_openshift.sh files/gitconfig files/run_worker.sh ./files/
 RUN git rev-parse HEAD >/.packit-service.git.commit.hash \
     && git show --quiet --format=%B HEAD >/.packit-service.git.commit.message \
     && ansible-playbook -vv -c local -i localhost, files/recipe-worker.yaml \

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -8,6 +8,14 @@
     source_branch: "{{ lookup('env', 'SOURCE_BRANCH') }}"
   tasks:
     - import_tasks: tasks/process-source-branch.yaml
+    - name: Pip-install gevent & greenlet
+      # https://bugzilla.redhat.com/show_bug.cgi?id=2158732
+      # Install it before python3-sqlalchemy RPM
+      # which would otherwise pull in greenlet<2 RPM
+      pip:
+        name:
+          - gevent==22.*
+        executable: pip3
     - name: Install all RPM/python packages needed to run packit-service worker
       dnf:
         name:
@@ -34,8 +42,8 @@
           - python3-boto3 # AWS (S3)
           - python3-fasjson-client
           # concurrency pool, see run_worker.sh
-          - python3-eventlet
-          - python3-gevent
+          # temporarily installed from PyPI, see above
+          #           - python3-gevent
           # v6 = bodhi-client, v5 = python3-bodhi{,-client}
           - bodhi-client
         state: present


### PR DESCRIPTION
`gevent` from PyPI pulls in `greenlet>2.0.0` which fixes [RHBZ#2158732 (Memory leak with Python 3.11)](https://bugzilla.redhat.com/show_bug.cgi?id=2158732)

We can't pip install only `greenlet>2` because
```
$ rpm -q --requires python3-gevent-0:21.12.0-4.fc37.x86_64
python3.11dist(greenlet) < 2~~
```

Fixes #1824

And remove `python3-eventlet` temporarily readded with 3c8f66ff

EDIT: Looks OK on staging.