### PR TITLE
Use CentOS Stream9 as a base image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,8 +97,8 @@ services:
       GIT_SSH_COMMAND: "ssh -F /home/packit/.ssh/config"
       #SQLALCHEMY_ECHO: 1
     volumes:
-      - ../packit/packit:/usr/local/lib/python3.11/site-packages/packit:ro,z
-      - ./packit_service:/usr/local/lib/python3.11/site-packages/packit_service:ro,z
+      - ../packit/packit:/usr/local/lib/python3.9/site-packages/packit:ro,z
+      - ./packit_service:/usr/local/lib/python3.9/site-packages/packit_service:ro,z
       - ./files/run_worker.sh:/usr/bin/run_worker.sh:ro,Z
       - ./secrets/packit/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
       - ./secrets/packit/dev/copr:/home/packit/.config/copr:ro,z
@@ -243,7 +243,7 @@ services:
       CELERY_RETRY_LIMIT: 0
       PUSHGATEWAY_ADDRESS: ""
     volumes:
-      - ./packit_service:/usr/local/lib/python3.11/site-packages/packit_service:ro,z
+      - ./packit_service:/usr/local/lib/python3.9/site-packages/packit_service:ro,z
       - ./secrets/packit/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
       - ./secrets/packit/dev/copr:/home/packit/.config/copr:ro,z
       - ./secrets/packit/dev/ssh_config:/packit-ssh/config:ro,z

--- a/files/check-inside-openshift.yaml
+++ b/files/check-inside-openshift.yaml
@@ -49,7 +49,7 @@
           type: Ready
         wait_timeout: 100
     - name: rsync ../ to pod:/src
-      command: oc rsync ../ mount-src:/src --no-perms
+      ansible.builtin.command: oc rsync ../ mount-src:/src --no-perms
     - name: Delete the pod with mounted /src
       k8s:
         host: "{{ oc_server.stdout }}"
@@ -99,7 +99,7 @@
     # Why k8s module can't be used here:
     # https://github.com/ansible/ansible/issues/55221#issuecomment-501792651
     - name: create test job in openshift
-      shell: oc create -f {{ test_job_path }}
+      ansible.builtin.shell: oc create -f {{ test_job_path }}
     - name: Wait for tests to finish
       k8s:
         host: "{{ oc_server.stdout }}"

--- a/files/deployment-check.yaml
+++ b/files/deployment-check.yaml
@@ -9,7 +9,7 @@
     as_root: true # needs to run as root in zuul
   tasks:
     - name: Check deployment
-      command: make check
+      ansible.builtin.command: make check
       environment:
         DEPLOYMENT: dev
         ANSIBLE_STDOUT_CALLBACK: debug

--- a/files/deployment.yaml
+++ b/files/deployment.yaml
@@ -89,7 +89,7 @@
         dest: "{{ deployment_dir }}/vars/packit/dev.yml"
 
     - name: Actually deploy
-      command: make deploy
+      ansible.builtin.command: make deploy
       environment:
         DEPLOYMENT: dev
         ANSIBLE_STDOUT_CALLBACK: debug

--- a/files/docker/Dockerfile
+++ b/files/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Image for the web service (httpd), for celery worker see files/docker/Dockerfile.worker
 
-FROM quay.io/packit/base
+FROM quay.io/packit/base:c9s
 
 ARG SOURCE_BRANCH
 RUN  if [[ -z $SOURCE_BRANCH ]]; then \

--- a/files/docker/Dockerfile.tests
+++ b/files/docker/Dockerfile.tests
@@ -1,6 +1,6 @@
 # For running tests locally, see check_in_container target in Makefile
 
-FROM quay.io/packit/base
+FROM quay.io/packit/base:c9s
 
 ARG SOURCE_BRANCH
 RUN  if [[ -z $SOURCE_BRANCH ]]; then \

--- a/files/docker/Dockerfile.worker
+++ b/files/docker/Dockerfile.worker
@@ -1,6 +1,6 @@
 # Celery worker which runs tasks (packit) from the web service
 
-FROM quay.io/packit/base
+FROM quay.io/packit/base:c9s
 
 ARG SOURCE_BRANCH
 RUN  if [[ -z $SOURCE_BRANCH ]]; then \

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -23,7 +23,8 @@
           - nss_wrapper # openshift anyuid passwd madness
           - python3-requests
           - python3-prometheus_client
-          - python3-sqlalchemy+postgresql
+          - python3-sqlalchemy
+          - python3-psycopg2
           # celery-5.3.0b1.fc37 doesn't play well with flower
           # celery-5.2.6.fc37 requires billiard<4.0 and F37 has billiard-4.1.0
           # so we're installing 5.2.x from PyPI, see below

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -8,14 +8,6 @@
     source_branch: "{{ lookup('env', 'SOURCE_BRANCH') }}"
   tasks:
     - import_tasks: tasks/process-source-branch.yaml
-    - name: Pip-install gevent & greenlet
-      # greenlet < 2.0.1 (required by gevent < 22) leaks memory on Python-3.11 (RHBZ#2158732)
-      # Install gevent >= 22 (requires greenlet>2) before python3-sqlalchemy RPM
-      # which would otherwise pull in greenlet<2 RPM
-      pip:
-        name:
-          - gevent==22.*
-        executable: pip3
     - name: Install all RPM/python packages needed to run packit-service worker
       dnf:
         name:
@@ -36,6 +28,7 @@
           - postgresql # pg_dump
           - python3-boto3 # AWS (S3)
           - python3-fasjson-client
+          - python3-gevent # concurrency pool, see run_worker.sh
           - bodhi-client
         state: present
         install_weak_deps: False

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -9,8 +9,8 @@
   tasks:
     - import_tasks: tasks/process-source-branch.yaml
     - name: Pip-install gevent & greenlet
-      # https://bugzilla.redhat.com/show_bug.cgi?id=2158732
-      # Install it before python3-sqlalchemy RPM
+      # greenlet < 2.0.1 (required by gevent < 22) leaks memory on Python-3.11 (RHBZ#2158732)
+      # Install gevent >= 22 (requires greenlet>2) before python3-sqlalchemy RPM
       # which would otherwise pull in greenlet<2 RPM
       pip:
         name:
@@ -25,10 +25,6 @@
           - python3-prometheus_client
           - python3-sqlalchemy
           - python3-psycopg2
-          # celery-5.3.0b1.fc37 doesn't play well with flower
-          # celery-5.2.6.fc37 requires billiard<4.0 and F37 has billiard-4.1.0
-          # so we're installing 5.2.x from PyPI, see below
-          #           - python3-celery
           - python3-redis # celery[redis]
           - python3-lazy-object-proxy
           - dnf-utils
@@ -40,10 +36,6 @@
           - postgresql # pg_dump
           - python3-boto3 # AWS (S3)
           - python3-fasjson-client
-          # concurrency pool, see run_worker.sh
-          # temporarily installed from PyPI, see above
-          #           - python3-gevent
-          # v6 = bodhi-client, v5 = python3-bodhi{,-client}
           - bodhi-client
         state: present
         install_weak_deps: False
@@ -52,9 +44,8 @@
         name:
           - git+https://github.com/packit/sandcastle.git@{{ source_branch }}
           - sentry-sdk
-          - syslog-rfc5424-formatter
-          - git+https://github.com/jpopelka/billiard.git@v3_py311
-          - celery==5.2.*
+          - syslog-rfc5424-formatter # Logging to Splunk
+          - celery==5.2.* # celery-5.3.0b1 doesn't play well with flower
         executable: pip3
     - name: Check if all pip packages have all dependencies installed
       command: pip check

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -9,7 +9,7 @@
   tasks:
     - import_tasks: tasks/process-source-branch.yaml
     - name: Install all RPM/python packages needed to run packit-service worker
-      dnf:
+      ansible.builtin.dnf:
         name:
           - python3-ipdb # for easy debugging
           - nss_wrapper # openshift anyuid passwd madness
@@ -33,7 +33,7 @@
         state: present
         install_weak_deps: False
     - name: Install pip deps
-      pip:
+      ansible.builtin.pip:
         name:
           - git+https://github.com/packit/sandcastle.git@{{ source_branch }}
           # The above bodhi-client RPM installs python3-requests-2.25.1 and python3-urllib3-1.26.5
@@ -43,12 +43,11 @@
           - sentry-sdk
           - syslog-rfc5424-formatter # Logging to Splunk
           - celery==5.2.* # celery-5.3.0b1 doesn't play well with flower
-        executable: pip3
     - name: Check if all pip packages have all dependencies installed
       command: pip check
     - import_tasks: tasks/setup-copr-repos.yaml
     - name: Install ogr, specfile and packit from copr
-      dnf:
+      ansible.builtin.dnf:
         name:
           - python3-ogr
           - python3-specfile

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -43,6 +43,10 @@
       pip:
         name:
           - git+https://github.com/packit/sandcastle.git@{{ source_branch }}
+          # The above bodhi-client RPM installs python3-requests-2.25.1 and python3-urllib3-1.26.5
+          # The below sentry_sdk would then install urllib3-2.x because of its urllib3>=1.26.11 requirement
+          # and 'pip check' would then scream that "requests 2.25.1 has requirement urllib3<1.27"
+          - urllib3<1.27
           - sentry-sdk
           - syslog-rfc5424-formatter # Logging to Splunk
           - celery==5.2.* # celery-5.3.0b1 doesn't play well with flower

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -21,16 +21,11 @@
           - python3-sqlalchemy
           - python3-psycopg2
           - python3-prometheus_client
-          - python3-celery
           - python3-redis # celery[redis]
           - python3-lazy-object-proxy
           - python3-flask-restx
-          - python3-flask-cors
           - python3-flask-talisman
-          - python3-flexmock # because of the hack during the alembic upgrade
-          # (see d90948124e46_add_tables_for_triggers_koji_and_tests.py )
           - python-jwt
-          # v6 = bodhi-client, v5 = python3-bodhi{,-client}
           - bodhi-client
           # This is to be able to provide service version via API
           - python-setuptools_scm
@@ -41,6 +36,9 @@
         name:
           - sentry-sdk[flask]
           - syslog-rfc5424-formatter
+          - celery==5.2.* # RPM not available on c9s
+          - flask-cors # RHBZ#2100076
+          - flexmock # because of alembic (d90948124e46_..._.py )
         executable: pip3
     - name: Check if all pip packages have all dependencies installed
       command: pip check

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -18,7 +18,8 @@
           - python3-mod_wsgi
           - mod_ssl
           - python3-alembic
-          - python3-sqlalchemy+postgresql
+          - python3-sqlalchemy
+          - python3-psycopg2
           - python3-prometheus_client
           - python3-celery
           - python3-redis # celery[redis]

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -9,7 +9,7 @@
   tasks:
     - import_tasks: tasks/process-source-branch.yaml
     - name: Install all RPM/python packages needed to run packit-service
-      dnf:
+      ansible.builtin.dnf:
         name:
           - python3-ipdb # for easy debugging
           - python3-click
@@ -32,7 +32,7 @@
         state: present
         install_weak_deps: False
     - name: Install pip deps
-      pip:
+      ansible.builtin.pip:
         name:
           # The above bodhi-client RPM installs python3-requests-2.25.1 and python3-urllib3-1.26.5
           # The below sentry_sdk would then install urllib3-2.x because of its urllib3>=1.26.11 requirement
@@ -43,12 +43,11 @@
           - celery==5.2.* # RPM not available on c9s
           - flask-cors # RHBZ#2100076
           - flexmock # because of alembic (d90948124e46_..._.py )
-        executable: pip3
     - name: Check if all pip packages have all dependencies installed
-      command: pip check
+      ansible.builtin.command: pip check
     - import_tasks: tasks/setup-copr-repos.yaml
     - name: Install ogr, specfile and packit from copr
-      dnf:
+      ansible.builtin.dnf:
         name:
           - python3-ogr
           - python3-specfile

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -34,6 +34,10 @@
     - name: Install pip deps
       pip:
         name:
+          # The above bodhi-client RPM installs python3-requests-2.25.1 and python3-urllib3-1.26.5
+          # The below sentry_sdk would then install urllib3-2.x because of its urllib3>=1.26.11 requirement
+          # and 'pip check' would then scream that "requests 2.25.1 has requirement urllib3<1.27"
+          - urllib3<1.27
           - sentry-sdk[flask]
           - syslog-rfc5424-formatter
           - celery==5.2.* # RPM not available on c9s

--- a/files/packit-service-image.yaml
+++ b/files/packit-service-image.yaml
@@ -3,7 +3,7 @@
   hosts: all
   tasks:
     - name: Build service and worker images
-      command: "make {{ item }}"
+      ansible.builtin.command: "make {{ item }}"
       args:
         chdir: "{{ zuul.project.src_dir }}"
       become: true

--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -8,13 +8,13 @@
     - name: Install test RPM dependencies
       dnf:
         name:
-          - python3-flexmock
           - tar
           - rsync
         state: present
     - name: Install pip deps
       pip:
         name:
+          - flexmock
           - requre
           - pytest
           - pytest-cov

--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -6,13 +6,13 @@
   hosts: all
   tasks:
     - name: Install test RPM dependencies
-      dnf:
+      ansible.builtin.dnf:
         name:
           - tar
           - rsync
         state: present
     - name: Install pip deps
-      pip:
+      ansible.builtin.pip:
         name:
           - flexmock
           - requre
@@ -20,4 +20,3 @@
           - pytest-cov
           - pytest-flask
           - deepdiff
-        executable: pip3

--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -11,28 +11,28 @@
     - import_tasks: tasks/common.yaml
     - name: Create /tmp/sandcastle
       # working dir for the upstream git which is mapped to the sandbox pod
-      file:
+      ansible.builtin.file:
         state: directory
         path: /tmp/sandcastle
         mode: 0777
     - name: Copy gitconfig
-      copy:
+      ansible.builtin.copy:
         src: gitconfig
         dest: "{{ home_path }}/.gitconfig"
     - name: Copy run_worker.sh
-      copy:
+      ansible.builtin.copy:
         src: run_worker.sh
         dest: /usr/bin/run_worker.sh
         mode: 0777
     - name: Install scripts
-      copy:
+      ansible.builtin.copy:
         src: "{{ item }}"
         dest: /usr/bin/
         mode: 0777
       with_fileglob:
         - "{{ playbook_dir }}/scripts/*.py"
     - name: Make sure allowlist.py is present
-      file:
+      ansible.builtin.file:
         state: file
         path: "{{ item }}"
       loop:

--- a/files/tasks/common.yaml
+++ b/files/tasks/common.yaml
@@ -26,7 +26,6 @@
 - name: Install packit-service from {{ packit_service_path }}
   ansible.builtin.pip:
     name: "{{ packit_service_path }}"
-    executable: pip3
 - name: Clean all the cache files (especially pip)
   ansible.builtin.file:
     state: absent

--- a/files/zuul-tests-requre.yaml
+++ b/files/zuul-tests-requre.yaml
@@ -4,11 +4,11 @@
   hosts: all
   tasks:
     - name: Creates zuul secrets directory
-      file:
+      ansible.builtin.file:
         path: "{{ zuul.project.src_dir }}/secrets/packit/dev"
         state: directory
     - name: Run tests which are executed within openshift
-      command: make check-inside-openshift-zuul
+      ansible.builtin.command: make check-inside-openshift-zuul
       args:
         chdir: "{{ zuul.project.src_dir }}"
       become: true

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -4,20 +4,20 @@
   hosts: all
   tasks:
     - name: Install podman
-      package:
+      ansible.builtin.package:
         name:
           - podman
         state: present
       become: true
     # Fix the SELinux context for podman
     - name: Create ~/.local/share/
-      file:
+      ansible.builtin.file:
         path: ~/.local/share/
         state: directory
         recurse: yes
         setype: data_home_t
     - name: Run tests within a container
-      command: "make check-in-container"
+      ansible.builtin.command: "make check-in-container"
       args:
         chdir: "{{ zuul.project.src_dir }}"
       environment:


### PR DESCRIPTION
[celery](https://bugzilla.redhat.com/show_bug.cgi?id=2032543) & [flexmock](https://bugzilla.redhat.com/show_bug.cgi?id=2120251) are not packaged for CentOS Stream 9 yet, but they can be easily installed from PyPI (we've actually already been using `celery` from PyPI in worker)

Related to packit/deployment#410