### PR TITLE
Re-build JobConfigView(s) after deserialization

### DIFF
--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -40,7 +40,10 @@ class only_once:
 
 # wrappers for dumping/loading of configs
 def load_package_config(package_config: dict):
-    return PackageConfigSchema().load(package_config) if package_config else None
+    package_config_obj = (
+        PackageConfigSchema().load(package_config) if package_config else None
+    )
+    return PackageConfig.post_load(package_config_obj)
 
 
 def dump_package_config(package_config: PackageConfig):


### PR DESCRIPTION
Fix Job identifier after deserialization.
Related with monorepo packit-service refactoring.
Merge after packit/packit#1946