### PR TITLE
Attach news to the Check Run status

### DIFF
--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -3,6 +3,7 @@
 
 import logging
 from enum import Enum, auto
+from random import choice
 from typing import Optional, Union, Dict
 
 from ogr.abstract import CommitStatus, GitProject
@@ -23,6 +24,27 @@ from packit_service.constants import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+NEWS_FOOTER = [
+    "Wondering what happened during the last year in Packit? "
+    "Take a look at [our blog post](https://packit.dev/posts/2022-features/).",
+    "Do you maintain a Fedora package and don't have access to the upstream repository? "
+    "Packit can help. "
+    "Take a look [here](https://packit.dev/posts/pull-from-upstream/) to know more.",
+    "Do you maintain a Fedora package and you think it's boring? Packit can help. "
+    "Take a look [here](https://packit.dev/posts/downstream-automation/) to know more.",
+    "Want to use a build from a different project when testing? "
+    "Take a look [here](https://packit.dev/posts/testing-farm-triggering/) to know more.",
+]
+
+
+def get_random_news_sentence() -> str:
+    """
+    A random sentence to show our users as a footer when adding a status.
+    (Will be visible at the very bottom of the markdown field.
+    """
+    return choice(NEWS_FOOTER)
 
 
 class BaseCommitStatus(Enum):
@@ -465,7 +487,11 @@ class StatusReporterGithubChecks(StatusReporterGithubStatuses):
             f" {description}"
         )
 
-        summary = self._create_table(url, links_to_external_services) + markdown_content
+        summary = (
+            self._create_table(url, links_to_external_services)
+            + markdown_content
+            + f"---\n*{get_random_news_sentence()}*"
+        )
 
         try:
             status = (

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -14,6 +14,7 @@ from ogr.services.github.check_run import (
 )
 from ogr.services.gitlab import GitlabProject
 from ogr.services.pagure import PagureProject
+from packit_service.worker import reporting
 
 from packit_service.worker.reporting import (
     StatusReporter,
@@ -217,6 +218,10 @@ def test_set_status_github_check(
     check_conclusion,
     trigger_id,
 ):
+    flexmock(reporting).should_receive("get_random_news_sentence").and_return(
+        "Interesting news."
+    )
+
     project = GithubProject(None, None, None)
     reporter = StatusReporter.get_instance(
         project=project,
@@ -234,7 +239,9 @@ def test_set_status_github_check(
         external_id=str(trigger_id),
         status=check_status,
         conclusion=check_conclusion,
-        output=create_github_check_run_output(title, summary),
+        output=create_github_check_run_output(
+            title, summary + "---\n*Interesting news.*"
+        ),
     ).once()
 
     reporter.set_status(state, title, check_name, url)
@@ -429,6 +436,10 @@ def test_status_instead_check(
     exception_type,
     trigger_id,
 ):
+    flexmock(reporting).should_receive("get_random_news_sentence").and_return(
+        "Interesting news."
+    )
+
     project = GithubProject(None, None, None)
     reporter = StatusReporter.get_instance(
         project=project,
@@ -446,7 +457,9 @@ def test_status_instead_check(
         external_id=str(trigger_id),
         status=check_status,
         conclusion=check_conclusion,
-        output=create_github_check_run_output(title, summary),
+        output=create_github_check_run_output(
+            title, summary + "---\n*Interesting news.*"
+        ),
     ).and_raise(exception_type).once()
 
     act_upon.should_receive("set_commit_status").with_args(


### PR DESCRIPTION
For now, there is a constant defining multiple text options. Each time, a random choice is picked.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>

---

RELEASE NOTES BEGIN
You will newly see news about Packit as a footer of the GitHub check runs summary.
RELEASE NOTES END
