### PR TITLE
fix(events): add GitLab release SHA manually

### DIFF
--- a/packit_service/worker/events/gitlab.py
+++ b/packit_service/worker/events/gitlab.py
@@ -222,6 +222,11 @@ class ReleaseGitlabEvent(AddReleaseDbTrigger, AbstractGitlabEvent):
     def commit_sha(self):
         return self._commit_sha
 
+    def get_dict(self, default_dict: Optional[dict] = None) -> dict:
+        result = super().get_dict()
+        result["commit_sha"] = self.commit_sha
+        return result
+
 
 class TagPushGitlabEvent(AddBranchPushDbTrigger, AbstractGitlabEvent):
     def __init__(


### PR DESCRIPTION
When retrying or constructing an event for the Celery task, we need to override the default ‹get_dict› on the release events because of the ‹commit_sha› property.

We forgot about it here

https://github.com/packit/packit-service/pull/1778#discussion_r1033332816

Signed-off-by: Matej Focko <mfocko@redhat.com>

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to _„GitLab ‹propose-downstream› saga pt. 4“_