### PR TITLE
Propagate exception message to propose_downstream logs

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -325,6 +325,8 @@ class AbstractSyncReleaseHandler(
             raise
         except Exception as ex:
             logger.debug(f"{self.sync_release_job_type} failed: {ex}")
+            # make sure exception message is propagated to the logs
+            logging.getLogger("packit").error(str(ex))
             # eat the exception and continue with the execution
             self.sync_release_helper.report_status_for_branch(
                 branch=branch,


### PR DESCRIPTION
There is another case of failed `propose_downstream` with no error message in the logs:
https://dashboard.packit.dev/results/propose-downstream/2152

This ensures that any exception raised during `sync_release()` is logged.

Fixes #1953.

I'm not sure if I should also revert https://github.com/packit/packit/commit/1ed4f97292ccf316db037b8cc795c8e8efb3a5fe (to prevent the error from being logged twice).