### PR TITLE
Create a script to remove old data from the DB

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,7 @@ repos:
             types-PyYAML,
             types-cachetools,
           ]
+        exclude: files/scripts/
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.2
     hooks:

--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -34,4 +34,7 @@
     - name: Make sure allowlist.py is present
       file:
         state: file
-        path: /usr/bin/allowlist.py
+        path: "{{ item }}"
+      loop:
+        - /usr/bin/allowlist.py
+        - /usr/bin/db-cleanup.py

--- a/files/scripts/README.md
+++ b/files/scripts/README.md
@@ -24,3 +24,21 @@ Removing a user or from the allowlist:
 ```
 $ oc exec packit-worker-0 allowlist.py remove <path_to_namespace>
 ```
+
+# Cleaning up the database
+
+This also requires logging in to the OpenShift cluster and selecting the right
+project in order to be able to run the script.
+
+Then run
+
+```
+$ oc exec packit-worker-long-running-0 db-cleanup.py
+```
+
+which removes all data older than a year from the database. It's possible to
+remove even more, by specifying the maximum age of the data:
+
+```
+$ oc exec packit-worker-long-running-0 db-cleanup.py '6 months'
+```

--- a/files/scripts/db-cleanup.py
+++ b/files/scripts/db-cleanup.py
@@ -1,0 +1,212 @@
+#!/usr/bin/python3
+
+import argparse
+from sqlalchemy import create_engine, func, select, delete, distinct, union
+from packit_service.models import (
+    CoprBuildGroupModel,
+    CoprBuildTargetModel,
+    get_pg_url,
+    GitBranchModel,
+    GitProjectModel,
+    IssueModel,
+    JobTriggerModel,
+    JobTriggerModelType,
+    KojiBuildGroupModel,
+    KojiBuildTargetModel,
+    PipelineModel,
+    ProjectAuthenticationIssueModel,
+    ProjectReleaseModel,
+    PullRequestModel,
+    SRPMBuildModel,
+    SyncReleaseModel,
+    SyncReleaseTargetModel,
+    tf_copr_association_table,
+    TFTTestRunGroupModel,
+    TFTTestRunTargetModel,
+    VMImageBuildTargetModel,
+)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""\
+Remove old data from the DB in order to speed up queries.
+
+Set POSTGRESQL_* environment variables to define the DB URL.
+See get_pg_url() for details.
+"""
+    )
+    parser.add_argument(
+        "age",
+        type=str,
+        nargs="?",
+        default="1 year",
+        help="Remove data older than this. For example: "
+        "'1 year' or '6 months'. Defaults to '1 year'.",
+    )
+    args = parser.parse_args()
+
+    engine = create_engine(
+        get_pg_url(),
+        echo=True,
+    )
+    with engine.begin() as conn:
+        # Delete the pipelines older than AGE
+        stmt = delete(PipelineModel).where(func.age(PipelineModel.datetime) >= args.age)
+        conn.execute(stmt)
+
+        # Delete JobTriggers, SRPMBuilds and VMImageBuilds which don't belong to a pipeline
+        attr = [
+            (JobTriggerModel, PipelineModel.job_trigger_id),
+            (SRPMBuildModel, PipelineModel.srpm_build_id),
+            (VMImageBuildTargetModel, PipelineModel.vm_image_build_id),
+        ]
+        for model, field in attr:
+            orphaned = (
+                select(distinct(model.id))
+                .outerjoin(PipelineModel, field == model.id)
+                .filter(PipelineModel.id == None)  # noqa
+            )
+            stmt = delete(model).where(model.id.in_(orphaned))
+            conn.execute(stmt)
+
+        # Delete CoprBuildTargets and tf-copr associations which don't belong to a pipeline
+        orphaned = (
+            select(distinct(CoprBuildTargetModel.id))
+            .outerjoin_from(
+                CoprBuildGroupModel,
+                CoprBuildTargetModel,
+                CoprBuildTargetModel.copr_build_group_id == CoprBuildGroupModel.id,
+            )
+            .outerjoin(
+                PipelineModel,
+                PipelineModel.copr_build_group_id == CoprBuildGroupModel.id,
+            )
+            .filter(PipelineModel.id == None)  # noqa
+        )
+        stmt = delete(tf_copr_association_table).where(
+            tf_copr_association_table.c.copr_id.in_(orphaned)
+        )
+        conn.execute(stmt)
+        stmt = delete(CoprBuildTargetModel).where(CoprBuildTargetModel.id.in_(orphaned))
+        conn.execute(stmt)
+
+        # Delete KojiBuildTargets, TFTTestRunTargets and SyncReleaseTargets
+        # which don't belong to any pipeline
+        attr = [
+            (
+                KojiBuildTargetModel,
+                KojiBuildGroupModel,
+                PipelineModel.koji_build_group_id,
+                KojiBuildTargetModel.koji_build_group_id,
+            ),
+            (
+                TFTTestRunTargetModel,
+                TFTTestRunGroupModel,
+                PipelineModel.test_run_group_id,
+                TFTTestRunTargetModel.tft_test_run_group_id,
+            ),
+            (
+                SyncReleaseTargetModel,
+                SyncReleaseModel,
+                PipelineModel.sync_release_run_id,
+                SyncReleaseTargetModel.sync_release_id,
+            ),
+        ]
+        for target_m, group_m, id_f, model_group_id in attr:
+            print(f"Working on {target_m}...")
+            orphaned = (
+                select(distinct(target_m.id))
+                .outerjoin_from(group_m, target_m, model_group_id == group_m.id)
+                .outerjoin(PipelineModel, id_f == group_m.id)
+                .filter(PipelineModel.id == None)  # noqa
+            )
+            stmt = delete(target_m).where(target_m.id.in_(orphaned))
+            conn.execute(stmt)
+
+        # Now that the targets are all cleaned up, let's get rid of the Groups
+        # which don't reference any targets and are not referenced by any pipeline.
+        #   - CoprBuildGroups
+        #   - KojiBuildGroups
+        #   - TFTTestRunGroups
+        #   - SynReleaseRuns
+        groups = [
+            (
+                CoprBuildGroupModel,
+                CoprBuildTargetModel,
+                CoprBuildTargetModel.copr_build_group_id,
+                PipelineModel.copr_build_group_id,
+            ),
+            (
+                KojiBuildGroupModel,
+                KojiBuildTargetModel,
+                KojiBuildTargetModel.koji_build_group_id,
+                PipelineModel.koji_build_group_id,
+            ),
+            (
+                TFTTestRunGroupModel,
+                TFTTestRunTargetModel,
+                TFTTestRunTargetModel.tft_test_run_group_id,
+                PipelineModel.test_run_group_id,
+            ),
+        ]
+        for group, target, target_group_id, pipeline_group_id in groups:
+            orphaned_groups = (
+                select(distinct(group.id))
+                .outerjoin(
+                    target,
+                    group.id == target_group_id,
+                )
+                .outerjoin(
+                    PipelineModel,
+                    pipeline_group_id == group.id,
+                )
+                .filter(target.id == None)  # noqa
+                .filter(PipelineModel.id == None)  # noqa
+            )
+            stmt = delete(group).where(group.id.in_(orphaned_groups))
+            conn.execute(stmt)
+
+        # Delete the trigger objects which are not referenced by any JobTriggers
+        #   - PullRequestModel
+        #   - GitBranchModel
+        #   - ProjectReleaseModel
+        #   - IssueModel
+
+        trigger_types = [
+            (JobTriggerModelType.pull_request, PullRequestModel),
+            (JobTriggerModelType.branch_push, GitBranchModel),
+            (JobTriggerModelType.release, ProjectReleaseModel),
+            (JobTriggerModelType.issue, IssueModel),
+        ]
+        for trigger_type, trigger_model in trigger_types:
+            triggers = (
+                select(JobTriggerModel)
+                .filter(JobTriggerModel.type == trigger_type)
+                .subquery()
+            )
+            orphaned_triggers = (
+                select(trigger_model.id)
+                .outerjoin(triggers, trigger_model.id == triggers.columns.trigger_id)
+                .filter(triggers.columns.trigger_id == None)  # noqa
+            )
+            stmt = delete(trigger_model).where(trigger_model.id.in_(orphaned_triggers))
+            conn.execute(stmt)
+
+        # Delete the GitProjectModel not referenced by anything
+        # - PullRequestModel
+        # - GitBranchModel
+        # - ProjectReleaseModel
+        # - IssueModel
+        # - ProjectAuthenticationIssueModel
+        referenced_projects = union(
+            select(PullRequestModel.project_id),
+            select(GitBranchModel.project_id),
+            select(ProjectReleaseModel.project_id),
+            select(IssueModel.project_id),
+            select(ProjectAuthenticationIssueModel.project_id),
+        )
+        stmt = delete(GitProjectModel).where(
+            GitProjectModel.id.not_in(referenced_projects)
+        )
+        conn.execute(stmt)


### PR DESCRIPTION
Getting rid of old data speeds up API queries.

To find out how much, I've run 2 tests:
1. Measure how much time it takes to query `/api/runs` and iterating through 100 pages, with 10 results per page.
2. Measure how much time it takes to query `/api/copr-builds` and iterating through 100 pages, with 50 results per page.

| | `/api/runs` | `/api/copr-builds` |
| --- | --: | --: |
| before cleanup | 0:01:14.973 | 0:02:02.964 |
| keeping 1 year | 0:00:51.586 | 0:01:29.547 |
| % | -31.19% | -27.18% |
| keeping 6 months | 0:00:39.452 | 0:01:04.199 |
| % | -47.38% | -47.79% |

Times are  `hours:minutes:seconds.milliseconds`.

Resolves #1957.
