### PR TITLE
Treat artifacts from tf_extra_params differently

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -32,6 +32,7 @@ TESTING_FARM_EXTRA_PARAM_MERGED_SUBTREES = (
     "test",
     "settings",
 )
+TESTING_FARM_ARTIFACTS_KEY = "artifacts"
 
 MSG_DOWNSTREAM_JOB_ERROR_HEADER = (
     "Packit failed on creating {object} in dist-git "

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -773,6 +773,58 @@ def test_payload(
             ],
             [{"tmt": {"context": {"how": "full"}}}],
         ),
+        (
+            {
+                "environments": [
+                    {
+                        "arch": "x86_64",
+                        "artifacts": [
+                            {
+                                "id": "123:fedora-37",
+                                "type": "fedora-copr-build",
+                            }
+                        ],
+                    }
+                ]
+            },
+            {
+                "environments": [
+                    {
+                        "artifacts": [
+                            {
+                                "type": "repository",
+                                "id": "123:fedora-37",
+                                "packages": "some-nvr",
+                            }
+                        ],
+                        "settings": {
+                            "provisioning": {"tags": {"BusinessUnit": "sst_upgrades"}}
+                        },
+                    }
+                ]
+            },
+            {
+                "environments": [
+                    {
+                        "arch": "x86_64",
+                        "artifacts": [
+                            {
+                                "id": "123:fedora-37",
+                                "type": "fedora-copr-build",
+                            },
+                            {
+                                "type": "repository",
+                                "id": "123:fedora-37",
+                                "packages": "some-nvr",
+                            },
+                        ],
+                        "settings": {
+                            "provisioning": {"tags": {"BusinessUnit": "sst_upgrades"}}
+                        },
+                    }
+                ]
+            },
+        ),
     ],
 )
 def test_merge_payload_with_extra_params(payload, params, result):


### PR DESCRIPTION
Since we do not want to overwrite artifacts defined by us in the payload, only add the ones from the tf_extra_params if present.

The merging logic cannot be changed in general for lists, as "environments" is also a list, but there, we want to do the zip + merge.

I am still wondering whether introducing a new config key for additional artifacts would not be a cleaner solution, WDYT @lachmanfrantisek ?
 
Fixes #2035

TODO:
- [x] documentation
---

RELEASE NOTES BEGIN
TODO
RELEASE NOTES END
