### PR TITLE
Fix: linked git project can be None

### DIFF
--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -51,9 +51,9 @@ class CoprBuildsList(Resource):
                 "ref": build_info.commit_sha,
                 "pr_id": build_info.get_pr_id(),
                 "branch_name": build_info.get_branch_name(),
-                "repo_namespace": project_info.namespace,
-                "repo_name": project_info.repo_name,
-                "project_url": project_info.project_url,
+                "repo_namespace": project_info.namespace if project_info else "",
+                "repo_name": project_info.repo_name if project_info else "",
+                "project_url": project_info.project_url if project_info else "",
             }
 
             for i, chroot in enumerate(build.target):

--- a/packit_service/service/api/utils.py
+++ b/packit_service/service/api/utils.py
@@ -87,8 +87,7 @@ def get_sync_release_info(sync_release_model: SyncReleaseModel):
     }
 
     project = sync_release_model.get_project()
-    result_dict["repo_namespace"] = project.namespace
-    result_dict["repo_name"] = project.repo_name
-    result_dict["project_url"] = project.project_url
-
+    result_dict["repo_namespace"] = project.namespace if project else ""
+    result_dict["repo_name"] = project.repo_name if project else ""
+    result_dict["project_url"] = project.project_url if project else ""
     return result_dict


### PR DESCRIPTION
The `dashboard` makes `packit-service api` code tracebacking when using db prod data.

The pages where this happens are also those who take a lot of time to load.

ref packit/packit-service#1908

```
service             | [Fri Mar 10 10:49:39.612972 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960] Traceback (most recent call last):
service             | [Fri Mar 10 10:49:39.613404 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib64/python3.11/site-packages/mod_wsgi/server/__init__.py", line 1568, in handle_request
service             | [Fri Mar 10 10:49:39.613413 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     return self.application(environ, start_response)
service             | [Fri Mar 10 10:49:39.613415 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613421 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/werkzeug/middleware/dispatcher.py", line 78, in __call__
service             | [Fri Mar 10 10:49:39.613423 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     return app(environ, start_response)
service             | [Fri Mar 10 10:49:39.613424 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613428 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask/app.py", line 2548, in __call__
service             | [Fri Mar 10 10:49:39.613430 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     return self.wsgi_app(environ, start_response)
service             | [Fri Mar 10 10:49:39.613431 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613435 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask/app.py", line 2528, in wsgi_app
service             | [Fri Mar 10 10:49:39.613436 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     response = self.handle_exception(e)
service             | [Fri Mar 10 10:49:39.613437 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]                ^^^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613441 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask_restx/api.py", line 674, in error_router
service             | [Fri Mar 10 10:49:39.613442 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     return original_handler(f)
service             | [Fri Mar 10 10:49:39.613443 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613447 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask_restx/api.py", line 672, in error_router
service             | [Fri Mar 10 10:49:39.613448 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     return self.handle_error(e)
service             | [Fri Mar 10 10:49:39.613449 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613453 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask/app.py", line 2525, in wsgi_app
service             | [Fri Mar 10 10:49:39.613454 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     response = self.full_dispatch_request()
service             | [Fri Mar 10 10:49:39.613456 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613460 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask/app.py", line 1822, in full_dispatch_request
service             | [Fri Mar 10 10:49:39.613461 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     rv = self.handle_user_exception(e)
service             | [Fri Mar 10 10:49:39.613462 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613466 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask_restx/api.py", line 674, in error_router
service             | [Fri Mar 10 10:49:39.613468 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     return original_handler(f)
service             | [Fri Mar 10 10:49:39.613469 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613472 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask_restx/api.py", line 672, in error_router
service             | [Fri Mar 10 10:49:39.613474 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     return self.handle_error(e)
service             | [Fri Mar 10 10:49:39.613475 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613478 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask/app.py", line 1820, in full_dispatch_request
service             | [Fri Mar 10 10:49:39.613480 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     rv = self.dispatch_request()
service             | [Fri Mar 10 10:49:39.613481 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]          ^^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613485 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask/app.py", line 1796, in dispatch_request
service             | [Fri Mar 10 10:49:39.613486 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
service             | [Fri Mar 10 10:49:39.613487 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613491 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask_restx/api.py", line 405, in wrapper
service             | [Fri Mar 10 10:49:39.613493 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     resp = resource(*args, **kwargs)
service             | [Fri Mar 10 10:49:39.613494 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613500 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask/views.py", line 107, in view
service             | [Fri Mar 10 10:49:39.613502 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     return current_app.ensure_sync(self.dispatch_request)(**kwargs)
service             | [Fri Mar 10 10:49:39.613503 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613507 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/usr/lib/python3.11/site-packages/flask_restx/resource.py", line 46, in dispatch_request
service             | [Fri Mar 10 10:49:39.613508 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     resp = meth(*args, **kwargs)
service             | [Fri Mar 10 10:49:39.613509 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]            ^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613513 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]   File "/src/packit_service/service/api/copr_builds.py", line 54, in get
service             | [Fri Mar 10 10:49:39.613514 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]     "repo_namespace": project_info.namespace,
service             | [Fri Mar 10 10:49:39.613515 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960]                       ^^^^^^^^^^^^^^^^^^^^^^
service             | [Fri Mar 10 10:49:39.613529 2023] [wsgi:error] [pid 20:tid 50] [remote 10.89.0.4:37960] AttributeError: 'NoneType' object has no attribute 'namespace'
```
