### PR TITLE
tests: Mock 'get_repo_download_url()' calls

### DIFF
--- a/tests/integration/test_vm_image_build.py
+++ b/tests/integration/test_vm_image_build.py
@@ -26,6 +26,7 @@ from packit_service.models import (
 from packit_service.worker.allowlist import Allowlist
 from tests.spellbook import first_dict_value, get_parameters_from_results
 from packit_service.worker.handlers.vm_image import VMImageBuildHandler
+from packit.copr_helper import CoprHelper
 
 
 def test_vm_image_build(github_vm_image_build_comment):
@@ -91,6 +92,13 @@ def test_vm_image_build(github_vm_image_build_comment):
         ),
     )
     flexmock(Signature).should_receive("apply_async").times(1)
+    repo_download_url = (
+        "https://download.copr.fedorainfracloud.org/"
+        "results/mmassari/knx-stack/fedora-36-x86_64/"
+    )
+    flexmock(CoprHelper).should_receive("get_repo_download_url").once().and_return(
+        repo_download_url
+    )
     flexmock(VMImageBuildHandler).should_receive("vm_image_builder").and_return(
         flexmock()
         .should_receive("create_image")
@@ -103,8 +111,7 @@ def test_vm_image_build(github_vm_image_build_comment):
                 "upload_request": {"type": "aws", "options": {}},
             },
             {"packages": ["python-knx-stack"]},
-            "https://download.copr.fedorainfracloud.org/"
-            "results/mmassari/knx-stack/fedora-36-x86_64/",
+            repo_download_url,
         )
         .mock()
     )

--- a/tests/unit/test_handler_vm_image.py
+++ b/tests/unit/test_handler_vm_image.py
@@ -124,7 +124,15 @@ def test_vm_image_build_handler(fake_package_config_job_config_project_db_trigge
     flexmock(db_trigger).should_receive("__str__").and_return("db_trigger object")
     handler.data._db_trigger = db_trigger
     handler._project = project
+    handler._packit_api = flexmock(copr_helper=flexmock())
 
+    repo_download_url = (
+        "https://download.copr.fedorainfracloud.org/"
+        "results/mmassari/knx-stack/fedora-36-x86_64/"
+    )
+    handler.packit_api.copr_helper.should_receive("get_repo_download_url").with_args(
+        owner="mmassari", project="knx-stack", chroot="fedora-36-x86_64"
+    ).and_return(repo_download_url)
     flexmock(handler).should_receive("vm_image_builder").and_return(
         flexmock()
         .should_receive("create_image")
@@ -137,8 +145,7 @@ def test_vm_image_build_handler(fake_package_config_job_config_project_db_trigge
                 "upload_request": {"type": "aws", "options": {}},
             },
             {"packages": ["python-knx-stack"]},
-            "https://download.copr.fedorainfracloud.org/"
-            "results/mmassari/knx-stack/fedora-36-x86_64/",
+            repo_download_url,
         )
         .mock()
     )


### PR DESCRIPTION
So that they don't work with real Copr repositories.