### PR TITLE
Require copr build job definition for tests

### DIFF
--- a/packit_service/worker/checker/testing_farm.py
+++ b/packit_service/worker/checker/testing_farm.py
@@ -97,3 +97,28 @@ class CanActorRunJob(ActorChecker, GetTestingFarmJobHelperMixin):
             )
             return False
         return True
+
+
+class IsCoprBuildDefined(Checker, GetTestingFarmJobHelperMixin):
+    """
+    If the test job doesn't have enabled skip_build option, check whether
+    there is matching build job present and report if there is no.
+    """
+
+    def pre_check(self) -> bool:
+        if (
+            not self.testing_farm_job_helper.skip_build
+            and not self.testing_farm_job_helper.job_build
+        ):
+            logger.info(
+                "Build required and no build job found in the configuration, "
+                "reporting and skipping."
+            )
+            self.testing_farm_job_helper.report_status_to_tests(
+                description="Test job requires build job definition in the configuration.",
+                state=BaseCommitStatus.neutral,
+                url="",
+            )
+            return False
+
+        return True

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -82,37 +82,6 @@ def configured_as(job_type: JobType):
     return _add_to_mapping
 
 
-def required_for(job_type: JobType):
-    """
-    [class decorator]
-    Specify a job_type for which this handler is the prerequisite.
-    E.g. for test, we need to run build first.
-
-    If there is a matching job_type defined by @configured_as,
-    we don't use the decorated handler with the job-config using this job_type.
-    If there is none, we use the job-config with this job_type.
-
-    Example:
-        - When there is a build and test defined, we run build only once
-          with the build job-config.
-        - When there is only test defined,
-          we run build with the test job-configuration.
-
-    ```
-    @configured_as(job_type=JobType.copr_build)
-    @configured_as(job_type=JobType.build)
-    @required_for(job_type=JobType.tests)
-    class CoprBuildHandler(JobHandler):
-    ```
-    """
-
-    def _add_to_mapping(kls: Type["JobHandler"]):
-        MAP_REQUIRED_JOB_TYPE_TO_HANDLER[job_type].add(kls)
-        return kls
-
-    return _add_to_mapping
-
-
 def reacts_to(event: Type["Event"]):
     """
     [class decorator]

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -56,7 +56,6 @@ from packit_service.worker.handlers.abstract import (
     TaskName,
     configured_as,
     reacts_to,
-    required_for,
     run_for_comment,
     run_for_check_rerun,
     RetriableJobHandler,
@@ -135,7 +134,6 @@ class AbstractCoprBuildReportHandler(
 
 @configured_as(job_type=JobType.copr_build)
 @configured_as(job_type=JobType.build)
-@required_for(job_type=JobType.tests)
 @reacts_to(event=CoprBuildStartEvent)
 class CoprBuildStartHandler(AbstractCoprBuildReportHandler):
     topic = "org.fedoraproject.prod.copr.build.start"
@@ -206,7 +204,6 @@ class CoprBuildStartHandler(AbstractCoprBuildReportHandler):
 
 @configured_as(job_type=JobType.copr_build)
 @configured_as(job_type=JobType.build)
-@required_for(job_type=JobType.tests)
 @reacts_to(event=CoprBuildEndEvent)
 class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
     topic = "org.fedoraproject.prod.copr.build.end"

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -33,6 +33,7 @@ from packit_service.worker.checker.testing_farm import (
     IsEventForJob,
     IsEventOk,
     IsJobConfigTriggerMatching,
+    IsCoprBuildDefined,
 )
 from packit_service.worker.events import (
     TestingFarmResultsEvent,
@@ -119,6 +120,7 @@ class TestingFarmHandler(
         return (
             IsJobConfigTriggerMatching,
             IsEventOk,
+            IsCoprBuildDefined,
             CanActorRunJob,
         )
 
@@ -301,11 +303,8 @@ class TestingFarmHandler(
             if self.testing_farm_job_helper.job_build:
                 msg = "Build required, already handled by build job."
             else:
-                msg = "Build required, CoprBuildHandler task sent."
-                self.run_copr_build_handler(
-                    self.data.get_dict(),
-                    len(self.testing_farm_job_helper.build_targets),
-                )
+                # this should not happen as there is the IsCoprBuildDefined pre-check
+                msg = "Build required, no build job defined in config."
             logger.info(msg)
             return TaskResults(
                 success=True,

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -230,7 +230,12 @@ def mock_release_functionality(request):
                     "trigger": "pull_request",
                     "job": "tests",
                     "metadata": {"targets": "fedora-all"},
-                }
+                },
+                {
+                    "trigger": "pull_request",
+                    "job": "copr_build",
+                    "metadata": {"targets": "fedora-all"},
+                },
             ]
         ]
     ),
@@ -436,7 +441,15 @@ def test_check_rerun_pr_koji_build_handler_old_job_name(
                     "targets": [
                         "fedora-all",
                     ],
-                }
+                },
+                {
+                    "trigger": "commit",
+                    "job": "copr_build",
+                    "branch": "main",
+                    "targets": [
+                        "fedora-all",
+                    ],
+                },
             ]
         ]
     ),

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -177,7 +177,7 @@ def one_job_finished_with_msg(results: List[TaskResults], msg: str):
                     "trigger": "pull_request",
                     "job": "tests",
                     "metadata": {"targets": "fedora-rawhide-x86_64"},
-                }
+                },
             ]
         ]
     ),
@@ -197,15 +197,11 @@ def test_pr_comment_build_test_handler(
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(set())
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
-        description=TASK_ACCEPTED,
-        state=BaseCommitStatus.pending,
+        description="Test job requires build job definition in the configuration.",
+        state=BaseCommitStatus.neutral,
         url="",
-        markdown_content=None,
-        links_to_external_services=None,
-        update_feedback_time=object,
     ).once()
-    flexmock(Signature).should_receive("apply_async").twice()
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Signature).should_receive("apply_async").never()
     pr = flexmock(head_commit="12345")
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
@@ -213,20 +209,7 @@ def test_pr_comment_build_test_handler(
     flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
 
     processing_results = SteveJobs().process_message(pr_build_comment_event)
-    event_dict, job, job_config, package_config = get_parameters_from_results(
-        processing_results
-    )
-    assert json.dumps(event_dict)
-    results = run_testing_farm_handler(
-        package_config=package_config,
-        event=event_dict,
-        job_config=job_config,
-    )
-    assert first_dict_value(results["job"])["success"]
-    assert (
-        "CoprBuildHandler task sent"
-        in first_dict_value(results["job"])["details"]["msg"]
-    )
+    assert len(processing_results) == 0
 
 
 @pytest.mark.parametrize(
@@ -535,7 +518,12 @@ def test_pr_test_command_handler(pr_embedded_command_comment_event):
             "trigger": "pull_request",
             "job": "tests",
             "metadata": {"targets": "fedora-rawhide-x86_64"},
-        }
+        },
+        {
+            "trigger": "pull_request",
+            "job": "copr_build",
+            "metadata": {"targets": "fedora-rawhide-x86_64"},
+        },
     ]
     packit_yaml = (
         "{'specfile_path': 'the-specfile.spec', 'synced_files': [], 'jobs': "
@@ -1541,112 +1529,6 @@ def test_pr_test_command_handler_composes_not_available(
     )
 
 
-def test_pr_test_command_handler_missing_build(pr_embedded_command_comment_event):
-    jobs = [
-        {
-            "trigger": "pull_request",
-            "job": "tests",
-            "metadata": {"targets": "fedora-rawhide-x86_64"},
-        }
-    ]
-    packit_yaml = (
-        "{'specfile_path': 'the-specfile.spec', 'synced_files': [], 'jobs': "
-        + str(jobs)
-        + "}"
-    )
-    pr = flexmock(head_commit="12345")
-    flexmock(GithubProject).should_receive("get_pr").and_return(pr)
-    comment = flexmock()
-    flexmock(pr).should_receive("get_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
-    flexmock(
-        GithubProject,
-        full_repo_name="packit-service/hello-world",
-        get_file_content=lambda path, ref: packit_yaml,
-        get_files=lambda ref, filter_regex: ["the-specfile.spec"],
-        get_web_url=lambda: "https://github.com/the-namespace/the-repo",
-    )
-    flexmock(Github, get_repo=lambda full_name_or_id: None)
-
-    trigger = flexmock(
-        job_config_trigger_type=JobConfigTriggerType.pull_request, id=123
-    )
-    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
-    flexmock(PullRequestModel).should_receive("get_by_id").with_args(123).and_return(
-        trigger
-    )
-    flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
-    flexmock(PullRequestModel).should_receive("get_or_create").with_args(
-        pr_id=9,
-        namespace="packit-service",
-        repo_name="hello-world",
-        project_url="https://github.com/packit-service/hello-world",
-    ).and_return(
-        flexmock(
-            id=9,
-            job_config_trigger_type=JobConfigTriggerType.pull_request,
-            job_trigger_model_type=JobTriggerModelType.pull_request,
-        )
-    )
-    flexmock(JobTriggerModel).should_receive("get_or_create").with_args(
-        type=JobTriggerModelType.pull_request, trigger_id=9
-    ).and_return(trigger)
-
-    pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
-    flexmock(
-        GithubProject, get_files=lambda ref, recursive: ["foo.spec", ".packit.yaml"]
-    )
-    flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(Signature).should_receive("apply_async").twice()
-    flexmock(CoprHelper).should_receive("get_valid_build_targets").and_return(
-        {"test-target", "test-target-without-build"}
-    )
-    run_model = flexmock(test_run_group=None)
-    test_run = flexmock(
-        id=1,
-        status=TestingFarmResult.new,
-        copr_builds=[flexmock(status=BuildStatus.success)],
-        target="test-target",
-    )
-    flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
-    flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
-        [run_model]
-    ).and_return(flexmock(grouped_targets=[test_run]))
-    flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
-        flexmock(
-            status=BuildStatus.success, group_of_targets=flexmock(runs=[run_model])
-        )
-    ).and_return()
-
-    flexmock(TestingFarmJobHelper).should_receive("job_owner").and_return("owner")
-    flexmock(TestingFarmJobHelper).should_receive("job_project").and_return("project")
-    flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").once()
-    flexmock(TestingFarmJobHelper).should_receive(
-        "report_status_to_tests_for_chroot"
-    ).once()
-    flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
-        TaskResults(success=False, details={})
-    )
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
-
-    processing_results = SteveJobs().process_message(pr_embedded_command_comment_event)
-    event_dict, job, job_config, package_config = get_parameters_from_results(
-        processing_results
-    )
-    assert json.dumps(event_dict)
-
-    flexmock(packit_service.worker.handlers.testing_farm).should_receive(
-        "dump_job_config"
-    ).with_args(job_config=load_job_config(job_config)).once()
-
-    run_testing_farm_handler(
-        package_config=package_config,
-        event=event_dict,
-        job_config=job_config,
-    )
-
-
 def test_pr_test_command_handler_missing_build_trigger_with_build_job_config(
     pr_embedded_command_comment_event,
 ):
@@ -1772,7 +1654,12 @@ def test_pr_test_command_handler_not_allowed_external_contributor_on_internal_TF
             "trigger": "pull_request",
             "job": "tests",
             "metadata": {"targets": "fedora-rawhide-x86_64", "use_internal_tf": True},
-        }
+        },
+        {
+            "trigger": "pull_request",
+            "job": "copr_build",
+            "metadata": {"targets": "fedora-rawhide-x86_64"},
+        },
     ]
     packit_yaml = (
         "{'specfile_path': 'the-specfile.spec', 'synced_files': [], 'jobs': "
@@ -1808,7 +1695,7 @@ def test_pr_test_command_handler_not_allowed_external_contributor_on_internal_TF
     ).and_return(
         flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
     ).times(
-        3
+        4
     )
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(
@@ -1818,10 +1705,11 @@ def test_pr_test_command_handler_not_allowed_external_contributor_on_internal_TF
     flexmock(Signature).should_receive("apply_async").times(0)
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").times(0)
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
-        description="phracek can't run tests internally",
+        description="phracek can't run tests (and builds) internally",
         state=BaseCommitStatus.neutral,
         markdown_content="*As a project maintainer, "
-        "you can trigger the test job manually via `/packit test` comment.*",
+        "you can trigger the build and test jobs manually via `/packit build`"
+        " comment or only test job via `/packit test` comment.*",
     ).once()
 
     processing_results = SteveJobs().process_message(pr_embedded_command_comment_event)
@@ -1877,7 +1765,7 @@ def test_pr_build_command_handler_not_allowed_external_contributor_on_internal_T
     ).and_return(
         flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
     ).times(
-        6
+        7
     )
     pr_embedded_command_comment_event["comment"]["body"] = "/packit build"
     flexmock(
@@ -1954,7 +1842,12 @@ def test_trigger_packit_command_without_config(
                     "trigger": "pull_request",
                     "job": "tests",
                     "metadata": {"targets": "fedora-rawhide-x86_64"},
-                }
+                },
+                {
+                    "trigger": "pull_request",
+                    "job": "copr_build",
+                    "metadata": {"targets": "fedora-rawhide-x86_64"},
+                },
             ]
         ]
     ),
@@ -2268,7 +2161,12 @@ def test_pr_test_command_handler_multiple_builds(pr_embedded_command_comment_eve
             "trigger": "pull_request",
             "job": "tests",
             "metadata": {"targets": ["fedora-rawhide-x86_64", "fedora-35-x86_64"]},
-        }
+        },
+        {
+            "trigger": "pull_request",
+            "job": "copr_build",
+            "metadata": {"targets": ["fedora-rawhide-x86_64", "fedora-35-x86_64"]},
+        },
     ]
     packit_yaml = (
         "{'specfile_path': 'the-specfile.spec', 'synced_files': [], 'jobs': "

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -199,33 +199,6 @@ from packit_service.worker.result import TaskResults
             {CoprBuildEndHandler},
             id="config=build_for_pr&pull_request&CoprBuildEndEvent",
         ),
-        # Copr results for test:
-        pytest.param(
-            CoprBuildStartEvent,
-            flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    packages={"package": CommonPackageConfig()},
-                ),
-            ],
-            {CoprBuildStartHandler},
-            id="config=build_for_pr&pull_request&CoprBuildStartEvent",
-        ),
-        pytest.param(
-            CoprBuildEndEvent,
-            flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    packages={"package": CommonPackageConfig()},
-                ),
-            ],
-            {CoprBuildEndHandler},
-            id="config=test_for_pr&pull_request&CoprBuildEndEvent",
-        ),
         # Test results:
         pytest.param(
             TestingFarmResultsEvent,
@@ -745,54 +718,6 @@ from packit_service.worker.result import TaskResults
             {CoprBuildHandler},
             id="config=test_for_pr+build_for_commit+build_for_release"
             "&commit&PushGitHubEvent",
-        ),
-        pytest.param(
-            CoprBuildStartEvent,
-            flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    packages={"package": CommonPackageConfig()},
-                ),
-                JobConfig(
-                    type=JobType.build,
-                    trigger=JobConfigTriggerType.commit,
-                    packages={"package": CommonPackageConfig()},
-                ),
-                JobConfig(
-                    type=JobType.build,
-                    trigger=JobConfigTriggerType.release,
-                    packages={"package": CommonPackageConfig()},
-                ),
-            ],
-            {CoprBuildStartHandler},
-            id="config=test_for_pr+build_for_commit+build_for_release"
-            "&pull_request&CoprBuildStartEvent",
-        ),
-        pytest.param(
-            CoprBuildEndEvent,
-            flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    packages={"package": CommonPackageConfig()},
-                ),
-                JobConfig(
-                    type=JobType.build,
-                    trigger=JobConfigTriggerType.commit,
-                    packages={"package": CommonPackageConfig()},
-                ),
-                JobConfig(
-                    type=JobType.build,
-                    trigger=JobConfigTriggerType.release,
-                    packages={"package": CommonPackageConfig()},
-                ),
-            ],
-            {CoprBuildEndHandler},
-            id="config=test_for_pr+build_for_commit+build_for_release"
-            "&pull_request&CoprBuildEndEvent",
         ),
         pytest.param(
             TestingFarmResultsEvent,
@@ -1876,100 +1801,6 @@ def test_get_handlers_for_check_rerun_event(
             ],
             id="tests_for_pr+build_for_commit+build_for_release"
             "&CoprBuildHandler&ReleaseEvent",
-        ),
-        pytest.param(
-            CoprBuildStartHandler,
-            CoprBuildStartEvent,
-            flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    packages={
-                        "package": CommonPackageConfig(
-                            project="project1",
-                        )
-                    },
-                ),
-                JobConfig(
-                    type=JobType.build,
-                    trigger=JobConfigTriggerType.commit,
-                    packages={
-                        "package": CommonPackageConfig(
-                            project="project2",
-                        )
-                    },
-                ),
-                JobConfig(
-                    type=JobType.build,
-                    trigger=JobConfigTriggerType.release,
-                    packages={
-                        "package": CommonPackageConfig(
-                            project="project3",
-                        )
-                    },
-                ),
-            ],
-            [
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    packages={
-                        "package": CommonPackageConfig(
-                            project="project1",
-                        )
-                    },
-                ),
-            ],
-            id="tests_for_pr+build_for_commit+build_for_release"
-            "&CoprBuildStartHandler&CoprBuildStartEvent",
-        ),
-        pytest.param(
-            CoprBuildEndHandler,
-            CoprBuildEndEvent,
-            flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
-            [
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    packages={
-                        "package": CommonPackageConfig(
-                            project="project1",
-                        )
-                    },
-                ),
-                JobConfig(
-                    type=JobType.build,
-                    trigger=JobConfigTriggerType.commit,
-                    packages={
-                        "package": CommonPackageConfig(
-                            project="project2",
-                        )
-                    },
-                ),
-                JobConfig(
-                    type=JobType.build,
-                    trigger=JobConfigTriggerType.release,
-                    packages={
-                        "package": CommonPackageConfig(
-                            project="project3",
-                        )
-                    },
-                ),
-            ],
-            [
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    packages={
-                        "package": CommonPackageConfig(
-                            project="project1",
-                        )
-                    },
-                ),
-            ],
-            id="tests_for_pr+build_for_commit+build_for_release"
-            "&CoprBuildEndHandler&CoprBuildEndEvent",
         ),
         pytest.param(
             TestingFarmResultsHandler,

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -1515,6 +1515,11 @@ def test_get_artifacts(chroot, build, additional_build, result):
         pytest.param(
             [
                 JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                ),
+                JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
                     packages={
@@ -1522,7 +1527,7 @@ def test_get_artifacts(chroot, build, additional_build, result):
                             use_internal_tf=True,
                         )
                     },
-                )
+                ),
             ],
             {"event_type": "PullRequestGithubEvent"},
             False,
@@ -1530,6 +1535,11 @@ def test_get_artifacts(chroot, build, additional_build, result):
         ),
         pytest.param(
             [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                ),
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
@@ -1556,6 +1566,11 @@ def test_get_artifacts(chroot, build, additional_build, result):
         pytest.param(
             [
                 JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                ),
+                JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
                     packages={
@@ -1578,31 +1593,6 @@ def test_get_artifacts(chroot, build, additional_build, result):
             {"event_type": "PullRequestGithubEvent"},
             True,
             id="multiple_test_jobs_build_required_internal_job_skip_build",
-        ),
-        pytest.param(
-            [
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    packages={
-                        "package": CommonPackageConfig(
-                            identifier="public",
-                        )
-                    },
-                ),
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    packages={
-                        "package": CommonPackageConfig(
-                            use_internal_tf=True,
-                        )
-                    },
-                ),
-            ],
-            {"event_type": "PullRequestCommentGithubEvent", "comment": "/packit test"},
-            True,
-            id="multiple_test_jobs_build_not_required",
         ),
     ],
 )


### PR DESCRIPTION
Add pre-check for TestingFarmHandler that checks whether there is a copr build job definition in the config, if not, report it to user and do not run the tests.

Related to #1775

**Do not merge this before the configurations in affected repos are updated (or at least wait some time after PRs are opened)**

---

RELEASE NOTES BEGIN
Packit will now additionally require for each test job requiring build a build job definition to be present in the Packit configuration file.
RELEASE NOTES END
