### PR TITLE
Merge extra TF parameters to the payload

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -25,6 +25,11 @@ CONFIG_FILE_NAME = "packit-service.yaml"
 TESTING_FARM_API_URL = "https://api.dev.testing-farm.io/v0.1/"
 TESTING_FARM_INSTALLABILITY_TEST_URL = "https://gitlab.com/testing-farm/tests"
 TESTING_FARM_INSTALLABILITY_TEST_REF = "main"
+TESTING_FARM_EXTRA_PARAM_MERGED_SUBTREES = (
+    "environments",
+    "test",
+    "settings",
+)
 
 MSG_DOWNSTREAM_JOB_ERROR_HEADER = (
     "Packit failed on creating {object} in dist-git "


### PR DESCRIPTION
Tests are going to fail until https://github.com/packit/packit/pull/1832 is merged.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

Fixes: #1627 
Fixes: #1797 

---

RELEASE NOTES BEGIN
Packit now allows passing in free-form parameters to Testing Farm in order to support all of its option immediately once they are added. The parameters can be passed through the `tf_extra_params` config option. The free-form dict must follow the structure of Testing Farm POST requests. See our documentation and examples for more information.
RELEASE NOTES END
