### PR TITLE
Set hard time limit for tasks

### DIFF
--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -34,3 +34,6 @@ beat_schedule = {
 # http://mher.github.io/flower/prometheus-integration.html#set-up-your-celery-application
 worker_send_task_events = True
 task_send_sent_event = True
+
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_time_limit
+task_time_limit = 900  # 15 min


### PR DESCRIPTION
Checking Flower history in Grafana, most tasks finished within 3min, some within 6min, and one exception around 10min, so 15min ought to be enough for anybody ;)

Related to #1858