### PR TITLE
fix(container worker): copy all scripts inside

### DIFF
--- a/files/docker/Dockerfile.worker
+++ b/files/docker/Dockerfile.worker
@@ -26,6 +26,7 @@ COPY .git/ .git/
 COPY packit_service/ packit_service/
 
 COPY files/recipe-worker.yaml files/setup_env_in_openshift.sh files/gitconfig files/run_worker.sh ./files/
+COPY files/scripts/ ./files/scripts/
 RUN git rev-parse HEAD >/.packit-service.git.commit.hash \
     && git show --quiet --format=%B HEAD >/.packit-service.git.commit.message \
     && ansible-playbook -vv -c local -i localhost, files/recipe-worker.yaml \

--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -30,4 +30,8 @@
         dest: /usr/bin/
         mode: 0777
       with_fileglob:
-        - scripts/*.py
+        - "{{ playbook_dir }}/scripts/*.py"
+    - name: Make sure allowlist.py is present
+      file:
+        state: file
+        path: /usr/bin/allowlist.py


### PR DESCRIPTION
...and make sure at least allowlist.py is present

```
TASK [Install scripts] *********************************************************
task path: /src/files/recipe-worker.yaml:27
[WARNING]: Unable to find 'scripts' in expected paths (use -vvvvv to see paths)
skipping: [localhost] => {
    "changed": false,
    "skipped_reason": "No items in the list"
}
```

Unfortunately ansible did not failed on that ^

Changed here:
https://github.com/packit/packit-service/commit/f23fff07aae35cff0f2bfac28fb0f3b4fb2d2671

Fixes #1843