### PR TITLE
fix(tasks): HandlerTaskWithRetry.acks_late = True

### DIFF
--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -118,6 +118,9 @@ class HandlerTaskWithRetry(Task):
     max_retries = int(getenv("CELERY_RETRY_LIMIT", DEFAULT_RETRY_LIMIT))
     retry_kwargs = {"max_retries": max_retries}
     retry_backoff = int(getenv("CELERY_RETRY_BACKOFF", DEFAULT_RETRY_BACKOFF))
+    # https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.acks_late
+    # retry if worker gets obliterated during execution
+    acks_late = True
 
 
 class BodhiHandlerTaskWithRetry(HandlerTaskWithRetry):


### PR DESCRIPTION
since we retry failed tasks that use HandlerTaskWithRetry, let's also do
acks_late for these to make sure they are rescheduled if a worker is
shut down in the middle of processing

TODO:

- [x] ~~Write new tests or update the old ones to cover new functionality.~~ I will verify on stg, I can't see how we could write a test case for this :) tear down a worker and see if the tasks is restarted

Fixes #1927

---

RELEASE NOTES BEGIN
Packit will retry tasks that are interrupted by a worker shutdown. This should improve throughput and reduce cases where there is no outcome, i.e. "builds should have been done but nothing happened".
RELEASE NOTES END