### PR TITLE
fix(gitlab): add release hook to interesting

### DIFF
--- a/packit_service/service/api/webhooks.py
+++ b/packit_service/service/api/webhooks.py
@@ -323,6 +323,7 @@ class GitlabWebhook(Resource):
             "Note Hook",
             "Pipeline Hook",
             "Push Hook",
+            "Release Hook",
         }
         event_type = request.headers.get("X-Gitlab-Event")
         if not event_type and not config.validate_webhooks:


### PR DESCRIPTION
Adding a `"Release Hook"` to the list of hooks that we process from GitLab. It's required for a `propose-downstream`.

We care… and are interested *wink wink*

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

I wanna test it with the fake ogr release on GitLab today (presuming the review happens on the Friday…).

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes _fixed sooner than reported_

_release notes not added, not even God knows what will happen…_