### PR TITLE
Fix/packit service/1879

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,15 @@ You can also run only certain pieces of packit-service for local development
 (e.g. worker, database or service/httpd).
 You also need to populate `secrets/packit/dev/` manually, for instructions
 see [deployment repo](https://github.com/packit/deployment/tree/main/secrets).
+Be sure to copy the content you need from `extra-vars.yml` to `packit-service.yaml`
 
 When you are running service/httpd and making requests to it,
 make sure that `server_name` configuration file in `packit-service.yaml` is set.
+
+### tokman
+
+To make tokman work with docker-compose create a `config.py` file in `./secrets/packit/dev/tokman-files` using this [template](https://github.com/packit/tokman/blob/main/config.py.example).
+In `.secrets/packit/dev/packit-service.yaml` fix url to tokman from `http://tokman` to `http://tokman:8000`
 
 ### binding on localhost
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,20 @@
 version: "2"
 
 services:
+  tokman:
+    image: quay.io/packit/tokman
+    container_name: tokman
+    ports:
+      - 8000:8000
+    environment:
+      LOG_LEVEL: debug
+      TOKMAN_CONFIG: /config/config.py
+      BIND_ADDR: 0.0.0.0:8000
+    volumes:
+      - ./secrets/packit/dev/tokman-files:/config:ro,z
+      - ./secrets/packit/dev/tokman-files:/access_tokens:ro,z
+      - ./secrets/packit/dev/:/secrets:ro,z
+
   redis:
     image: quay.io/sclorg/redis-6-c9s
     container_name: redis
@@ -53,6 +67,7 @@ services:
     image: quay.io/packit/packit-worker:dev
     command: /usr/bin/run_worker.sh
     depends_on:
+      - tokman
       - redis
       - postgres
     environment:
@@ -68,6 +83,7 @@ services:
       PUSHGATEWAY_ADDRESS: ""
       AWS_ACCESS_KEY_ID: ""
       AWS_SECRET_ACCESS_KEY: ""
+      GIT_SSH_COMMAND: "ssh -F /home/packit/.ssh/config"
     volumes:
       - ../packit/packit:/usr/local/lib/python3.11/site-packages/packit:ro,z
       - ./packit_service:/usr/local/lib/python3.11/site-packages/packit_service:ro,z

--- a/packit_service/worker/helpers/sync_release/sync_release.py
+++ b/packit_service/worker/helpers/sync_release/sync_release.py
@@ -57,7 +57,9 @@ class SyncReleaseHelper(BaseJobHelper):
         Return all valid branches from config.
         """
         branches = get_branches(
-            *self.job.dist_git_branches, default=self.default_dg_branch
+            *self.job.dist_git_branches,
+            default_dg_branch=self.default_dg_branch,
+            default=self.default_dg_branch,
         )
         if self.branches_override:
             logger.debug(f"Branches override: {self.branches_override}")

--- a/tests/unit/test_distgit.py
+++ b/tests/unit/test_distgit.py
@@ -6,11 +6,13 @@ import pytest
 from flexmock import flexmock
 from fasjson_client import Client
 
+from ogr.services.github import GithubService
 from packit.api import PackitAPI
 from packit_service.worker.handlers.distgit import (
     ProposeDownstreamHandler,
     DownstreamKojiBuildHandler,
     AbstractSyncReleaseHandler,
+    PullFromUpstreamHandler,
 )
 from packit_service.worker.events.event import EventData
 from packit_service.config import PackageConfigGetter
@@ -114,3 +116,14 @@ def test_upstream_local_project_is_used():
     assert handler.packit_api
     assert not handler.packit_api.downstream_local_project
     assert handler.packit_api.upstream_local_project
+
+
+def test_pull_from_upstream_auth_method():
+    class Test(PullFromUpstreamHandler):
+        pass
+
+    handler = Test(None, None, {"event_type": "unknown"}, None)
+    flexmock(GithubService).should_receive("set_auth_method").once()
+    flexmock(AbstractSyncReleaseHandler).should_receive("run").once()
+    flexmock(GithubService).should_receive("reset_auth_method").once()
+    handler.run()


### PR DESCRIPTION
Customize authentication method for `PullFromUpstream`: use token instead of tokman.
Token should be added to the service configuration.
I tested it with a personal token and it seems to be working, we could use a token created for packit or a bot?

- [x] Write new unit tests

Fixes #1879

Merge after packit/ogr#767
