### PR TITLE
Workers default to prefork pool

### DIFF
--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -36,12 +36,12 @@ elif [[ "${CELERY_COMMAND}" == "worker" ]]; then
     : "${CONCURRENCY:=1}"
     export CONCURRENCY
 
-    # Options: solo | gevent
+    # Options: solo | prefork |  gevent
     # https://www.distributedpython.com/2018/10/26/celery-execution-pool/
     if ((CONCURRENCY > 1)); then
       : "${POOL:=gevent}"
     else
-      : "${POOL:=solo}"
+      : "${POOL:=prefork}"
     fi
     export POOL
 


### PR DESCRIPTION
`solo` seemed (aee469d) like a good fit for our use-case, i.e. single threaded/processed worker in OpenShift, but it probably has some limitations, like:
https://github.com/packit/packit-service/issues/1858#issuecomment-1422624605
https://github.com/packit/deployment/pull/457#issuecomment-1439677383
