### PR TITLE
fix(tf): pass merge SHA to the TF API

### DIFF
--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -570,7 +570,13 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
 
     payload = {
         "api_key": "secret token",
-        "test": {"fmf": {"url": "https://github.com/source/bar", "ref": "0011223344"}},
+        "test": {
+            "fmf": {
+                "url": "https://github.com/source/bar",
+                "ref": "0011223344",
+                "merge_sha": "deadbeef",
+            }
+        },
         "environments": [
             {
                 "arch": "x86_64",

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -847,6 +847,7 @@ def test_pr_test_command_handler_retries(
             "fmf": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
+                "merge_sha": "deadbeef",
             }
         },
         "environments": [
@@ -1036,6 +1037,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
             "fmf": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
+                "merge_sha": "deadbeef",
             }
         },
         "environments": [
@@ -2150,6 +2152,7 @@ def test_pr_test_command_handler_multiple_builds(pr_embedded_command_comment_eve
             "fmf": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
+                "merge_sha": "deadbeef",
             }
         },
         "environments": [

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -635,6 +635,7 @@ def test_payload(
     expected_test = {
         "url": project_url,
         "ref": commit_sha,
+        "merge_sha": "abcdefgh",
     }
     if tmt_plan:
         expected_test["name"] = tmt_plan
@@ -677,35 +678,46 @@ def test_payload(
 
 
 @pytest.mark.parametrize(
-    ("fmf_url," "fmf_ref," "result_url," "result_ref"),
+    ("fmf_url," "fmf_ref," "result_url," "result_ref," "merge_pr_in_ci"),
     [
-        (
+        (  # custom tests and specified ref
             "https://github.com/mmuzila/test",
             "main",
             "https://github.com/mmuzila/test",
             "main",
+            True,
         ),
-        (
+        (  # defaulting to the tests in repo, also merging
             None,
             None,
             "https://github.com/packit/packit",
             "feb41e5",
+            True,
         ),
-        (
+        (  # specifying only ref and merging
             None,
             "main",
             "https://github.com/packit/packit",
             "feb41e5",
+            True,
         ),
-        (
+        (  # specifying custom repo with tests, no ref
             "https://github.com/mmuzila/test",
             None,
             "https://github.com/mmuzila/test",
             None,
+            True,
+        ),
+        (  # defaulting to the tests in repo, no merging
+            None,
+            None,
+            "https://github.com/packit/packit",
+            "feb41e5",
+            False,
         ),
     ],
 )
-def test_test_repo(fmf_url, fmf_ref, result_url, result_ref):
+def test_test_repo(fmf_url, fmf_ref, result_url, result_ref, merge_pr_in_ci):
     tf_api = "https://api.dev.testing-farm.io/v0.1/"
     tf_token = "very-secret"
     ps_deployment = "test"
@@ -763,8 +775,7 @@ def test_test_repo(fmf_url, fmf_ref, result_url, result_ref):
             trigger=JobConfigTriggerType.pull_request,
             packages={
                 "package": CommonPackageConfig(
-                    fmf_url=fmf_url,
-                    fmf_ref=fmf_ref,
+                    fmf_url=fmf_url, fmf_ref=fmf_ref, merge_pr_in_ci=merge_pr_in_ci
                 )
             },
         ),
@@ -803,6 +814,16 @@ def test_test_repo(fmf_url, fmf_ref, result_url, result_ref):
     assert payload["test"].get("fmf")
     assert payload["test"]["fmf"].get("url") == result_url
     assert payload["test"]["fmf"].get("ref") == result_ref
+
+    # if custom fmf tests are not defined or we're not merging, we don't pass the
+    # merge SHA
+    merge_sha_should_be_none = fmf_url or not merge_pr_in_ci
+    assert (
+        merge_sha_should_be_none and payload["test"]["fmf"].get("merge_sha") is None
+    ) or (
+        not merge_sha_should_be_none
+        and payload["test"]["fmf"].get("merge_sha") == "abcdefgh"
+    )
 
 
 def test_get_request_details():


### PR DESCRIPTION
This change reflects introduction of the „new“ API parameter of the TF API. Merging is not yet implemented on the Testing Farm' side, just the API support.

Related MR: https://gitlab.com/testing-farm/api/-/merge_requests/30

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to #1224