### PR TITLE
Get the actual latest Koji build when retriggering Bodhi update

### DIFF
--- a/packit_service/worker/handlers/mixin.py
+++ b/packit_service/worker/handlers/mixin.py
@@ -192,7 +192,7 @@ class GetKojiBuildDataFromKojiService(Config, GetKojiBuildData):
         if not self._build:
             self._build = self.koji_helper.get_latest_build_in_tag(
                 package=self.project.repo,
-                tag=self._dist_git_branch,
+                tag=self.koji_helper.get_candidate_tag(self._dist_git_branch),
             )
             if not self._build:
                 raise PackitException(
@@ -237,7 +237,7 @@ class GetKojiBuildDataFromKojiServiceMultipleBranches(
         # call it every time since dist_git_branch reference can change
         build = self.koji_helper.get_latest_build_in_tag(
             package=self.project.repo,
-            tag=self._dist_git_branch,
+            tag=self.koji_helper.get_candidate_tag(self._dist_git_branch),
         )
         if not build:
             raise PackitException(

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -325,19 +325,25 @@ def test_issue_comment_retrigger_bodhi_update_handler(
     flexmock(PackitAPI).should_receive("create_update").with_args(
         dist_git_branch="f38",
         update_type="enhancement",
-        koji_builds=["python-teamcity-messages.f38"],
+        koji_builds=["python-teamcity-messages.fc38"],
     )
+    flexmock(KojiHelper).should_receive("get_candidate_tag").with_args(
+        "f38"
+    ).and_return("f38-updates-candidate")
     flexmock(KojiHelper).should_receive("get_latest_build_in_tag").with_args(
-        package="python-teamcity-messages", tag="f38"
-    ).and_return({"nvr": "python-teamcity-messages.f38", "build_id": 2, "state": 1})
+        package="python-teamcity-messages", tag="f38-updates-candidate"
+    ).and_return({"nvr": "python-teamcity-messages.fc38", "build_id": 2, "state": 1})
     flexmock(PackitAPI).should_receive("create_update").with_args(
         dist_git_branch="f37",
         update_type="enhancement",
-        koji_builds=["python-teamcity-messages.f37"],
+        koji_builds=["python-teamcity-messages.fc37"],
     )
+    flexmock(KojiHelper).should_receive("get_candidate_tag").with_args(
+        "f37"
+    ).and_return("f37-updates-candidate")
     flexmock(KojiHelper).should_receive("get_latest_build_in_tag").with_args(
-        package="python-teamcity-messages", tag="f37"
-    ).and_return({"nvr": "python-teamcity-messages.f37", "build_id": 1, "state": 1})
+        package="python-teamcity-messages", tag="f37-updates-candidate"
+    ).and_return({"nvr": "python-teamcity-messages.fc37", "build_id": 1, "state": 1})
 
     results = run_issue_comment_retrigger_bodhi_update(
         package_config=package_config,

--- a/tests/unit/test_handler_mixin.py
+++ b/tests/unit/test_handler_mixin.py
@@ -23,8 +23,11 @@ def test_GetKojiBuildDataFromKojiServiceMixin():
             )
             self.data = flexmock(pr_id="123")
 
+    flexmock(KojiHelper).should_receive("get_candidate_tag").with_args(
+        "a_branch"
+    ).and_return("a_tag")
     flexmock(KojiHelper).should_receive("get_latest_build_in_tag").with_args(
-        package="a_repo", tag="a_branch"
+        package="a_repo", tag="a_tag"
     ).and_return({"nvr": "1.0.0", "state": 1, "build_id": 123})
     mixin = Test()
     data = []
@@ -82,11 +85,17 @@ def test_GetKojiBuildDataFromKojiServiceMultipleBranches():
         def branches(self):
             return ["f37", "f38"]
 
+    flexmock(KojiHelper).should_receive("get_candidate_tag").with_args(
+        "f37"
+    ).and_return("f37-updates-candidate")
     flexmock(KojiHelper).should_receive("get_latest_build_in_tag").with_args(
-        package="a repo", tag="f37"
+        package="a repo", tag="f37-updates-candidate"
     ).and_return({"nvr": "1.0.1", "state": 1, "build_id": 123})
+    flexmock(KojiHelper).should_receive("get_candidate_tag").with_args(
+        "f38"
+    ).and_return("f38-updates-candidate")
     flexmock(KojiHelper).should_receive("get_latest_build_in_tag").with_args(
-        package="a repo", tag="f38"
+        package="a repo", tag="f38-updates-candidate"
     ).and_return({"nvr": "1.0.2", "state": 1, "build_id": 1234})
 
     mixin = Test()


### PR DESCRIPTION
Koji tags named equally to dist-git branches are what stable builds are tagged into, but when creating a Bodhi update, we are interested in the latest non-stable build that is tagged into a candidate tag.

Get candidate tag corresponding to the dist-git branch being processed and use that to get the latest build from Koji.

---

This is a problem when retriggering both from a dist-git PR and from an issue repository, see for example https://github.com/packit/specfile/issues/194.