### PR TITLE
fix(tf): don't pass `merge_sha` to the TF

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -319,12 +319,13 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             # We assign a commit hash for merging only if:
             # • there are no custom fmf tests set
             # • we merge and have a PR
-            if (
-                not self.custom_fmf
-                and self.job_config.merge_pr_in_ci
-                and self.target_branch_sha
-            ):
-                fmf["merge_sha"] = self.target_branch_sha
+            # TODO: Remove once it's fixed on TF side
+            # if (
+            #     not self.custom_fmf
+            #     and self.job_config.merge_pr_in_ci
+            #     and self.target_branch_sha
+            # ):
+            #     fmf["merge_sha"] = self.target_branch_sha
 
         if self.tmt_plan:
             fmf["name"] = self.tmt_plan

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -610,7 +610,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
             "fmf": {
                 "url": "https://github.com/source/bar",
                 "ref": "0011223344",
-                "merge_sha": "deadbeef",
+                # "merge_sha": "deadbeef",
                 "path": ".",
             }
         },

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -909,7 +909,7 @@ def test_pr_test_command_handler_retries(
             "fmf": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
-                "merge_sha": "deadbeef",
+                # "merge_sha": "deadbeef",
                 "path": ".",
             }
         },
@@ -1132,7 +1132,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
             "fmf": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
-                "merge_sha": "deadbeef",
+                # "merge_sha": "deadbeef",
                 "path": ".",
             }
         },
@@ -2376,7 +2376,7 @@ def test_pr_test_command_handler_multiple_builds(pr_embedded_command_comment_eve
             "fmf": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
-                "merge_sha": "deadbeef",
+                # "merge_sha": "deadbeef",
                 "path": ".",
             }
         },

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -701,7 +701,7 @@ def test_payload(
     expected_test = {
         "url": project_url,
         "ref": commit_sha,
-        "merge_sha": "abcdefgh",
+        # "merge_sha": "abcdefgh",
         "path": ".",
     }
     if tmt_plan:
@@ -1004,13 +1004,13 @@ def test_test_repo(
 
     # if custom fmf tests are not defined or we're not merging, we don't pass the
     # merge SHA
-    merge_sha_should_be_none = fmf_url or not merge_pr_in_ci
-    assert (
-        merge_sha_should_be_none and payload["test"]["fmf"].get("merge_sha") is None
-    ) or (
-        not merge_sha_should_be_none
-        and payload["test"]["fmf"].get("merge_sha") == "abcdefgh"
-    )
+    # merge_sha_should_be_none = fmf_url or not merge_pr_in_ci
+    # assert (
+    #     merge_sha_should_be_none and payload["test"]["fmf"].get("merge_sha") is None
+    # ) or (
+    #     not merge_sha_should_be_none
+    #     and payload["test"]["fmf"].get("merge_sha") == "abcdefgh"
+    # )
 
 
 def test_get_request_details():


### PR DESCRIPTION
Don't pass `merge_sha` to the TF till the issues with merging are
resolved.