### PR TITLE
Don't sync default files in pull-from-upstream

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -176,13 +176,16 @@ class AbstractSyncReleaseHandler(
     ) -> Optional[PullRequest]:
         try:
             branch_suffix = f"update-{self.sync_release_job_type.value}"
+            is_pull_from_upstream_job = (
+                self.sync_release_job_type == SyncReleaseJobType.pull_from_upstream
+            )
             downstream_pr = self.packit_api.sync_release(
                 dist_git_branch=branch,
                 tag=self.data.tag_name,
                 create_pr=True,
                 local_pr_branch_suffix=branch_suffix,
-                use_downstream_specfile=self.sync_release_job_type
-                == SyncReleaseJobType.pull_from_upstream,
+                use_downstream_specfile=is_pull_from_upstream_job,
+                sync_default_files=not is_pull_from_upstream_job,
             )
         except PackitDownloadFailedException as ex:
             # the archive has not been uploaded to PyPI yet

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -134,6 +134,7 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         create_pr=True,
         local_pr_branch_suffix="update-pull_from_upstream",
         use_downstream_specfile=True,
+        sync_default_files=False,
     ).and_return(flexmock(url="some_url")).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -161,6 +161,7 @@ def test_dist_git_push_release_handle(github_release_webhook, propose_downstream
         create_pr=True,
         local_pr_branch_suffix="update-propose_downstream",
         use_downstream_specfile=False,
+        sync_default_files=True,
     ).and_return(flexmock(url="some_url")).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -282,6 +283,7 @@ def test_dist_git_push_release_handle_multiple_branches(
             create_pr=True,
             local_pr_branch_suffix="update-propose_downstream",
             use_downstream_specfile=False,
+            sync_default_files=True,
         ).and_return(flexmock(url="some_url")).once()
 
         flexmock(ProposeDownstreamJobHelper).should_receive(
@@ -402,6 +404,7 @@ def test_dist_git_push_release_handle_one_failed(
                 create_pr=True,
                 local_pr_branch_suffix="update-propose_downstream",
                 use_downstream_specfile=False,
+                sync_default_files=True,
             ).and_return(flexmock(url="some_url")).once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
@@ -418,6 +421,7 @@ def test_dist_git_push_release_handle_one_failed(
                 create_pr=True,
                 local_pr_branch_suffix="update-propose_downstream",
                 use_downstream_specfile=False,
+                sync_default_files=True,
             ).and_raise(Exception, f"Failed {model.branch}").once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
@@ -645,6 +649,7 @@ def test_retry_propose_downstream_task(
         create_pr=True,
         local_pr_branch_suffix="update-propose_downstream",
         use_downstream_specfile=False,
+        sync_default_files=True,
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()
@@ -748,6 +753,7 @@ def test_dont_retry_propose_downstream_task(
         create_pr=True,
         local_pr_branch_suffix="update-propose_downstream",
         use_downstream_specfile=False,
+        sync_default_files=True,
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -149,6 +149,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
         create_pr=True,
         local_pr_branch_suffix="update-propose_downstream",
         use_downstream_specfile=False,
+        sync_default_files=True,
     ).and_return(flexmock(url="some_url")).times(1 if success else 0)
     flexmock(shutil).should_receive("rmtree").with_args("")
 


### PR DESCRIPTION
In propose-downstream, we by default sync the specfile and Packit config, this should not be done in pull-from-upstream that doesn't contain these files.

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
