### PR TITLE
Unify checking of the trigger branch name in build and test handlers

### DIFF
--- a/packit_service/worker/checker/testing_farm.py
+++ b/packit_service/worker/checker/testing_farm.py
@@ -2,14 +2,17 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+
 from packit_service.constants import (
     INTERNAL_TF_BUILDS_AND_TESTS_NOT_ALLOWED,
     INTERNAL_TF_TESTS_NOT_ALLOWED,
 )
-
-from packit_service.worker.checker.abstract import ActorChecker, Checker
-from packit_service.worker.events.gitlab import MergeRequestGitlabEvent
+from packit_service.worker.checker.abstract import (
+    ActorChecker,
+    Checker,
+)
 from packit_service.worker.events.enums import GitlabEventAction
+from packit_service.worker.events.gitlab import MergeRequestGitlabEvent
 from packit_service.worker.handlers.mixin import (
     GetTestingFarmJobHelperMixin,
     GetCoprBuildMixin,
@@ -18,6 +21,13 @@ from packit_service.worker.handlers.mixin import (
 from packit_service.worker.reporting import BaseCommitStatus
 
 logger = logging.getLogger(__name__)
+
+
+class IsJobConfigTriggerMatching(Checker, GetTestingFarmJobHelperMixin):
+    def pre_check(self) -> bool:
+        return self.testing_farm_job_helper.is_job_config_trigger_matching(
+            self.job_config
+        )
 
 
 class IsEventOk(

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -19,13 +19,15 @@ from packit_service.constants import (
     KojiBuildState,
 )
 from packit_service.constants import KojiTaskState
-from packit_service.worker.mixin import ConfigFromEventMixin
 from packit_service.models import AbstractTriggerDbType, KojiBuildTargetModel
 from packit_service.service.urls import (
     get_koji_build_info_url,
 )
 from packit_service.worker.checker.abstract import Checker
-from packit_service.worker.helpers.build.koji_build import KojiBuildJobHelper
+from packit_service.worker.checker.koji import (
+    PermissionOnKoji,
+    IsJobConfigTriggerMatching,
+)
 from packit_service.worker.events import (
     CheckRerunCommitEvent,
     CheckRerunPullRequestEvent,
@@ -47,11 +49,12 @@ from packit_service.worker.handlers.abstract import (
     run_for_check_rerun,
     run_for_comment,
 )
+from packit_service.worker.handlers.mixin import GetKojiBuildJobHelperMixin
+from packit_service.worker.helpers.build.koji_build import KojiBuildJobHelper
+from packit_service.worker.mixin import ConfigFromEventMixin
+from packit_service.worker.mixin import PackitAPIWithDownstreamMixin
 from packit_service.worker.reporting import BaseCommitStatus
 from packit_service.worker.result import TaskResults
-from packit_service.worker.checker.koji import PermissionOnKoji
-from packit_service.worker.mixin import PackitAPIWithDownstreamMixin
-from packit_service.worker.handlers.mixin import GetKojiBuildJobHelperMixin
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +97,10 @@ class KojiBuildHandler(
 
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker], ...]:
-        return (PermissionOnKoji,)
+        return (
+            IsJobConfigTriggerMatching,
+            PermissionOnKoji,
+        )
 
     def run(self) -> TaskResults:
         return self.koji_build_helper.run_koji_build()

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -32,6 +32,7 @@ from packit_service.worker.checker.testing_farm import (
     CanActorRunJob,
     IsEventForJob,
     IsEventOk,
+    IsJobConfigTriggerMatching,
 )
 from packit_service.worker.events import (
     TestingFarmResultsEvent,
@@ -116,6 +117,7 @@ class TestingFarmHandler(
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker], ...]:
         return (
+            IsJobConfigTriggerMatching,
             IsEventOk,
             CanActorRunJob,
         )

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -170,7 +170,11 @@ def mock_push_functionality(request):
         namespace="packit",
         repo_name="hello-world",
         project_url="https://github.com/packit/hello-world",
-    ).and_return(flexmock(id=12, job_config_trigger_type=JobConfigTriggerType.commit))
+    ).and_return(
+        flexmock(
+            id=12, job_config_trigger_type=JobConfigTriggerType.commit, name="main"
+        )
+    )
     flexmock(JobTriggerModel).should_receive("get_or_create").and_return(
         flexmock(id=123456)
     )
@@ -428,6 +432,7 @@ def test_check_rerun_pr_koji_build_handler_old_job_name(
                 {
                     "trigger": "commit",
                     "job": "tests",
+                    "branch": "main",
                     "targets": [
                         "fedora-all",
                     ],
@@ -501,7 +506,9 @@ def test_check_rerun_push_testing_farm_handler(
                 {
                     "trigger": "commit",
                     "job": "upstream_koji_build",
-                    "metadata": {"targets": "fedora-all", "scratch": "true"},
+                    "targets": "fedora-all",
+                    "scratch": "true",
+                    "branch": "main",
                 }
             ]
         ]

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -165,6 +165,7 @@ def test_precheck_push(github_push_event):
             id=1,
             job_config_trigger_type=JobConfigTriggerType.commit,
             job_trigger_model_type=JobTriggerModelType.branch_push,
+            name="build-branch",
         )
     )
     jc = JobConfig(
@@ -203,7 +204,9 @@ def test_precheck_push(github_push_event):
 
 def test_precheck_push_to_a_different_branch(github_push_event):
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
-        flexmock(id=1, job_config_trigger_type=JobConfigTriggerType.commit)
+        flexmock(
+            id=1, job_config_trigger_type=JobConfigTriggerType.commit, name="branch"
+        )
     )
 
     package_config = PackageConfig(
@@ -254,7 +257,7 @@ def test_precheck_push_actor_check(github_push_event):
         packages={"package": CommonPackageConfig(branch="branch")},
     )
     event = github_push_event.get_dict()
-    actor_checker = CoprBuildHandler.get_checkers()[1]
+    actor_checker = CoprBuildHandler.get_checkers()[2]
     assert actor_checker(package_config, job_config, event).pre_check()
 
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -1797,7 +1797,9 @@ def test_pr_test_command_handler_not_allowed_external_contributor_on_internal_TF
         project_url="https://github.com/packit-service/hello-world",
     ).and_return(
         flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
-    ).twice()
+    ).times(
+        3
+    )
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(
         GithubProject, get_files=lambda ref, recursive: ["foo.spec", ".packit.yaml"]
@@ -1865,7 +1867,7 @@ def test_pr_build_command_handler_not_allowed_external_contributor_on_internal_T
     ).and_return(
         flexmock(id=9, job_config_trigger_type=JobConfigTriggerType.pull_request)
     ).times(
-        4
+        6
     )
     pr_embedded_command_comment_event["comment"]["body"] = "/packit build"
     flexmock(


### PR DESCRIPTION
When the trigger type of the configured job is a commit, for builds and tests we additionally need to check whether the branch name from the trigger matches. Before the change, this was done only in Copr and Koji build handler pre-checks: unify the method that checks the match and use it also in TF handler pre-check.

Fixes #1981

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
---

RELEASE NOTES BEGIN
When reacting to branch pushes, Packit now correctly checks whether the branch name matches the configuration for the test jobs with configured `commit` trigger.
RELEASE NOTES END
