### PR TITLE
Provide more generic statuses in Gitlab on build submission

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -234,3 +234,5 @@ GITLAB_ISSUE = (
     "grant `{packit_user}` user `Developer` permissions on the `{namespace}/{repo}`"
     " repository. You can do so [here]({url}/-/project_members)."
 )
+
+DASHBOARD_JOBS_TESTING_FARM_PATH = "/jobs/testing-farm-runs"


### PR DESCRIPTION
Since in GitLab, we are not able to overwrite the pending statuses with new descriptions and links, provide more generic ones (for builds, provide the Copr web URL, for tests, the dashboard testing farm jobs view).

Fixes #1914

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

---

RELEASE NOTES BEGIN
Since in GitLab, it is not possible to overwrite the pending statuses, Packit now provides more generic descriptions and URLs when setting the first pending status.
RELEASE NOTES END
