### PR TITLE
Add broken test for monorepo refactoring

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -521,7 +521,7 @@ class SteveJobs:
         """
         matching_jobs = []
         if isinstance(self.event, PullRequestCommentPagureEvent):
-            for job in self.event.package_config.jobs:
+            for job in self.event.package_config.get_job_views():
                 if (
                     job.type in [JobType.koji_build, JobType.bodhi_update]
                     and job.trigger == JobConfigTriggerType.commit
@@ -532,7 +532,7 @@ class SteveJobs:
                     # can be re-triggered by a Pagure comment in a PR
                     matching_jobs.append(job)
         elif isinstance(self.event, AbstractIssueCommentEvent):
-            for job in self.event.package_config.jobs:
+            for job in self.event.package_config.get_job_views():
                 if (
                     job.type in (JobType.koji_build, JobType.bodhi_update)
                     and job.trigger == JobConfigTriggerType.commit
@@ -552,7 +552,7 @@ class SteveJobs:
         Get list of non-duplicated all jobs that matches with event's trigger.
         """
         jobs_matching_trigger = []
-        for job in self.event.package_config.jobs:
+        for job in self.event.package_config.get_job_views():
             if (
                 job.trigger == self.event.job_config_trigger_type
                 and (

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -3,11 +3,19 @@
 
 from typing import Type
 
+import copy
 import celery
 import pytest
 from flexmock import flexmock
 
-from packit.config import CommonPackageConfig, JobConfig, JobConfigTriggerType, JobType
+from packit.config import (
+    CommonPackageConfig,
+    JobConfig,
+    JobConfigTriggerType,
+    JobType,
+    PackageConfig,
+)
+
 from packit_service.config import ServiceConfig
 from packit_service.constants import COMMENT_REACTION
 from packit_service.worker.events import (
@@ -3121,3 +3129,106 @@ def test_create_tasks_tf_identifier(
         tasks_created * [None]
     ).and_return(flexmock().should_receive("apply_async").mock())
     assert tasks_created == len(SteveJobs(event).create_tasks(jobs, handler_kls))
+
+
+def test_monorepo_jobs_matching_event():
+    python_teamcity_messages = CommonPackageConfig(
+        patch_generation_ignore_paths=[],
+        specfile_path="python-teamcity-messages.spec",
+        upstream_ref=None,
+        files_to_sync=[
+            {
+                "dest": "python-teamcity-messages.spec",
+                "mkpath": False,
+                "filters": [],
+                "delete": False,
+                "src": ["python-teamcity-messages.spec"],
+            },
+            {
+                "dest": ".packit.yaml",
+                "mkpath": False,
+                "filters": [],
+                "delete": False,
+                "src": [".packit.yaml"],
+            },
+        ],
+        paths=["."],
+        dist_git_base_url="https://src.fedoraproject.org/",
+        upstream_package_name="teamcity-messages",
+        archive_root_dir_template="{upstream_pkg_name}-{version}",
+        upstream_project_url="https://github.com/majamassarini/teamcity-messages",
+        config_file_path=".packit.yaml",
+        patch_generation_patch_id_digits=4,
+        dist_git_namespace="rpms",
+        downstream_package_name="python-teamcity-messages",
+        upstream_tag_template="v{version}",
+    )
+    python_teamcity_messages_double = copy.deepcopy(python_teamcity_messages)
+    python_teamcity_messages_double.downstream_package_name = "a double"
+
+    packages = {
+        "python-teamcity-messages": copy.deepcopy(python_teamcity_messages),
+        "python-teamcity-messages-double": python_teamcity_messages_double,
+    }
+    jobs = [
+        JobConfig(
+            type=JobType.propose_downstream,
+            trigger=JobConfigTriggerType.release,
+            skip_build=False,
+            packages={
+                "python-teamcity-messages": python_teamcity_messages,
+                "python-teamcity-messages-double": python_teamcity_messages_double,
+            },
+        ),
+        JobConfig(
+            type=JobType.propose_downstream,
+            trigger=JobConfigTriggerType.release,
+            skip_build=False,
+            packages={
+                "python-teamcity-messages": python_teamcity_messages,
+            },
+        ),
+        JobConfig(
+            type=JobType.propose_downstream,
+            trigger=JobConfigTriggerType.release,
+            skip_build=False,
+            packages={
+                "python-teamcity-messages-double": python_teamcity_messages_double
+            },
+        ),
+    ]
+    packages_config = PackageConfig(packages=packages, jobs=jobs)
+
+    class Event(ReleaseEvent):
+        def __init__(self):
+            self._package_config_searched = None
+            self._package_config = packages_config
+            self._project = flexmock()
+            self._base_project = flexmock()
+            self._pr_id = flexmock()
+            self._commit_sha = flexmock()
+            self.fail_when_config_file_missing = True
+
+        @property
+        def job_config_trigger_type(self):
+            return JobConfigTriggerType.release
+
+    event = Event()
+    steve = SteveJobs(event)
+    handlers = steve.get_handlers_for_event()
+    assert handlers
+
+    for handler in handlers:
+        job_configs = steve.get_config_for_handler_kls(handler)
+        assert job_configs
+
+        original_ref = 0
+        double_ref = 0
+        for job_config in job_configs:
+            if job_config.downstream_package_name == "a double":
+                double_ref += 1
+            else:
+                original_ref += 1
+
+        assert original_ref == 2
+        assert double_ref == 2


### PR DESCRIPTION
DO NOT MERGE.

This is just a SPIKE PR to propose a solution on how to refactor the packit_api object to support monorepos.

related to https://github.com/packit/packit/issues/1618
related to https://github.com/packit/packit/pull/1838
related to https://github.com/packit/packit/pull/1840

Here there is a broken unit test that when fixed we could probably say we support the monorepo configuration in `packit-service`.
In [get_jobs_matching_event](https://github.com/majamassarini/packit-service/blob/2e8881d347ce4553cd6f4d48cd919291511c5187/packit_service/worker/jobs.py#L555) we return a `JobConfig` which is not *usable*. It is defined in the unit test [here](https://github.com/majamassarini/packit-service/blob/multiple_distgit_packit_api/tests/unit/test_jobs.py#L3174-L3182) and its properties can not be accessed, like the [`downstream_package_name`](https://github.com/majamassarini/packit-service/blob/2e8881d347ce4553cd6f4d48cd919291511c5187/tests/unit/test_jobs.py#L3228), because this `JobConfig` references multiple packages.

There are many possible solutions; here below I describe my favourite one.

Our handlers are being designed to work with one package at a time and I think they should keep doing that. For this reason if a user specifies multiple downstream packages for the same old job, like the `propose_downstream` job, then I can image that the call `self.event.package_config.jobs` should probably be substituted with another call able to return two different jobs, let me call them `JobConfigView` or something like that, for the same `JobConfig` which has multiple packages...

I think we should try to keep our handlers as  simple as we can and not manage multiple packages in the same handler instance run.
But if we are forced to do that, then we can write new handlers able to deal with a `JobConfig` holding multiple packages. Probably we could create a new class for a `JobConfig` holding multiple packages  and pass instances of this class to the new handlers.

Let me know if you see any problem with this solution.
