### PR TITLE
fix(allowlist): add release from gitlab

### DIFF
--- a/packit_service/worker/allowlist.py
+++ b/packit_service/worker/allowlist.py
@@ -40,6 +40,7 @@ from packit_service.worker.events import (
     TestingFarmResultsEvent,
     CheckRerunEvent,
 )
+from packit_service.worker.events.gitlab import ReleaseGitlabEvent
 from packit_service.worker.events.koji import KojiBuildEvent
 from packit_service.worker.events.new_hotness import NewHotnessUpdateEvent
 from packit_service.worker.helpers.build import CoprBuildJobHelper
@@ -435,6 +436,7 @@ class Allowlist:
             ): self._check_unchecked_event,
             (
                 ReleaseEvent,
+                ReleaseGitlabEvent,
                 PushGitHubEvent,
                 PushGitlabEvent,
             ): self._check_release_push_event,


### PR DESCRIPTION
Add ‹ReleaseGitlabEvent› to check for push/release in allowlist.

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
   - not even GitHub is tested for this…
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to _„‹propose-downstream› on GitLab, can we make it today? pt. 2“_