### PR TITLE
Create TF task as a last step of CoprBuildEndHandler

### DIFF
--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -311,8 +311,8 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
         self.measure_time_after_reporting()
 
         self.set_built_packages()
-        self.handle_testing_farm()
         self.build.set_status(BuildStatus.success)
+        self.handle_testing_farm()
 
         return TaskResults(success=True, details={})
 


### PR DESCRIPTION
Otherwise, the TF may be triggered when the build is still in pending state and therefore TF handler execution is skipped.

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
