### PR TITLE
Trigger identifier improvements

### DIFF
--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -363,7 +363,10 @@ class BaseBuildJobHelper(BaseJobHelper):
         identifier: Optional[str] = None,
     ):
         chroot_str = f":{chroot}" if chroot else ""
-        trigger_str = f":{trigger_identifier}" if trigger_identifier else ""
+        # replace ':' in the trigger identifier
+        trigger_str = (
+            f":{trigger_identifier.replace(':', '-')}" if trigger_identifier else ""
+        )
         optional_suffix = f":{identifier}" if identifier else ""
         return f"{job_name}{trigger_str}{chroot_str}{optional_suffix}"
 

--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -21,6 +21,8 @@ from packit_service.models import (
     PipelineModel,
     SRPMBuildModel,
     BuildStatus,
+    ProjectReleaseModel,
+    GitBranchModel,
 )
 from packit_service.service.urls import get_srpm_build_info_url
 from packit_service.trigger_mapping import are_job_types_same
@@ -397,12 +399,14 @@ class BaseBuildJobHelper(BaseJobHelper):
         # for commit and release triggers, we add the identifier to
         # the status name (branch name in case of commit trigger,
         # tag name in case of release trigger)
-        return (
-            self.metadata.identifier
-            if self.db_trigger.job_config_trigger_type
-            in (JobConfigTriggerType.commit, JobConfigTriggerType.release)
-            else None
-        )
+        identifier = None
+
+        if isinstance(self.db_trigger, ProjectReleaseModel):
+            identifier = self.db_trigger.tag_name
+        elif isinstance(self.db_trigger, GitBranchModel):
+            identifier = self.db_trigger.name
+
+        return identifier
 
     def get_build_check(self, chroot: str = None) -> str:
         return self.get_build_check_cls(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,12 @@ from ogr import GithubService, GitlabService, PagureService
 from packit.config import JobConfigTriggerType, JobConfig, PackageConfig
 from packit.config.common_package_config import Deployment
 from packit_service.config import ServiceConfig
-from packit_service.models import JobTriggerModelType, JobTriggerModel, BuildStatus
+from packit_service.models import (
+    JobTriggerModelType,
+    JobTriggerModel,
+    BuildStatus,
+    PullRequestModel,
+)
 from packit_service.worker.events import (
     PullRequestGithubEvent,
     PushGitHubEvent,
@@ -152,6 +157,7 @@ def copr_build_model(
     repo_name="hello-world",
     repo_namespace="packit-service",
     forge_instance="github.com",
+    trigger_kls=PullRequestModel,
     job_config_trigger_type=JobConfigTriggerType.pull_request,
     job_trigger_model_type=JobTriggerModelType.pull_request,
     **trigger_model_kwargs,
@@ -161,7 +167,13 @@ def copr_build_model(
         namespace=repo_namespace,
         project_url=f"https://{forge_instance}/{repo_namespace}/{repo_name}",
     )
-    trigger_object_model = flexmock(
+
+    # so that isinstance works
+    class Trigger(trigger_kls):
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    trigger_object_model = Trigger(
         id=1,
         project=project_model,
         job_config_trigger_type=job_config_trigger_type,

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -33,6 +33,8 @@ from packit_service.models import (
     TFTTestRunGroupModel,
     TestingFarmResult,
     BuildStatus,
+    ProjectReleaseModel,
+    GitBranchModel,
 )
 from packit_service.service.urls import (
     get_copr_build_info_url,
@@ -238,6 +240,7 @@ def copr_build_branch_push():
         job_trigger_model_type=JobTriggerModelType.branch_push,
         name="build-branch",
         task_accepted_time=datetime.now(),
+        trigger_kls=GitBranchModel,
     )
 
 
@@ -249,6 +252,7 @@ def copr_build_release():
         tag_name="v1.0.1",
         commit_hash="0011223344",
         task_accepted_time=datetime.now(),
+        trigger_kls=ProjectReleaseModel,
     )
 
 


### PR DESCRIPTION
1. replace ':' (since ':' works as a delimiter in the statuses)
2. get the identifier directly by accessing the DB trigger attributes

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
