### PR TITLE
fix: do not request access to GitLab forks

### DIFF
--- a/packit_service/worker/helpers/job_helper.py
+++ b/packit_service/worker/helpers/job_helper.py
@@ -164,14 +164,14 @@ class BaseJobHelper:
         so we can extend it in subclasses easily.
         """
         if self.is_gitlab_instance and not self.is_reporting_allowed:
-            self.request_project_access()
             description = (
-                f"{description}\n\n---\n*Packit-User does not have access to the "
+                f"{description}\n\n---\nPackit-User does not have access to the "
                 "source project (=usually author's fork of the project). "
-                "We have requested access to be able to set "
-                "commit statuses / pipelines instead of the comments. "
                 "(This is only about the representation of the results. "
-                "Packit is still able to do its job without having the permissions.)*"
+                "Packit is still able to do its job without having the permissions.)\n\n"
+                "*In case you wish to receive commit statuses instead of comments, please "
+                "add login of the author of this comment to your fork with a role "
+                "`Reporter`.*"
             )
 
             final_commit_states = (


### PR DESCRIPTION
When creating commit statuses, we need to have access to the repository having the commits, in case of one-time contributors automatic requesting of access can be an unnecessary noise and spam.

Do not request the access and just post a note about the possibility to add the GitLab user to the said repository.

Fixes #1892

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #1892

---

RELEASE NOTES BEGIN
Packit will no longer automatically request access to the forks on GitLab. This will prevent us from spamming one-time contributors with requesting the access, whereas the regular contributors can add Packit following the instructions from the comments on the MRs, so they can receive the results of Packit pipeline right from the commit statuses.
RELEASE NOTES END
