### PR TITLE
Change pending to running status on build submission

### DIFF
--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -419,7 +419,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         """
         return self.package_config.jobs.index(self.job_config)
 
-    def report_pending_build_and_test_on_build_submission(self, web_url: str):
+    def report_running_build_and_test_on_build_submission(self, web_url: str):
         """
         Report the first pending status for build/test job considering the
         issue in GitLab where we cannot overwrite the pending status
@@ -440,12 +440,12 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
 
         self.report_status_to_build(
             description=description,
-            state=BaseCommitStatus.pending,
+            state=BaseCommitStatus.running,
             url=url_for_build,
         )
         self.report_status_to_all_test_jobs(
             description=description,
-            state=BaseCommitStatus.pending,
+            state=BaseCommitStatus.running,
             url=url_for_tests,
         )
 
@@ -479,7 +479,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             self._srpm_model.set_copr_build_id(str(build_id))
             self._srpm_model.set_copr_web_url(web_url)
 
-        self.report_pending_build_and_test_on_build_submission(web_url)
+        self.report_running_build_and_test_on_build_submission(web_url)
         self.handle_rpm_build_start(group, build_id, web_url)
 
         return TaskResults(success=True, details={})

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -460,31 +460,31 @@ def test_report_pending_build_and_test_on_build_submission(
     if generic_statuses:
         flexmock(CoprBuildJobHelper).should_receive("report_status_to_build").with_args(
             description="Job is in progress...",
-            state=BaseCommitStatus.pending,
+            state=BaseCommitStatus.running,
             url=web_url,
         ).once()
         flexmock(CoprBuildJobHelper).should_receive(
             "report_status_to_all_test_jobs"
         ).with_args(
             description="Job is in progress...",
-            state=BaseCommitStatus.pending,
+            state=BaseCommitStatus.running,
             url=DASHBOARD_JOBS_TESTING_FARM_PATH,
         ).once()
     else:
         flexmock(CoprBuildJobHelper).should_receive("report_status_to_build").with_args(
             description="SRPM build in Copr was submitted...",
-            state=BaseCommitStatus.pending,
+            state=BaseCommitStatus.running,
             url="/results/srpm-builds/1",
         ).once()
         flexmock(CoprBuildJobHelper).should_receive(
             "report_status_to_all_test_jobs"
         ).with_args(
             description="SRPM build in Copr was submitted...",
-            state=BaseCommitStatus.pending,
+            state=BaseCommitStatus.running,
             url="/results/srpm-builds/1",
         ).once()
 
-    helper.report_pending_build_and_test_on_build_submission("copr-url")
+    helper.report_running_build_and_test_on_build_submission("copr-url")
 
 
 def test_get_latest_fedora_stable_chroot(github_pr_event):


### PR DESCRIPTION
To differentiate "Task was accepted" state (=> we have not started the handling of the task) and state when we actually started the processing.


Related to #1914 

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
