### PR TITLE
Monorepo refactoring 

### DIFF
--- a/packit_service/worker/allowlist.py
+++ b/packit_service/worker/allowlist.py
@@ -302,7 +302,9 @@ class Allowlist:
 
                 job_helper = job_helper_kls(
                     service_config=self.service_config,
-                    package_config=event.get_package_config(),
+                    package_config=event.get_packages_config().get_package_config_for(
+                        job_config
+                    ),
                     project=project,
                     metadata=EventData.from_event_dict(event.get_dict()),
                     db_trigger=event.db_trigger,

--- a/packit_service/worker/events/github.py
+++ b/packit_service/worker/events/github.py
@@ -391,7 +391,7 @@ class InstallationEvent(Event):
         return result
 
     @property
-    def package_config(self):
+    def packages_config(self):
         return None
 
     @property

--- a/packit_service/worker/events/new_hotness.py
+++ b/packit_service/worker/events/new_hotness.py
@@ -70,13 +70,13 @@ class NewHotnessUpdateEvent(Event):
         )
 
     @property
-    def package_config(self):
+    def packages_config(self):
         if not self._package_config_searched and not self._package_config:
-            self._package_config = self.get_package_config()
+            self._package_config = self.get_packages_config()
             self._package_config_searched = True
         return self._package_config
 
-    def get_package_config(self) -> Optional[PackageConfig]:
+    def get_packages_config(self) -> Optional[PackageConfig]:
         logger.debug(f"Getting package_config:\n" f"\tproject: {self.project}\n")
 
         package_config = PackageConfigGetter.get_package_config_from_repo(
@@ -91,7 +91,9 @@ class NewHotnessUpdateEvent(Event):
 
     @property
     def project_url(self) -> Optional[str]:
-        return self.package_config.upstream_project_url if self.package_config else None
+        return (
+            self.packages_config.upstream_project_url if self.packages_config else None
+        )
 
     @property
     def repo_url(self) -> Optional[RepoUrl]:
@@ -109,10 +111,10 @@ class NewHotnessUpdateEvent(Event):
 
     @property
     def tag_name(self):
-        if not (self.package_config and self.package_config.upstream_tag_template):
+        if not (self.packages_config and self.packages_config.upstream_tag_template):
             return self.version
 
-        return self.package_config.upstream_tag_template.format(version=self.version)
+        return self.packages_config.upstream_tag_template.format(version=self.version)
 
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
         d = self.__dict__

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -362,7 +362,11 @@ class JobHandler(Handler):
         return signature(
             cls.task_name.value,
             kwargs={
-                "package_config": dump_package_config(event.package_config),
+                "package_config": dump_package_config(
+                    event.packages_config.get_package_config_for(job)
+                    if event.packages_config
+                    else None
+                ),
                 "job_config": dump_job_config(job),
                 "event": event.get_dict(),
             },

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -218,7 +218,11 @@ class SteveJobs:
         """
         params = {
             "service_config": self.service_config,
-            "package_config": self.event.package_config,
+            "package_config": self.event.packages_config.get_package_config_for(
+                job_config
+            )
+            if self.event.packages_config
+            else None,
             "project": self.event.project,
             "metadata": EventData.from_event_dict(self.event.get_dict()),
             "db_trigger": self.event.db_trigger,
@@ -344,7 +348,7 @@ class SteveJobs:
             if not dist_git_package_config:
                 self.event.fail_when_config_file_missing = True
 
-        if not self.event.package_config:
+        if not self.event.packages_config:
             # this happens when service receives events for repos which don't have packit config
             # success=True - it's not an error that people don't have packit.yaml in their repo
             return False
@@ -465,7 +469,9 @@ class SteveJobs:
             return False
 
         if not handler_kls.pre_check(
-            package_config=self.event.package_config,
+            package_config=self.event.packages_config.get_package_config_for(job_config)
+            if self.event.packages_config
+            else None,
             job_config=job_config,
             event=self.event.get_dict(),
         ):
@@ -530,7 +536,7 @@ class SteveJobs:
         """
         matching_jobs = []
         if isinstance(self.event, PullRequestCommentPagureEvent):
-            for job in self.event.package_config.get_job_views():
+            for job in self.event.packages_config.get_job_views():
                 if (
                     job.type in [JobType.koji_build, JobType.bodhi_update]
                     and job.trigger == JobConfigTriggerType.commit
@@ -541,7 +547,7 @@ class SteveJobs:
                     # can be re-triggered by a Pagure comment in a PR
                     matching_jobs.append(job)
         elif isinstance(self.event, AbstractIssueCommentEvent):
-            for job in self.event.package_config.get_job_views():
+            for job in self.event.packages_config.get_job_views():
                 if (
                     job.type in (JobType.koji_build, JobType.bodhi_update)
                     and job.trigger == JobConfigTriggerType.commit
@@ -561,7 +567,7 @@ class SteveJobs:
         Get list of non-duplicated all jobs that matches with event's trigger.
         """
         jobs_matching_trigger = []
-        for job in self.event.package_config.get_job_views():
+        for job in self.event.packages_config.get_job_views():
             if (
                 job.trigger == self.event.job_config_trigger_type
                 and (

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -530,7 +530,7 @@ class SteveJobs:
         """
         matching_jobs = []
         if isinstance(self.event, PullRequestCommentPagureEvent):
-            for job in self.event.package_config.jobs:
+            for job in self.event.package_config.get_job_views():
                 if (
                     job.type in [JobType.koji_build, JobType.bodhi_update]
                     and job.trigger == JobConfigTriggerType.commit
@@ -541,7 +541,7 @@ class SteveJobs:
                     # can be re-triggered by a Pagure comment in a PR
                     matching_jobs.append(job)
         elif isinstance(self.event, AbstractIssueCommentEvent):
-            for job in self.event.package_config.jobs:
+            for job in self.event.package_config.get_job_views():
                 if (
                     job.type in (JobType.koji_build, JobType.bodhi_update)
                     and job.trigger == JobConfigTriggerType.commit
@@ -561,7 +561,7 @@ class SteveJobs:
         Get list of non-duplicated all jobs that matches with event's trigger.
         """
         jobs_matching_trigger = []
-        for job in self.event.package_config.jobs:
+        for job in self.event.package_config.get_job_views():
             if (
                 job.trigger == self.event.job_config_trigger_type
                 and (

--- a/packit_service/worker/result.py
+++ b/packit_service/worker/result.py
@@ -32,10 +32,15 @@ class TaskResults(dict):
     def create_from(
         cls, success: bool, msg: str, event: Event, job_config: JobConfig = None
     ):
+        package_config = (
+            event.packages_config.get_package_config_for(job_config)
+            if event.packages_config
+            else None
+        )
         details = {
             "msg": msg,
             "event": event.get_dict(),
-            "package_config": dump_package_config(event.package_config),
+            "package_config": dump_package_config(package_config),
         }
 
         details.update(

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -157,7 +157,7 @@ def test_check_copr_build_updated(build_status, build_ended_on):
             .mock(),
         )
     )
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         PackageConfig(
             jobs=[
                 JobConfig(
@@ -241,7 +241,7 @@ def test_check_copr_build_waiting_started():
             .mock(),
         )
     )
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         PackageConfig(
             jobs=[
                 JobConfig(
@@ -325,7 +325,7 @@ def test_check_copr_build_waiting_already_started():
             .mock(),
         )
     )
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         PackageConfig(
             jobs=[
                 JobConfig(
@@ -486,7 +486,7 @@ def test_check_pending_testing_farm_runs(created):
             ok=lambda: True,
         )
     ).once()
-    flexmock(TestingFarmResultsEvent).should_receive("get_package_config").and_return(
+    flexmock(TestingFarmResultsEvent).should_receive("get_packages_config").and_return(
         PackageConfig(
             jobs=[
                 JobConfig(
@@ -568,7 +568,7 @@ def test_check_pending_testing_farm_runs_identifiers(identifier):
             ok=lambda: True,
         )
     ).once()
-    flexmock(TestingFarmResultsEvent).should_receive("get_package_config").and_return(
+    flexmock(TestingFarmResultsEvent).should_receive("get_packages_config").and_return(
         PackageConfig(
             jobs=[
                 JobConfig(

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -293,7 +293,7 @@ def test_copr_build_end(
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     pc_build_pr.jobs[0].notifications.pull_request.successful_build = pc_comment_pr_succ
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         pc_build_pr
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -379,7 +379,7 @@ def test_copr_build_end_push(
         .should_receive("comment")
         .never()
     )
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         pc_build_push
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -451,7 +451,7 @@ def test_copr_build_end_release(
         .never()
         .mock()
     )
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         pc_build_release
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -561,7 +561,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         ],
     )
 
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         config
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -837,7 +837,7 @@ def test_copr_build_end_report_multiple_testing_farm_jobs(
         ],
     )
 
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         config
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -978,7 +978,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         ],
     )
 
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         config
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -1162,7 +1162,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         ],
     )
 
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         config
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -1307,7 +1307,7 @@ def test_copr_build_start(copr_build_start, pc_build_pr, copr_build_pr):
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         pc_build_pr
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -1360,7 +1360,7 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build_pr
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock())
     )
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         pc_tests
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -1424,7 +1424,7 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_bui
     flexmock(GithubProject).should_receive("get_pr").and_return(
         flexmock(source_project=flexmock()).should_receive("comment").never()
     )
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         pc_build_pr
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -1487,7 +1487,7 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_bui
 def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build_pr):
     koji_build_pr.target = "rawhide"
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(KojiTaskEvent).should_receive("get_package_config").and_return(
+    flexmock(KojiTaskEvent).should_receive("get_packages_config").and_return(
         pc_koji_build_pr
     )
 
@@ -1551,7 +1551,7 @@ def test_koji_build_start_build_not_found(koji_build_scratch_start):
 def test_koji_build_end(koji_build_scratch_end, pc_koji_build_pr, koji_build_pr):
     koji_build_pr.target = "rawhide"
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(KojiTaskEvent).should_receive("get_package_config").and_return(
+    flexmock(KojiTaskEvent).should_receive("get_packages_config").and_return(
         pc_koji_build_pr
     )
 
@@ -1600,7 +1600,7 @@ def test_srpm_build_end(srpm_build_end, pc_build_pr, srpm_build_model):
     pr = flexmock(source_project=flexmock())
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         pc_build_pr
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -1667,7 +1667,7 @@ def test_srpm_build_end_failure(srpm_build_end, pc_build_pr, srpm_build_model):
     pr = flexmock(source_project=flexmock())
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         pc_build_pr
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -1729,7 +1729,7 @@ def test_srpm_build_start(srpm_build_start, pc_build_pr, srpm_build_model):
     pr = flexmock(source_project=flexmock())
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         pc_build_pr
     )
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -486,10 +486,8 @@ def test_check_and_report(
             },
         )
     ]
-    flexmock(PullRequestGithubEvent).should_receive("get_package_config").and_return(
-        flexmock(
-            jobs=job_configs,
-        )
+    flexmock(PullRequestGithubEvent).should_receive("get_packages_config").and_return(
+        flexmock(jobs=job_configs, get_package_config_for=lambda job_config: flexmock())
     )
     flexmock(PullRequestModel).should_receive("get_or_create").and_return(
         flexmock(

--- a/tests/unit/test_babysit_vm_image.py
+++ b/tests/unit/test_babysit_vm_image.py
@@ -109,14 +109,15 @@ def test_update_vm_image_build(stop_babysitting, build_status, vm_image_builder_
             )
             .mock()
         )
-    flexmock(VMImageBuildResultEvent).should_receive("get_package_config").and_return(
+    flexmock(VMImageBuildResultEvent).should_receive("get_packages_config").and_return(
         flexmock(
-            jobs=[
+            get_package_config_for=lambda job_config: flexmock(),
+            get_job_views=lambda: [
                 flexmock(
                     trigger=JobConfigTriggerType.pull_request,
                     type=JobType.vm_image_build,
                 )
-            ]
+            ],
         )
     )
     flexmock(VMImageBuildResultEvent).should_receive(

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -359,9 +359,9 @@ class TestEvents:
             reference="1f6a716aa7a618a9ffe56970d77177d99d100022",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_mr_action(self, merge_request_update):
         event_object = Parser.parse_event(merge_request_update)
@@ -384,9 +384,9 @@ class TestEvents:
             reference="45e272a57335e4e308f3176df6e9226a9e7805a9",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_mr_closed(self, merge_request_closed):
         event_object = Parser.parse_event(merge_request_closed)
@@ -422,9 +422,9 @@ class TestEvents:
             reference="528b803be6f93e19ca4130bf4976f2800a3004c4",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_pr_comment_created(self, github_pr_comment_created):
         event_object = Parser.parse_event(github_pr_comment_created)
@@ -461,9 +461,9 @@ class TestEvents:
             reference="12345",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_mr_comment(self, gitlab_mr_comment):
         event_object = Parser.parse_event(gitlab_mr_comment)
@@ -497,9 +497,9 @@ class TestEvents:
             reference="45e272a57335e4e308f3176df6e9226a9e7805a9",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_pr_comment_empty(self, github_pr_comment_empty):
         event_object = Parser.parse_event(github_pr_comment_empty)
@@ -536,10 +536,10 @@ class TestEvents:
             reference="12345",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_issue_comment(self, github_issue_comment_propose_downstream):
         event_object = Parser.parse_event(github_issue_comment_propose_downstream)
@@ -575,9 +575,9 @@ class TestEvents:
             reference="123456",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_issue_comment_no_handler(self, github_issue_comment_no_handler):
         event_object = Parser.parse_event(github_issue_comment_no_handler)
@@ -600,9 +600,9 @@ class TestEvents:
             reference=None,
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
         assert event_object.commit_sha is None
         assert event_object.tag_name == ""
 
@@ -637,9 +637,9 @@ class TestEvents:
             reference="123456",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_github_push(self, github_push_branch):
         event_object = Parser.parse_event(github_push_branch)
@@ -666,9 +666,9 @@ class TestEvents:
             reference="04885ff850b0fa0e206cd09db73565703d48f99b",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_gitlab_push(self, gitlab_push):
         event_object = Parser.parse_event(gitlab_push)
@@ -695,9 +695,9 @@ class TestEvents:
             reference="cb2859505e101785097e082529dced35bbee0c8f",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_gitlab_push_many_commits(self, gitlab_push_many_commits):
         event_object = Parser.parse_event(gitlab_push_many_commits)
@@ -727,9 +727,9 @@ class TestEvents:
             reference="15af92227f9e965b392e85ba2f08a41a5aeb278a",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_github_push_branch(self, github_push_branch):
         event_object = Parser.parse_event(github_push_branch)
@@ -756,10 +756,10 @@ class TestEvents:
             reference="04885ff850b0fa0e206cd09db73565703d48f99b",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_gitlab_pipeline(self, gitlab_mr_pipeline):
         event_object = Parser.parse_event(gitlab_mr_pipeline)
@@ -800,9 +800,9 @@ class TestEvents:
             reference="ee58e259da263ecb4c1f0129be7aef8cfd4dedd6",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_pagure_flag(self, pagure_pr_flag_updated):
         event_object = Parser.parse_event(pagure_pr_flag_updated)
@@ -862,12 +862,12 @@ class TestEvents:
             reference="beaf90bcecc51968a46663f8d6f092bfdc92e682",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
         flexmock(PagureProject).should_receive("get_web_url").and_return(
             "https://src.fedoraproject.org/rpms/python-teamcity-messages"
         )
-        assert event_object.package_config
+        assert event_object.packages_config
 
     @pytest.mark.parametrize("identifier", [None, "foo"])
     def test_parse_testing_farm_notification(
@@ -985,10 +985,10 @@ class TestEvents:
             reference="0011223344",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_copr_build_event_end(self, copr_build_results_end, copr_build_pr):
         flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
@@ -1028,10 +1028,10 @@ class TestEvents:
             reference="0011223344",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_koji_build_scratch_event_start(
         self, koji_build_scratch_start, koji_build_pr
@@ -1106,7 +1106,7 @@ class TestEvents:
             path=".packit.yaml", ref="0eb3e12005cb18f15d3054020f7ac934c01eae08"
         ).and_return(packit_yaml)
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_koji_build_event_start_rawhide(
         self, koji_build_start_rawhide, mock_config
@@ -1146,7 +1146,7 @@ class TestEvents:
             path=".packit.yaml", ref="e029dd5250dde9a37a2cdddb6d822d973b09e5da"
         ).and_return(packit_yaml)
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_koji_build_event_start_f36(self, koji_build_start_f36, mock_config):
         event_object = Parser.parse_event(koji_build_start_f36)
@@ -1184,7 +1184,7 @@ class TestEvents:
             path=".packit.yaml", ref="51b57ec04f5e6e9066ac859a1408cfbf1ead307e"
         ).and_return(packit_yaml)
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_koji_build_event_start_epel8(
         self, koji_build_start_epel8, mock_config
@@ -1223,7 +1223,7 @@ class TestEvents:
             path=".packit.yaml", ref="23806a208e32cc937f3a6eb151c62cbbc10d8f96"
         ).and_return(packit_yaml)
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_koji_build_event_completed_old_format(
         self, koji_build_completed_old_format, mock_config
@@ -1261,7 +1261,7 @@ class TestEvents:
             path=".packit.yaml", ref="0eb3e12005cb18f15d3054020f7ac934c01eae08"
         ).and_return(packit_yaml)
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_koji_build_event_completed_rawhide(
         self, koji_build_completed_rawhide, mock_config
@@ -1301,7 +1301,7 @@ class TestEvents:
             path=".packit.yaml", ref="e029dd5250dde9a37a2cdddb6d822d973b09e5da"
         ).and_return(packit_yaml)
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_koji_build_event_completed_f36(
         self, koji_build_completed_f36, mock_config
@@ -1341,7 +1341,7 @@ class TestEvents:
             path=".packit.yaml", ref="51b57ec04f5e6e9066ac859a1408cfbf1ead307e"
         ).and_return(packit_yaml)
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_parse_koji_build_event_completed_epel8(
         self, koji_build_completed_epel8, mock_config
@@ -1381,7 +1381,7 @@ class TestEvents:
             path=".packit.yaml", ref="23806a208e32cc937f3a6eb151c62cbbc10d8f96"
         ).and_return(packit_yaml)
 
-        assert event_object.package_config
+        assert event_object.packages_config
 
     def test_get_project_pr(self, github_pr_webhook, mock_config):
         event_object = Parser.parse_event(github_pr_webhook)
@@ -1486,9 +1486,9 @@ class TestEvents:
             reference="0e5d8b51fd5dfa460605e1497d22a76d65c6d7fd",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
         assert event_object.build_targets_override is None
         assert event_object.tests_targets_override == {"fedora-rawhide-x86_64"}
         assert event_object.actor == "lbarcziova"
@@ -1527,9 +1527,9 @@ class TestEvents:
             reference="0e5d8b51fd5dfa460605e1497d22a76d65c6d7fd",
             fail_when_missing=False,
         ).and_return(
-            flexmock()
+            flexmock(get_package_config_views=lambda: {})
         ).once()
-        assert event_object.package_config
+        assert event_object.packages_config
         assert event_object.build_targets_override is None
         assert event_object.tests_targets_override == {"fedora-rawhide-x86_64"}
 
@@ -1627,6 +1627,7 @@ class TestEvents:
             flexmock(
                 upstream_project_url=upstream_project_url,
                 upstream_tag_template=upstream_tag_template,
+                get_packages_config=lambda: flexmock(),
             )
         ).once()
 
@@ -1648,7 +1649,7 @@ class TestEvents:
             == "https://src.fedoraproject.org/rpms/redis"
         )
         assert event_object.tag_name == tag_name
-        assert event_object.package_config
+        assert event_object.packages_config
 
         if create_db_trigger:
             assert event_object.db_trigger

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -3,11 +3,19 @@
 
 from typing import Type
 
+import copy
 import celery
 import pytest
 from flexmock import flexmock
 
-from packit.config import CommonPackageConfig, JobConfig, JobConfigTriggerType, JobType
+from packit.config import (
+    CommonPackageConfig,
+    JobConfig,
+    JobConfigTriggerType,
+    JobType,
+    PackageConfig,
+)
+
 from packit_service.config import ServiceConfig
 from packit_service.constants import COMMENT_REACTION
 from packit_service.worker.events import (
@@ -3124,3 +3132,106 @@ def test_create_tasks_tf_identifier(
         tasks_created * [None]
     ).and_return(flexmock().should_receive("apply_async").mock())
     assert tasks_created == len(SteveJobs(event).create_tasks(jobs, handler_kls))
+
+
+def test_monorepo_jobs_matching_event():
+    python_teamcity_messages = CommonPackageConfig(
+        patch_generation_ignore_paths=[],
+        specfile_path="python-teamcity-messages.spec",
+        upstream_ref=None,
+        files_to_sync=[
+            {
+                "dest": "python-teamcity-messages.spec",
+                "mkpath": False,
+                "filters": [],
+                "delete": False,
+                "src": ["python-teamcity-messages.spec"],
+            },
+            {
+                "dest": ".packit.yaml",
+                "mkpath": False,
+                "filters": [],
+                "delete": False,
+                "src": [".packit.yaml"],
+            },
+        ],
+        paths=["."],
+        dist_git_base_url="https://src.fedoraproject.org/",
+        upstream_package_name="teamcity-messages",
+        archive_root_dir_template="{upstream_pkg_name}-{version}",
+        upstream_project_url="https://github.com/majamassarini/teamcity-messages",
+        config_file_path=".packit.yaml",
+        patch_generation_patch_id_digits=4,
+        dist_git_namespace="rpms",
+        downstream_package_name="python-teamcity-messages",
+        upstream_tag_template="v{version}",
+    )
+    python_teamcity_messages_double = copy.deepcopy(python_teamcity_messages)
+    python_teamcity_messages_double.downstream_package_name = "a double"
+
+    packages = {
+        "python-teamcity-messages": copy.deepcopy(python_teamcity_messages),
+        "python-teamcity-messages-double": python_teamcity_messages_double,
+    }
+    jobs = [
+        JobConfig(
+            type=JobType.propose_downstream,
+            trigger=JobConfigTriggerType.release,
+            skip_build=False,
+            packages={
+                "python-teamcity-messages": python_teamcity_messages,
+                "python-teamcity-messages-double": python_teamcity_messages_double,
+            },
+        ),
+        JobConfig(
+            type=JobType.propose_downstream,
+            trigger=JobConfigTriggerType.release,
+            skip_build=False,
+            packages={
+                "python-teamcity-messages": python_teamcity_messages,
+            },
+        ),
+        JobConfig(
+            type=JobType.propose_downstream,
+            trigger=JobConfigTriggerType.release,
+            skip_build=False,
+            packages={
+                "python-teamcity-messages-double": python_teamcity_messages_double
+            },
+        ),
+    ]
+    packages_config = PackageConfig(packages=packages, jobs=jobs)
+
+    class Event(ReleaseEvent):
+        def __init__(self):
+            self._package_config_searched = None
+            self._package_config = packages_config
+            self._project = flexmock()
+            self._base_project = flexmock()
+            self._pr_id = flexmock()
+            self._commit_sha = flexmock()
+            self.fail_when_config_file_missing = True
+
+        @property
+        def job_config_trigger_type(self):
+            return JobConfigTriggerType.release
+
+    event = Event()
+    steve = SteveJobs(event)
+    handlers = steve.get_handlers_for_event()
+    assert handlers
+
+    for handler in handlers:
+        job_configs = steve.get_config_for_handler_kls(handler)
+        assert job_configs
+
+        original_ref = 0
+        double_ref = 0
+        for job_config in job_configs:
+            if job_config.downstream_package_name == "a double":
+                double_ref += 1
+            else:
+                original_ref += 1
+
+        assert original_ref == 2
+        assert double_ref == 2

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -948,8 +948,8 @@ def test_get_handlers_for_event(event_cls, db_trigger, jobs, result):
             return db_trigger
 
         @property
-        def package_config(self):
-            return flexmock(jobs=jobs)
+        def packages_config(self):
+            return flexmock(get_job_views=lambda: jobs)
 
     event = Event()
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(
@@ -1180,8 +1180,8 @@ def test_get_handlers_for_comment_event(
             return db_trigger
 
         @property
-        def package_config(self):
-            return flexmock(jobs=jobs)
+        def packages_config(self):
+            return flexmock(get_job_views=lambda: jobs)
 
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(
         ServiceConfig(comment_command_prefix=packit_comment_command_prefix)
@@ -1381,8 +1381,8 @@ def test_get_handlers_for_check_rerun_event(
             return db_trigger
 
         @property
-        def package_config(self):
-            return flexmock(jobs=jobs)
+        def packages_config(self):
+            return flexmock(get_job_views=lambda: jobs)
 
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(
         ServiceConfig(packit_comment_command_prefix="/packit")
@@ -2611,8 +2611,8 @@ def test_get_config_for_handler_kls(
             return db_trigger
 
         @property
-        def package_config(self):
-            return flexmock(jobs=jobs)
+        def packages_config(self):
+            return flexmock(get_job_views=lambda: jobs)
 
     event = Event()
 
@@ -3045,8 +3045,8 @@ def test_get_jobs_matching_trigger(
             return job_config_trigger_type
 
         @property
-        def package_config(self):
-            return flexmock(jobs=jobs)
+        def packages_config(self):
+            return flexmock(get_job_views=lambda: jobs)
 
     event = Event(**kwargs)
     assert result == SteveJobs(event).get_jobs_matching_event()
@@ -3109,8 +3109,10 @@ def test_create_tasks_tf_identifier(
             self._db_trigger = None
 
         @property
-        def package_config(self):
-            return flexmock(jobs=jobs)
+        def packages_config(self):
+            return flexmock(
+                jobs=jobs, get_package_config_for=lambda job_config: flexmock()
+            )
 
         def get_dict(self, *args, **kwargs):
             return {"identifier": identifier}

--- a/tests_openshift/database/test_tasks.py
+++ b/tests_openshift/database/test_tasks.py
@@ -93,7 +93,7 @@ def test_check_copr_build(clean_before_and_after, packit_build_752):
             }
         )
     )
-    flexmock(AbstractCoprBuildEvent).should_receive("get_package_config").and_return(
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
         PackageConfig(
             packages={"packit": CommonPackageConfig()},
             jobs=[


### PR DESCRIPTION
Fixes packit/packit-service#1897

Merge after packit/packit#1864

Merge before packit/hardly#93

---

RELEASE NOTES BEGIN
Now `packit-service` supports multi packages configuration (aka monorepo config). 
RELEASE NOTES END
