### PR TITLE
Don't react to pull request comments by Packit

### DIFF
--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -702,6 +702,10 @@ class Parser:
             logger.warning("No Gitlab username from event.")
             return None
 
+        if actor in {"packit-as-a-service", "packit-as-a-service-stg"}:
+            logger.debug("Our own comment.")
+            return None
+
         commit_sha = nested_get(event, "merge_request", "last_commit", "id")
         if not commit_sha:
             logger.warning("No commit_sha from the event.")
@@ -1441,6 +1445,10 @@ class Parser:
         action = PullRequestCommentAction.created.value
         pr_id = event["pullrequest"]["id"]
         pagure_login = event["agent"]
+        if pagure_login in {"packit", "packit-stg"}:
+            logger.debug("Our own comment.")
+            return None
+
         base_repo_namespace = event["pullrequest"]["project"]["namespace"]
         base_repo_name = event["pullrequest"]["project"]["name"]
         repo_from = event["pullrequest"]["repo_from"]


### PR DESCRIPTION
This was already done for GitHub, mirror the behaviour for GitLab and Pagure.

Related to #2044

---

RELEASE NOTES BEGIN
TBD
RELEASE NOTES END
