### PR TITLE
Get branches also from comments in issue repository

### DIFF
--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -288,12 +288,17 @@ class GetBranchesFromIssueMixin(Config, GetBranches):
 
         You can retrigger the update by adding a comment (`/packit propose-downstream`) into this issue.
         """
-        branches = []
+        branches = set()
+        branch_regex = re.compile(r"\s*\| `(\S+)` \|")
         issue = self.data.project.get_issue(self.data.issue_id)
         for line in issue.description.splitlines():
-            if m := re.match(r"\s*\| `(\S+)` \|", line):
-                branches.append(m[1])
-        return branches
+            if m := branch_regex.match(line):
+                branches.add(m[1])
+        for comment in issue.get_comments():
+            for line in comment.body.splitlines():
+                if m := branch_regex.match(line):
+                    branches.add(m[1])
+        return list(branches)
 
 
 class GetVMImageBuilder(Protocol):

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -276,7 +276,8 @@ Packit failed on creating pull-requests in dist-git (https://src.fedoraproject.o
 | `f37` | `` |
 | `f38` | `` |
 You can retrigger the update by adding a comment (`/packit propose-downstream`) into this issue.
-    """
+        """,
+        get_comments=lambda: [],
     )
     project = (
         flexmock(GithubProject).should_receive("get_issue").and_return(issue).mock()


### PR DESCRIPTION
If a Bodhi update fails and there is an existing issue in the configured issue repository, packit adds a comment to it mentioning the corresponding dist-git branch(es) rather than updating the description.

Collect a set of branches from both the issue description and its comments.

See for example https://github.com/packit/specfile/issues/194.