### PR TITLE
Check whether architecture for TF is supported

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 from enum import Enum
+from typing import List
 
 CONTACTS_URL = "https://packit.dev/#contact"
 DOCS_URL = "https://packit.dev/docs"
@@ -236,3 +237,16 @@ GITLAB_ISSUE = (
 )
 
 DASHBOARD_JOBS_TESTING_FARM_PATH = "/jobs/testing-farm-runs"
+
+# https://docs.testing-farm.io/general/0.1/test-environment.html#_supported_architectures
+PUBLIC_TF_ARCHITECTURE_LIST: List[str] = [
+    "aarch64",
+    "x86_64",
+]
+
+INTERNAL_TF_ARCHITECTURE_LIST: List[str] = [
+    "aarch64",
+    "ppc64le",
+    "s390x",
+    "x86_64",
+]


### PR DESCRIPTION
Before submitting the TF request, check whether the configured architecture is supported by TF. In case not, report this to user and do not submit the request.

Fixes #1966


---

RELEASE NOTES BEGIN
Packit now checks whether the configured architecture for the test target is supported by Testing Farm and in case not doesn't submit these test requests.
RELEASE NOTES END
