### PR TITLE
fix: mention proper permission level and login for GitLab

### DIFF
--- a/packit_service/worker/helpers/job_helper.py
+++ b/packit_service/worker/helpers/job_helper.py
@@ -181,14 +181,15 @@ class BaseJobHelper:
         so we can extend it in subclasses easily.
         """
         if self.is_gitlab_instance and not self.is_reporting_allowed:
+            login = self.project.service.user.get_username()
             description = (
-                f"{description}\n\n---\nPackit-User does not have access to the "
+                f"{description}\n\n---\nPackit does not have access to the "
                 "source project (=usually author's fork of the project). "
                 "(This is only about the representation of the results. "
                 "Packit is still able to do its job without having the permissions.)\n\n"
                 "*In case you wish to receive commit statuses instead of comments, please "
-                "add login of the author of this comment to your fork with a role "
-                "`Reporter`.*"
+                f"add {login} to your fork with a role `Developer`.*"
+                " For more details see our [guide](https://packit.dev/docs/guide#gitlab)."
             )
 
             final_commit_states = (


### PR DESCRIPTION
When creating commit statuses to GitLab, Packit needs to have Developer permissions to create them. Also add a proper login instead of the generic “author of the comment”.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->
