### PR TITLE
fix: propagate git-forge exceptions to Sentry

### DIFF
--- a/packit_service/worker/helpers/sync_release/pull_from_upstream.py
+++ b/packit_service/worker/helpers/sync_release/pull_from_upstream.py
@@ -52,3 +52,6 @@ class PullFromUpstreamHelper(SyncReleaseHelper):
 
     def report_status_for_branch(self, branch, description, state, url):
         pass
+
+    def report_status_to_all(self, description, state, url="", markdown_content=None):
+        pass

--- a/packit_service/worker/helpers/sync_release/sync_release.py
+++ b/packit_service/worker/helpers/sync_release/sync_release.py
@@ -83,3 +83,12 @@ class SyncReleaseHelper(BaseJobHelper):
 
     def report_status_for_branch(self, branch, description, state, url):
         raise NotImplementedError("Use subclass")
+
+    def report_status_to_all(
+        self,
+        description,
+        state,
+        url="",
+        markdown_content=None,
+    ):
+        raise NotImplementedError("Use subclass")

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -673,13 +673,12 @@ def test_retry_propose_downstream_task(
         url=url,
     ).once()
     flexmock(ProposeDownstreamJobHelper).should_receive(
-        "report_status_for_branch"
+        "report_status_to_all"
     ).with_args(
-        branch="main",
         description="Propose downstream is being retried because "
         "we were not able yet to download the archive. ",
         state=BaseCommitStatus.pending,
-        url=url,
+        url="",
     ).once()
 
     processing_results = SteveJobs().process_message(github_release_webhook)


### PR DESCRIPTION
When running propose-downstream, do not „auto-catch“ everything. Let the git-forge exceptions propagate further, so they also count in the Sentry alerts.

Introduce a new ‹run_for_target› method for running propose-downstream to better decompose the current structure of the dist-git handler.

Signed-off-by: Matej Focko <mfocko@redhat.com>

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #1660