### PR TITLE
Run API tests during make check-db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ check-db: build-test-image compose-for-db-up
 		-v $(CURDIR)/secrets/packit/dev/privkey.pem:/secrets/privkey.pem:ro,z \
 		-w /src \
 		--network packit-service_default \
-		$(TEST_IMAGE) make check "TEST_TARGET=tests_openshift/database"
+		$(TEST_IMAGE) make check "TEST_TARGET=tests_openshift/database tests_openshift/service"
 		$(COMPOSE) down
 
 .PHONY: build-revdep-test-image


### PR DESCRIPTION
SSIA. I thought about creating a separate target but DB and API tests are very related and I feel like the goal of the target is to reproduce tests_openshift from zuul as much as possible