### PR TITLE
Utilize update_release config option

### DIFF
--- a/packit_service/worker/helpers/build/babysit.py
+++ b/packit_service/worker/helpers/build/babysit.py
@@ -200,10 +200,10 @@ def update_copr_builds(build_id: int, builds: Iterable["CoprBuildTargetModel"]) 
         return True
 
     if not build_copr.ended_on and not build_copr.started_on:
-        logger.info("The copr build has not started yet.")
+        logger.info(f"The copr build {build_id} has not started yet.")
         return False
 
-    logger.info(f"The status is {build_copr.state!r}.")
+    logger.info(f"The status of {build_id} is {build_copr.state!r}.")
 
     current_time = datetime.now(timezone.utc)
     for build in builds:
@@ -218,7 +218,7 @@ def update_copr_builds(build_id: int, builds: Iterable["CoprBuildTargetModel"]) 
             continue
         if build.status not in (BuildStatus.pending, BuildStatus.waiting_for_srpm):
             logger.info(
-                f"DB state says {build.status!r}, "
+                f"DB state of {build_id} says {build.status!r}, "
                 "things were taken care of already, skipping."
             )
             continue

--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -431,17 +431,19 @@ class BaseBuildJobHelper(BaseJobHelper):
         )
         self._srpm_model.set_start_time(datetime.datetime.utcnow())
 
-        bump_version = (
-            self.job_config.release_suffix != ""
-            and self.job_config.trigger
-            != JobConfigTriggerType.release  # do not modify version for release
-        )
+        if (
+            self.job_config.release_suffix == ""  # TODO remove eventually
+            or self.job_config.trigger == JobConfigTriggerType.release
+        ):
+            update_release = False  # do not modify version/release
+        else:
+            update_release = None  # take the value from config (defaults to True)
 
         try:
             self._srpm_path = Path(
                 self.api.create_srpm(
                     srpm_dir=self.api.up.local_project.working_dir,
-                    bump_version=bump_version,
+                    update_release=update_release,
                     release_suffix=self.job_config.release_suffix,
                 )
             )

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -422,7 +422,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 if pr_id
                 else None,
                 job_config_index=self.get_job_config_index(),
-                bump_version=self.job_config.trigger != JobConfigTriggerType.release,
+                update_release=self.job_config.trigger != JobConfigTriggerType.release,
                 release_suffix=self.job_config.release_suffix,
             )
             build_id, web_url = self.submit_copr_build(script=script)


### PR DESCRIPTION
The `update_release: false` in a package config now works the same way as `release_suffix: ""`.
The `self.job_config.release_suffix == ''` condition can be removed once users move to `update_release: false`.

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [x] packit/packit.dev#587

Fixes #1760 

Merge after packit/packit#1827

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
