### PR TITLE
fix(bodhi): auth failure is not expected anymore

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -95,7 +95,6 @@ DEFAULT_RETRY_LIMIT_OUTAGE = 5
 # because jitter is enabled by default, celery makes these retries random:
 # https://docs.celeryq.dev/en/latest/userguide/tasks.html#Task.retry_jitter
 DEFAULT_RETRY_BACKOFF = 7
-RETRY_INTERVAL_IN_MINUTES_WHEN_USER_ACTION_IS_NEEDED = 10
 BASE_RETRY_INTERVAL_IN_MINUTES_FOR_OUTAGES = 1
 BASE_RETRY_INTERVAL_IN_SECONDS_FOR_INTERNAL_ERRORS = 10
 

--- a/tests/unit/test_bodhi_update_error_msgs.py
+++ b/tests/unit/test_bodhi_update_error_msgs.py
@@ -1,7 +1,6 @@
 import pytest
 
 from flexmock import flexmock
-from fedora.client import AuthError
 
 from packit.exceptions import PackitException
 from packit.config import (
@@ -161,54 +160,6 @@ def test_pull_request_retrigger_bodhi_update_with_koji_data(
     handler = RetriggerBodhiUpdateHandler(package_config, job_config, data, flexmock())
     with pytest.raises(PackitException):
         handler.run()
-
-
-def test_pull_request_retrigger_bodhi_update_auth_err(
-    package_config__job_config__pull_request_event,
-):
-    package_config, job_config, data = package_config__job_config__pull_request_event
-
-    msg = (
-        "Packit failed on creating Bodhi update in dist-git (an url):\n\n"
-        "| dist-git branch | error |\n| --------------- | ----- |\n"
-        "| `f36` | Bodhi update creation failed for `a_package_1.f36` "
-        "because of the missing permissions. Please, give packit user `commit`"
-        " rights in the [dist-git settings](projec_url/adduser). *Try 2/2.* |\n\n"
-        "Fedora Bodhi update was re-triggered by comment in dist-git PR with id 123.\n\n"
-        "You can retrigger the update by adding a comment (`/packit create-update`) "
-        "into this issue.\n\n---\n\n"
-        "*Get in [touch with us](https://packit.dev/#contact) if you need some help.*\n"
-    )
-    flexmock(bodhi).should_receive("report_in_issue_repository").with_args(
-        issue_repository=None,
-        service_config=ServiceConfig,
-        title=("Fedora Bodhi update failed to be created"),
-        message=msg,
-        comment_to_existing=msg,
-    ).once()
-
-    error_msg = "error abc"
-    dg = flexmock(local_project=flexmock(git_url="an url"))
-    packit_api = (
-        flexmock(dg=dg)
-        .should_receive("create_update")
-        .and_raise(PackitException, error_msg)
-        .mock()
-    )
-    flexmock(RetriggerBodhiUpdateHandler).should_receive("packit_api").and_return(
-        packit_api
-    )
-    flexmock(RetriggerBodhiUpdateHandler).should_receive("__next__").and_return(
-        KojiBuildData(dist_git_branch="f36", build_id=1, nvr="a_package_1.f36", state=1)
-    )
-    flexmock(CeleryTask).should_receive("is_last_try").and_return(True)
-    flexmock(CeleryTask).should_receive("retries").and_return(1)
-    flexmock(CeleryTask).should_receive("get_retry_limit").and_return(1)
-    flexmock(PackitException).should_receive("__cause__").and_return(
-        AuthError("another_error")
-    )
-    handler = RetriggerBodhiUpdateHandler(package_config, job_config, data, flexmock())
-    handler.run()
 
 
 def test_issue_comment_retrigger_bodhi_update_no_koji_data(package_config__job_config):


### PR DESCRIPTION
After we were given the global rights to run Bodhi updates, we don't need to ask for ‹commit› privileges on dist-git, therefore this kind of failure is now unexpected and should be reported to Sentry.

Also we shouldn't suggest adding ‹commit› access to the dist-git as it is no longer needed.

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to #1721