### PR TITLE
Check chroot ended_on in Copr babysit task

### DIFF
--- a/packit_service/worker/helpers/build/babysit.py
+++ b/packit_service/worker/helpers/build/babysit.py
@@ -246,7 +246,7 @@ def update_copr_build_state(
     """
     event_kls: Type[AbstractCoprBuildEvent]
     handler_kls: Type[AbstractCoprBuildReportHandler]
-    if build_copr.ended_on:
+    if chroot_build_copr.ended_on:
         event_kls = CoprBuildEndEvent
         handler_kls = CoprBuildEndHandler
         timestamp = chroot_build_copr.ended_on

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -85,13 +85,14 @@ def test_check_copr_build_already_successful():
 
 
 @pytest.mark.parametrize(
-    "build_status",
+    "build_status, build_ended_on",
     [
-        BuildStatus.pending,
-        BuildStatus.waiting_for_srpm,
+        (BuildStatus.pending, "timestamp"),
+        (BuildStatus.pending, None),
+        (BuildStatus.waiting_for_srpm, None),
     ],
 )
-def test_check_copr_build_updated(build_status):
+def test_check_copr_build_updated(build_status, build_ended_on):
     db_build = (
         flexmock(
             build_id="55",
@@ -139,7 +140,8 @@ def test_check_copr_build_updated(build_status):
             .with_args(1)
             .and_return(
                 flexmock(
-                    ended_on=True,
+                    ended_on=build_ended_on,
+                    started_on="timestamp",
                     state="completed",
                     source_package={
                         "name": "source_package_name",
@@ -168,7 +170,7 @@ def test_check_copr_build_updated(build_status):
         )
     )
     flexmock(CoprBuildEndHandler).should_receive("run_job").and_return().once()
-    assert check_copr_build(build_id=1)
+    assert check_copr_build(build_id=1) is bool(build_ended_on)
 
 
 def test_check_copr_build_waiting_started():


### PR DESCRIPTION
Instead of checking the ended_on attribute for the whole build, check this only for the particular chroot.

Fixes #1836


---

RELEASE NOTES BEGIN
We have fixed a bug which caused long Copr build end reporting time on a few occurrences.
RELEASE NOTES END
