### PR TITLE
Ignore only the top level 'build' directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ secrets
 .vagrant/
 *.egg-info
 .mypy_cache/
-build/
+/build/


### PR DESCRIPTION
Otherwise packit_service/worker/helpers/build/ is also going to be ignored.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>