### PR TITLE
Gather metrics about event processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ check-in-container:
 		--env COV_REPORT \
 		--env TEST_TARGET \
 		--env COLOR \
+		--env PUSHGATEWAY_ADDRESS= \
 		-v $(CURDIR):/src:Z \
 		-w /src \
 		-v $(CURDIR)/files/packit-service.yaml:/root/.config/packit-service.yaml:Z \

--- a/packit_service/worker/monitoring.py
+++ b/packit_service/worker/monitoring.py
@@ -140,6 +140,25 @@ class Pushgateway:
             ),
         )
 
+        self.events_processed = Counter(
+            "events_processed",
+            "The number of events processed from the Celery queue",
+            registry=self.registry,
+        )
+
+        self.events_not_handled = Counter(
+            "events_not_handled",
+            "The number of events resulting in a Celery task, "
+            "but then dropped during processing",
+            registry=self.registry,
+        )
+
+        self.events_pre_check_failed = Counter(
+            "events_pre_check_failed",
+            "The number of events for which pre_check() failed",
+            registry=self.registry,
+        )
+
     def push(self):
         if not (self.pushgateway_address and self.worker_name):
             logger.debug("Pushgateway address or worker name not defined.")

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -142,7 +142,7 @@ def process_message(self, event: dict) -> List[TaskResults]:
     Returns:
         task results
     """
-    return SteveJobs().process_message(event=event)
+    return SteveJobs.process_message(event=event)
 
 
 @celery_app.task(

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -56,7 +56,7 @@ def test_bodhi_update_for_unknown_koji_build(koji_build_completed_old_format):
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
     flexmock(Signature).should_receive("apply_async").times(2)
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(PackitAPI).should_receive("create_update").with_args(
         dist_git_branch="rawhide",
         update_type="enhancement",
@@ -413,7 +413,7 @@ def test_bodhi_update_build_not_tagged_yet(
     flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
 
     flexmock(Task).should_receive("retry").and_raise(Retry).once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(koji_build_completed_old_format)
     # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
@@ -473,7 +473,7 @@ def test_bodhi_update_for_unknown_koji_build_not_for_unfinished(
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     # 0*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
     flexmock(Signature).should_receive("apply_async").times(1)
-    flexmock(Pushgateway).should_receive("push").times(0)
+    flexmock(Pushgateway).should_receive("push").times(1)
     flexmock(PackitAPI).should_receive("create_update").times(0)
 
     # Database structure
@@ -528,7 +528,7 @@ def test_bodhi_update_for_known_koji_build(koji_build_completed_old_format):
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
     flexmock(Signature).should_receive("apply_async").times(2)
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(PackitAPI).should_receive("create_update").with_args(
         dist_git_branch="rawhide",
         update_type="enhancement",
@@ -589,7 +589,7 @@ def test_bodhi_update_for_not_configured_branch(koji_build_completed_old_format)
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     # 0*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
     flexmock(Signature).should_receive("apply_async").times(1)
-    flexmock(Pushgateway).should_receive("push").times(0)
+    flexmock(Pushgateway).should_receive("push").times(1)
     flexmock(PackitAPI).should_receive("create_update").times(0)
 
     # Database structure
@@ -644,7 +644,7 @@ def test_bodhi_update_fedora_stable_by_default(koji_build_completed_f36):
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     # 1*CreateBodhiUpdateHandler + 1*KojiBuildReportHandler
     flexmock(Signature).should_receive("apply_async").times(2)
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(PackitAPI).should_receive("create_update").with_args(
         dist_git_branch="f36",
         update_type="enhancement",

--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -281,7 +281,7 @@ def test_check_rerun_pr_testing_farm_handler(
         markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(4).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_testing_farm)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -338,7 +338,7 @@ def test_check_rerun_pr_koji_build_handler(
         markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(4).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_koji_build)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -412,7 +412,7 @@ def test_check_rerun_pr_koji_build_handler_old_job_name(
         markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(4).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_koji_build)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -495,7 +495,7 @@ def test_check_rerun_push_testing_farm_handler(
         markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(4).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_testing_farm)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -554,7 +554,7 @@ def test_check_rerun_push_koji_build_handler(
         markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(4).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_koji_build_push)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -612,7 +612,7 @@ def test_check_rerun_release_koji_build_handler(
         markdown_content=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(4).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_koji_build)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -672,7 +672,7 @@ def test_check_rerun_release_propose_downstream_handler(
         update_feedback_time=object,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(
         check_rerun_event_propose_downstream

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -93,7 +93,7 @@ def test_sync_from_downstream():
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(RepositoryCache).should_call("__init__").once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(PackitAPI).should_receive("sync_from_downstream").with_args(
         dist_git_branch="main", upstream_branch="aaa", sync_only_specfile=True
     )
@@ -197,7 +197,7 @@ def test_downstream_koji_build():
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(PackitAPI).should_receive("build").with_args(
         dist_git_branch="main",
         scratch=False,
@@ -513,7 +513,7 @@ def test_downstream_koji_build_where_multiple_branches_defined(jobs_config):
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(PackitAPI).should_receive("build").with_args(
         dist_git_branch="a-different-branch",
         scratch=False,

--- a/tests/integration/test_github_fas_verification.py
+++ b/tests/integration/test_github_fas_verification.py
@@ -36,7 +36,7 @@ def test_verification_successful():
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
     flexmock(PackageConfigGetter).should_receive(
@@ -98,7 +98,7 @@ def test_verification_not_successful():
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
     flexmock(PackageConfigGetter).should_receive(
@@ -168,7 +168,7 @@ def test_verification_incorrect_format(comment):
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
     flexmock(PackageConfigGetter).should_receive(
@@ -222,7 +222,7 @@ def test_verification_already_approved():
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
     flexmock(PackageConfigGetter).should_receive(
@@ -327,7 +327,7 @@ def test_verification_not_original_triggerer():
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
     flexmock(PackageConfigGetter).should_receive(

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -44,7 +44,7 @@ def test_installation():
     flexmock(AllowlistModel).should_receive("add_namespace")
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     processing_results = SteveJobs().process_message(installation_event())
     event_dict, job, job_config, package_config = get_parameters_from_results(
         processing_results
@@ -77,7 +77,7 @@ def test_reinstallation_already_approved_namespace():
     flexmock(PackageConfigGetter).should_receive("create_issue_if_needed").never()
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     processing_results = SteveJobs().process_message(installation_event())
     event_dict, job, job_config, package_config = get_parameters_from_results(
         processing_results
@@ -113,7 +113,7 @@ def test_reinstallation_denied_namespace():
     flexmock(PackageConfigGetter).should_receive("create_issue_if_needed").never()
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     processing_results = SteveJobs().process_message(installation_event())
     event_dict, job, job_config, package_config = get_parameters_from_results(
         processing_results
@@ -159,7 +159,7 @@ def test_reinstallation_not_approved_namespace(previous_sender_login, create_iss
         flexmock(PackageConfigGetter).should_receive("create_issue_if_needed").never()
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     processing_results = SteveJobs().process_message(installation_event())
     event_dict, job, job_config, package_config = get_parameters_from_results(
         processing_results

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -232,7 +232,7 @@ def test_issue_comment_propose_downstream_handler(
     ).once()
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     flexmock(ProposeDownstreamJobHelper).should_receive(
         "report_status_to_all"
     ).with_args(

--- a/tests/integration/test_koji_build.py
+++ b/tests/integration/test_koji_build.py
@@ -68,7 +68,7 @@ def test_downstream_koji_build_report_known_build(koji_build_fixture, request):
 
     # 1*KojiBuildReportHandler
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     # Database
     flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
@@ -140,7 +140,7 @@ def test_downstream_koji_build_report_unknown_build(koji_build_fixture, request)
 
     # 1*KojiBuildReportHandler
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     # Database
     run_model_flexmock = flexmock()

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -330,7 +330,7 @@ def test_copr_build_end(
         "https://my.host/my.srpm"
     ).mock()
 
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(copr_build_end)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -401,7 +401,7 @@ def test_copr_build_end_push(
         .once()
     )
 
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(copr_build_end_push)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -467,7 +467,7 @@ def test_copr_build_end_release(
     # skip SRPM url since it touches multiple classes
     flexmock(CoprBuildEndHandler).should_receive("set_srpm_url").and_return(None)
 
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(copr_build_end_release)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -716,7 +716,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         .once()
     )
 
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
 
     processing_results = SteveJobs().process_message(copr_build_end)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -838,7 +838,7 @@ def test_copr_build_end_push_testing_farm(copr_build_end_push, copr_build_branch
         .once()
     )
 
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(copr_build_end_push)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -941,7 +941,7 @@ def test_copr_build_end_push_testing_farm_different_branch(
         .once()
     )
 
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(copr_build_end_push)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -1099,7 +1099,7 @@ def test_copr_build_end_report_multiple_testing_farm_jobs(
         .once()
     )
 
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(copr_build_end)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -1269,7 +1269,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         .once()
     )
 
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
 
     # skip SRPM url since it touches multiple classes
     flexmock(CoprBuildEndHandler).should_receive("set_srpm_url").and_return(None)
@@ -1456,7 +1456,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         .at_least()
         .once()
     )
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
 
     # skip SRPM url since it touches multiple classes
     flexmock(CoprBuildEndHandler).should_receive("set_srpm_url").and_return(None)
@@ -1530,7 +1530,7 @@ def test_copr_build_start(copr_build_start, pc_build_pr, copr_build_pr):
     ).once()
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(copr_build_start)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -1592,7 +1592,7 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_bui
         .once()
     )
 
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     # skip SRPM url since it touches multiple classes
     flexmock(CoprBuildEndHandler).should_receive("set_srpm_url").and_return(None)
@@ -1641,7 +1641,7 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
         update_feedback_time=object,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(koji_build_scratch_start)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -1705,7 +1705,7 @@ def test_koji_build_end(koji_build_scratch_end, pc_koji_build_pr, koji_build_pr)
         update_feedback_time=object,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(koji_build_scratch_end)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -1748,7 +1748,7 @@ def test_srpm_build_end(srpm_build_end, pc_build_pr, srpm_build_model):
         .at_least()
         .once()
     )
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     flexmock(SRPMBuildModel).should_receive("get_by_copr_build_id").and_return(
         srpm_build_model
@@ -1810,7 +1810,7 @@ def test_srpm_build_end_failure(srpm_build_end, pc_build_pr, srpm_build_model):
         .at_least()
         .once()
     )
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(CoprBuildJobHelper).should_receive("monitor_not_submitted_copr_builds")
 
     flexmock(SRPMBuildModel).should_receive("get_by_copr_build_id").and_return(
@@ -1864,7 +1864,7 @@ def test_srpm_build_start(srpm_build_start, pc_build_pr, srpm_build_model):
     flexmock(CoprBuildTargetModel).should_receive("get_all_by_build_id").and_return(
         [flexmock(target="fedora-33-x86_64")]
     )
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     flexmock(SRPMBuildModel).should_receive("get_by_copr_build_id").and_return(
         srpm_build_model

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -163,7 +163,7 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         )
     )
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(1).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(shutil).should_receive("rmtree").with_args("")
 
     processing_results = SteveJobs().process_message(new_hotness_update)

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -265,7 +265,7 @@ def test_pr_comment_build_build_and_test_handler(
         "is_custom_copr_project_defined"
     ).and_return(False).once()
     flexmock(Signature).should_receive("apply_async").twice()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(4).and_return()
     pr = flexmock(head_commit="12345")
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
@@ -357,7 +357,7 @@ def test_pr_comment_production_build_handler(pr_production_build_comment_event):
         update_feedback_time=object,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     pr = flexmock(head_commit="12345")
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
@@ -589,7 +589,7 @@ def test_pr_test_command_handler(pr_embedded_command_comment_event):
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=True, details={})
     )
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -701,7 +701,7 @@ def test_pr_test_command_handler_identifiers(pr_embedded_command_comment_event):
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=True, details={})
     )
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -889,7 +889,7 @@ def test_pr_test_command_handler_retries(
         {"fedora-rawhide-x86_64"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(4).and_return()
 
     payload = {
         "api_key": "secret-token",
@@ -1104,7 +1104,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
         {"fedora-rawhide-x86_64"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -1330,7 +1330,7 @@ def test_pr_test_command_handler_compose_not_present(
         {"fedora-rawhide-x86_64"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -1478,7 +1478,7 @@ def test_pr_test_command_handler_composes_not_available(
         {"fedora-rawhide-x86_64"}
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -1623,7 +1623,7 @@ def test_pr_test_command_handler_missing_build_trigger_with_build_job_config(
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=False, details={})
     )
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
 
     processing_results = SteveJobs().process_message(pr_embedded_command_comment_event)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -1915,7 +1915,7 @@ def test_retest_failed(
         {"some_target"}
     )
 
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -2028,7 +2028,7 @@ def test_pr_test_command_handler_skip_build_option_no_fmf_metadata(
     ).and_return(group_model)
     flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -2258,7 +2258,7 @@ def test_pr_test_command_handler_multiple_builds(pr_embedded_command_comment_eve
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
         build
     )
-    flexmock(Pushgateway).should_receive("push").twice().and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -2531,7 +2531,7 @@ def test_bodhi_update_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added)
         koji_builds=["123"],
     ).once()
 
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(pagure_pr_comment_added)
     event_dict, job, job_config, package_config = get_parameters_from_results(

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -191,7 +191,7 @@ def test_dist_git_push_release_handle(github_release_webhook, propose_downstream
         )
     )
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
     flexmock(shutil).should_receive("rmtree").with_args("")
 
     url = get_propose_downstream_info_url(model.id)
@@ -320,7 +320,7 @@ def test_dist_git_push_release_handle_multiple_branches(
         )
     )
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
 
     processing_results = SteveJobs().process_message(github_release_webhook)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -450,7 +450,7 @@ def test_dist_git_push_release_handle_one_failed(
     )
 
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
 
     processing_results = SteveJobs().process_message(github_release_webhook)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -576,7 +576,7 @@ def test_dist_git_push_release_handle_all_failed(
     )
     flexmock(shutil).should_receive("rmtree").with_args("")
     flexmock(Signature).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
 
     processing_results = SteveJobs().process_message(github_release_webhook)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -668,7 +668,7 @@ def test_retry_propose_downstream_task(
 
     flexmock(shutil).should_receive("rmtree").with_args("")
     flexmock(Task).should_receive("retry").once().and_return()
-    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
 
     url = get_propose_downstream_info_url(model.id)
     flexmock(ProposeDownstreamJobHelper).should_receive(
@@ -780,7 +780,7 @@ def test_dont_retry_propose_downstream_task(
     flexmock(Context, retries=2)
     flexmock(shutil).should_receive("rmtree").with_args("")
     flexmock(Task).should_receive("retry").never()
-    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+    flexmock(Pushgateway).should_receive("push").times(3).and_return()
 
     url = get_propose_downstream_info_url(model.id)
     flexmock(ProposeDownstreamJobHelper).should_receive(

--- a/tests/integration/test_vm_image_build.py
+++ b/tests/integration/test_vm_image_build.py
@@ -112,7 +112,7 @@ def test_vm_image_build(github_vm_image_build_comment):
     flexmock(PipelineModel).should_receive("create").and_return(flexmock())
     flexmock(VMImageBuildTargetModel).should_receive("create").and_return(flexmock())
     flexmock(Celery).should_receive("send_task")
-    flexmock(Pushgateway).should_receive("push").once().and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(github_vm_image_build_comment)
     event_dict, _, job_config, package_config = get_parameters_from_results(

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -176,7 +176,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
     ).times(
         1 if success else 0
     )
-    flexmock(Pushgateway).should_receive("push").times(2 if success else 0)
+    flexmock(Pushgateway).should_receive("push").times(3 if success else 1)
 
     url = get_propose_downstream_info_url(model.id)
 
@@ -232,6 +232,6 @@ def test_ignore_delete_branch(github_push):
         is_private=lambda: False,
     )
 
-    processing_results = SteveJobs().process_message(github_push)
+    processing_results = SteveJobs.process_message(github_push)
 
     assert processing_results == []


### PR DESCRIPTION
Gather metrics to better understand how many events end up being processed from the Celery queue, and how many of these are dropped for some reason.

Turn 'pushgateway' into a class attribute in order to be able to work with it in a 'classmethod'.