### PR TITLE
Add 'complete' to TestingFarmResult enum

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -2061,6 +2061,7 @@ class TestingFarmResult(str, enum.Enum):
     unknown = "unknown"
     needs_inspection = "needs_inspection"
     retry = "retry"
+    complete = "complete"
 
 
 class TFTTestRunGroupModel(ProjectAndTriggersConnector, GroupModel, Base):


### PR DESCRIPTION
The 'state' from TF response can be  "new" "queued" "running" "complete" "error" (see https://testing-farm.gitlab.io/api/#operation/requestsGet) and since we parse it in case the 'result' is null, all these states should be in the TestingFarmResult enum. In general it should not happen that the 'state' is 'complete' and the 'result' is null (but TF can produce incorrect responses sometimes).

Fixes #2038

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
