### PR TITLE
utilize get_valid_build_targets from packit.copr_helper

### DIFF
--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -14,7 +14,7 @@ from ogr.parsing import parse_git_repo
 from ogr.services.github import GithubProject
 
 from packit.config import JobConfig, JobType, JobConfigTriggerType
-from packit.config.aliases import get_aliases, get_valid_build_targets
+from packit.config.aliases import get_aliases
 from packit.config.common_package_config import Deployment
 from packit.config.package_config import PackageConfig
 from packit.exceptions import (
@@ -204,10 +204,12 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         """
         Return all valid Copr build targets/chroots from config.
         """
-        return get_valid_build_targets(*self.configured_build_targets, default=None)
+        return self.api.copr_helper.get_valid_build_targets(
+            *self.configured_build_targets, default=None
+        )
 
     def build_targets_for_test_job_all(self, job: JobConfig):
-        return get_valid_build_targets(
+        return self.api.copr_helper.get_valid_build_targets(
             *self.configured_targets_for_tests_job(job), default=None
         )
 
@@ -444,15 +446,16 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
 
         return TaskResults(success=True, details={})
 
-    @staticmethod
-    def get_latest_fedora_stable_chroot() -> str:
+    def get_latest_fedora_stable_chroot(self) -> str:
         """
         Get the latest stable Fedora chroot.
 
         This is used as a chroot where the Copr source script will be run.
         """
         latest_fedora_stable_chroot = get_aliases().get("fedora-stable")[-1]
-        return list(get_valid_build_targets(latest_fedora_stable_chroot))[0]
+        return list(
+            self.api.copr_helper.get_valid_build_targets(latest_fedora_stable_chroot)
+        )[0]
 
     def submit_copr_build(self, script: Optional[str] = None) -> Tuple[int, str]:
         """

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -10,6 +10,7 @@ from github import Github
 from ogr.services.github import GithubProject
 
 from packit.config import JobConfigTriggerType
+from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
 from packit_service.constants import (
     TASK_ACCEPTED,
@@ -29,7 +30,6 @@ from packit_service.service.db_triggers import (
 from packit_service.worker.handlers import ProposeDownstreamHandler
 from packit_service.worker.helpers.build import (
     KojiBuildJobHelper,
-    copr_build,
     koji_build,
 )
 from packit_service.worker.helpers.sync_release.propose_downstream import (
@@ -235,7 +235,7 @@ def test_check_rerun_pr_testing_farm_handler(
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
         flexmock(status=BuildStatus.success)
     )
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64", "fedora-34-x86_64"}
     )
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
@@ -421,7 +421,7 @@ def test_check_rerun_push_testing_farm_handler(
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
         flexmock(status=BuildStatus.success)
     )
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64", "fedora-34-x86_64"}
     )
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
@@ -585,7 +585,7 @@ def test_check_rerun_release_propose_downstream_handler(
         "https://github.com/the-namespace/the-repo"
     )
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64", "fedora-34-x86_64"}
     )
     flexmock(ProposeDownstreamJobHelper).should_receive(

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -10,7 +10,6 @@ from celery.canvas import Signature
 from copr.v3 import Client
 from flexmock import flexmock
 
-import packit_service
 import packit_service.service.urls as urls
 from ogr.services.github import GithubProject
 from ogr.utils import RequestResponse
@@ -64,9 +63,7 @@ pytestmark = pytest.mark.usefixtures("mock_get_valid_build_targets")
 
 @pytest.fixture
 def mock_get_valid_build_targets():
-    flexmock(packit_service.worker.helpers.build.copr_build).should_receive(
-        "get_valid_build_targets"
-    ).and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {
             "fedora-33-x86_64",
             "fedora-32-x86_64",

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -11,6 +11,7 @@ from github import Github
 from ogr.services.github import GithubProject
 from ogr.services.pagure import PagureProject
 from ogr.utils import RequestResponse
+from packit.copr_helper import CoprHelper
 
 import packit_service.models
 import packit_service.service.urls as urls
@@ -50,7 +51,6 @@ from packit_service.worker.events.event import AbstractForgeIndependentEvent
 from packit_service.worker.handlers.bodhi import (
     RetriggerBodhiUpdateHandler,
 )
-from packit_service.worker.helpers.build import copr_build
 from packit_service.worker.helpers.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.helpers.build.koji_build import KojiBuildJobHelper
 from packit_service.worker.helpers.testing_farm import TestingFarmJobHelper
@@ -189,7 +189,7 @@ def test_pr_comment_build_test_handler(
     )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(set())
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(set())
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -254,7 +254,7 @@ def test_pr_comment_build_build_and_test_handler(
     )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(set())
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(set())
     flexmock(CoprBuildJobHelper).should_receive("report_status_to_build").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -554,7 +554,7 @@ def test_pr_test_command_handler(pr_embedded_command_comment_event):
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(copr_build).should_receive("get_valid_build_targets").times(5).and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").times(5).and_return(
         {"test-target"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
@@ -644,7 +644,7 @@ def test_pr_test_command_handler_identifiers(pr_embedded_command_comment_event):
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(copr_build).should_receive("get_valid_build_targets").times(5).and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").times(5).and_return(
         {"test-target"}
     )
     flexmock(CoprBuildTargetModel).should_receive("get_all_by").with_args(
@@ -835,7 +835,7 @@ def test_pr_test_command_handler_retries(
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
@@ -1018,7 +1018,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
@@ -1211,7 +1211,7 @@ def test_pr_test_command_handler_compose_not_present(
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
@@ -1339,7 +1339,7 @@ def test_pr_test_command_handler_composes_not_available(
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
@@ -1444,7 +1444,7 @@ def test_pr_test_command_handler_missing_build(pr_embedded_command_comment_event
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(Signature).should_receive("apply_async").twice()
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"test-target", "test-target-without-build"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
@@ -1542,7 +1542,7 @@ def test_pr_test_command_handler_missing_build_trigger_with_build_job_config(
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(Signature).should_receive("apply_async").twice()
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"test-target", "test-target-without-build"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
@@ -1795,7 +1795,7 @@ def test_retest_failed(
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(copr_build).should_receive("get_valid_build_targets").times(3).and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").times(3).and_return(
         {"test-target"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
@@ -1919,7 +1919,7 @@ def test_pr_test_command_handler_skip_build_option_no_fmf_metadata(
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
@@ -2108,7 +2108,7 @@ def test_pr_test_command_handler_multiple_builds(pr_embedded_command_comment_eve
     ).and_return(flexmock(id=2, type=JobTriggerModelType.pull_request))
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"fedora-rawhide-x86_64", "fedora-35-x86_64"}
     )
 

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -11,7 +11,6 @@ from flexmock import flexmock
 from ogr.abstract import GitProject, GitService
 from ogr.services.github import GithubProject, GithubService
 
-import packit_service
 from packit.api import PackitAPI
 from packit.config import CommonPackageConfig, JobType, JobConfig, JobConfigTriggerType
 from packit.copr_helper import CoprHelper
@@ -566,9 +565,7 @@ def test_check_and_report(
                     f"[in our onboarding guide]({DOCS_APPROVAL_URL})."
                 ),
             ).once()
-        flexmock(packit_service.worker.helpers.build.copr_build).should_receive(
-            "get_valid_build_targets"
-        ).and_return(
+        flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
             {
                 "fedora-rawhide-x86_64",
             }

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -18,7 +18,6 @@ from packit.local_project import LocalProject
 from packit.utils.repo import RepositoryCache
 from packit_service.config import ServiceConfig
 from packit_service.models import JobTriggerModelType
-from packit_service.worker.helpers.build import copr_build
 from packit_service.worker.helpers.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.helpers.build.koji_build import KojiBuildJobHelper
 
@@ -1087,22 +1086,22 @@ def test_build_targets_overrides(
         build_targets_override=build_targets_override,
         tests_targets_override=tests_targets_override,
     )
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "fedora-31", "fedora-32", default=None
     ).and_return(STABLE_CHROOTS)
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "fedora-32", "fedora-31", default=None
     ).and_return(STABLE_CHROOTS)
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         default=None
     ).and_return(set())
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "epel-7-x86_64", default=None
     ).and_return({"epel-7-x86_64"})
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "epel-7-ppc64le", default=None
     ).and_return({"epel-7-ppc64le"})
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "centos-stream-8", default=None
     ).and_return({"centos-stream-8-x86_64"})
     assert copr_build_helper.build_targets == build_targets
@@ -1309,22 +1308,22 @@ def test_tests_targets_overrides(
         build_targets_override=build_targets_override,
         tests_targets_override=tests_targets_override,
     )
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "fedora-31", "fedora-32", default=None
     ).and_return(STABLE_CHROOTS)
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "fedora-32", "fedora-31", default=None
     ).and_return(STABLE_CHROOTS)
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         default=None
     ).and_return(set())
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "epel-7-x86_64", default=None
     ).and_return({"epel-7-x86_64"})
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "epel-7-ppc64le", default=None
     ).and_return({"epel-7-ppc64le"})
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "centos-stream-8", default=None
     ).and_return({"centos-stream-8-x86_64"})
     assert testing_farm_helper.tests_targets == test_targets
@@ -1409,7 +1408,7 @@ def test_copr_build_target2test_targets(
         metadata=flexmock(pr_id=None),
         db_trigger=flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
     )
-    flexmock(copr_build, get_valid_build_targets=get_build_targets)
+    flexmock(CoprHelper, get_valid_build_targets=get_build_targets)
     assert (
         copr_build_helper.build_target2test_targets_for_test_job(build_target, jobs[0])
         == test_targets
@@ -1440,7 +1439,7 @@ def test_copr_build_and_test_targets_both_jobs_defined():
             },
         ),
     ]
-    flexmock(copr_build, get_valid_build_targets=get_build_targets)
+    flexmock(CoprHelper, get_valid_build_targets=get_build_targets)
     for i in [0, 1]:
         helper = (
             CoprBuildJobHelper
@@ -1663,16 +1662,16 @@ def test_copr_test_target2build_target(job_config, test_target, build_target):
         metadata=flexmock(pr_id=None),
         db_trigger=flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
     )
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "fedora-31", "fedora-32", default=None
     ).and_return(STABLE_CHROOTS)
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "fedora-32", "fedora-31", default=None
     ).and_return(STABLE_CHROOTS)
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "centos-stream-9-x86_64", default=None
     ).and_return({"centos-stream-9-x86_64"})
-    flexmock(copr_build).should_receive("get_valid_build_targets").with_args(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
         "epel-7-x86_64", default=None
     ).and_return({"epel-7-x86_64"})
     assert testing_farm_helper.test_target2build_target(test_target) == build_target

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -53,7 +53,6 @@ from packit_service.worker.events import (
     EventData,
 )
 from packit_service.worker.handlers import CoprBuildHandler
-from packit_service.worker.helpers.build import copr_build
 from packit_service.worker.helpers.build.copr_build import (
     BaseBuildJobHelper,
     CoprBuildJobHelper,
@@ -171,7 +170,7 @@ def test_copr_build_fails_chroot_update(github_pr_event):
     )
     # enforce that we are reporting on our own Copr project
     helper.job_build.owner = "packit"
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"f31", "f32"}
     )
     flexmock(CoprHelper).should_receive("create_copr_project_if_not_exists").and_raise(
@@ -411,9 +410,9 @@ def test_get_latest_fedora_stable_chroot(github_pr_event):
     flexmock(packit_service.worker.helpers.build.copr_build).should_receive(
         "get_aliases"
     ).and_return({"fedora-stable": ["fedora-34", "fedora-35"]})
-    flexmock(packit_service.worker.helpers.build.copr_build).should_receive(
-        "get_valid_build_targets"
-    ).with_args("fedora-35").and_return({"fedora-35-x86_64"})
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").with_args(
+        "fedora-35"
+    ).and_return({"fedora-35-x86_64"})
     assert (
         build_helper(github_pr_event).get_latest_fedora_stable_chroot()
         == "fedora-35-x86_64"
@@ -597,7 +596,7 @@ def test_copr_build_invalid_copr_project_name(github_pr_event):
     )
     # enforce that we are reporting on our own Copr project
     helper.job_build.owner = "packit"
-    flexmock(copr_build).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"f31", "f32"}
     )
     flexmock(CoprHelper).should_receive("create_copr_project_if_not_exists").and_raise(

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -3,8 +3,9 @@
 from datetime import datetime, timezone
 
 import pytest
-from celery import Signature
+from celery.canvas import Signature
 from flexmock import flexmock
+from packit.copr_helper import CoprHelper
 
 import packit_service.models
 import packit_service.service.urls as urls
@@ -33,7 +34,6 @@ from packit_service.worker.events import (
 )
 from packit_service.worker.handlers import TestingFarmHandler
 from packit_service.worker.handlers import TestingFarmResultsHandler as TFResultsHandler
-from packit_service.worker.helpers.build import copr_build as cb
 from packit_service.worker.helpers.testing_farm import (
     TestingFarmJobHelper as TFJobHelper,
 )
@@ -893,7 +893,7 @@ def test_trigger_build(copr_build, run_new_build, wait_for_build):
                 url="https://dashboard.localhost/results/copr-builds/1",
             )
 
-    flexmock(cb).should_receive("get_valid_build_targets").and_return(targets)
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(targets)
 
     tf_handler = TestingFarmHandler(
         package_config,
@@ -996,7 +996,7 @@ def test_get_additional_builds():
         project_url="https://github.com/my-namespace/my-repo",
     ).and_return(pr)
 
-    flexmock(cb).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"test-target", "another-test-target"}
     )
 
@@ -1088,7 +1088,7 @@ def test_get_additional_builds_builds_not_in_db():
         .and_return([])
         .mock()
     )
-    flexmock(cb).should_receive("get_valid_build_targets").and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {"test-target", "another-test-target"}
     )
     additional_copr_builds = helper.get_copr_builds_from_other_pr()

--- a/tests_openshift/database/test_tasks.py
+++ b/tests_openshift/database/test_tasks.py
@@ -5,8 +5,8 @@ import pytest
 from copr.v3 import Client, BuildProxy, BuildChrootProxy
 from flexmock import flexmock
 from munch import Munch
+from packit.copr_helper import CoprHelper
 
-import packit_service
 from ogr.services.github import GithubProject
 from packit.config import (
     CommonPackageConfig,
@@ -202,9 +202,7 @@ def test_check_copr_build(clean_before_and_after, packit_build_752):
     flexmock(GithubProject).should_receive("get_git_urls").and_return(
         {"git": "https://github.com/packit-service/packit.git"}
     )
-    flexmock(packit_service.worker.helpers.build.copr_build).should_receive(
-        "get_valid_build_targets"
-    ).and_return(
+    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
         {
             "fedora-33-x86_64",
             "fedora-32-x86_64",


### PR DESCRIPTION
the function was moved to avoid circular dependency

TODO:

- [x] needs to be merged together with https://github.com/packit/packit/pull/1824

---

RELEASE NOTES BEGIN
RELEASE NOTES END