### PR TITLE
Increase the SLO1 threshold to 25 seconds

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -736,8 +736,9 @@ class SteveJobs:
                 f"Reporting first initial status check time: {response_time} seconds."
             )
             pushgateway.first_initial_status_time.observe(response_time)
+            if response_time > 25:
+                pushgateway.no_status_after_25_s.inc()
             if response_time > 15:
-                pushgateway.no_status_after_15_s.inc()
                 # https://github.com/packit/packit-service/issues/1728
                 # we need more info why this has happened
                 logger.debug(f"Event dict: {self.event}.")

--- a/packit_service/worker/monitoring.py
+++ b/packit_service/worker/monitoring.py
@@ -56,9 +56,9 @@ class Pushgateway:
             registry=self.registry,
         )
 
-        self.no_status_after_15_s = Counter(
-            "no_status_after_15_s",
-            "Number of PRs/commits with no commit status for more than 15s",
+        self.no_status_after_25_s = Counter(
+            "no_status_after_25_s",
+            "Number of PRs/commits with no commit status for more than 25s",
             registry=self.registry,
         )
 


### PR DESCRIPTION
Keep logging tasks that took more than 15 seconds.