### PR TITLE
Do not run jobs when manual_trigger=True

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -70,6 +70,9 @@ from packit_service.worker.result import TaskResults
 logger = logging.getLogger(__name__)
 
 
+MANUAL_EVENTS = [AbstractCommentEvent, CheckRerunEvent]
+
+
 def get_handlers_for_comment(
     comment: str, packit_comment_command_prefix: str
 ) -> Set[Type[JobHandler]]:
@@ -614,6 +617,14 @@ class SteveJobs:
                     or self.event.job_identifier == job.identifier
                 )
                 and job not in jobs_matching_trigger
+                # Manual trigger condition
+                and (
+                    not job.manual_trigger
+                    or any(
+                        isinstance(self.event, event_type)
+                        for event_type in MANUAL_EVENTS
+                    )
+                )
             ):
                 jobs_matching_trigger.append(job)
 

--- a/tests/unit/test_babysit_vm_image.py
+++ b/tests/unit/test_babysit_vm_image.py
@@ -116,6 +116,7 @@ def test_update_vm_image_build(stop_babysitting, build_status, vm_image_builder_
                 flexmock(
                     trigger=JobConfigTriggerType.pull_request,
                     type=JobType.vm_image_build,
+                    manual_trigger=False,
                 )
             ],
         )
@@ -156,6 +157,7 @@ def test_update_vm_image_build(stop_babysitting, build_status, vm_image_builder_
                 get_pr_id=lambda: 21,
                 owner="owner",
                 commit_sha="123456",
+                manual_trigger=False,
             ),
         )
         == stop_babysitting

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -42,6 +42,7 @@ from packit_service.worker.events import (
     CheckRerunPullRequestEvent,
     CheckRerunReleaseEvent,
     ReleaseGitlabEvent,
+    CheckRerunEvent,
 )
 from packit_service.worker.events.koji import KojiBuildEvent
 from packit_service.worker.handlers import (
@@ -2650,6 +2651,7 @@ def test_handler_doesnt_match_to_job(
 @pytest.mark.parametrize(
     "event_kls,job_config_trigger_type,jobs,result,kwargs",
     [
+        # GitHub comment event tests
         pytest.param(
             PullRequestCommentGithubEvent,
             JobConfigTriggerType.pull_request,
@@ -2746,6 +2748,252 @@ def test_handler_doesnt_match_to_job(
             {},
         ),
         pytest.param(
+            PullRequestCommentGithubEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+                JobConfig(
+                    type=JobType.propose_downstream,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            PullRequestCommentGithubEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            PullRequestCommentGithubEvent,
+            JobConfigTriggerType.release,
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            PullRequestGithubEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            ReleaseEvent,
+            JobConfigTriggerType.release,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            {},
+        ),
+        # GitLab comment event tests
+        pytest.param(
+            MergeRequestCommentGitlabEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+                JobConfig(
+                    type=JobType.propose_downstream,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            MergeRequestCommentGitlabEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            MergeRequestCommentGitlabEvent,
+            JobConfigTriggerType.release,
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.bodhi_update,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            MergeRequestGitlabEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            ReleaseGitlabEvent,
+            JobConfigTriggerType.release,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+            ],
+            {},
+        ),
+        # Pagure comment event tests
+        pytest.param(
             PullRequestCommentPagureEvent,
             JobConfigTriggerType.pull_request,
             [
@@ -2841,6 +3089,7 @@ def test_handler_doesnt_match_to_job(
                             identifier="first",
                         )
                     },
+                    manual_trigger=True,
                 ),
             ],
             [
@@ -2852,6 +3101,7 @@ def test_handler_doesnt_match_to_job(
                             identifier="first",
                         )
                     },
+                    manual_trigger=True,
                 ),
             ],
             {},
@@ -2893,6 +3143,56 @@ def test_handler_doesnt_match_to_job(
                 ),
             ],
             {"issue_id": 1},
+        ),
+        # Common re-run event
+        pytest.param(
+            CheckRerunEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="first",
+                        )
+                    },
+                    manual_trigger=True,
+                ),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="first",
+                        )
+                    },
+                    manual_trigger=False,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="first",
+                        )
+                    },
+                    manual_trigger=True,
+                ),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="first",
+                        )
+                    },
+                    manual_trigger=False,
+                ),
+            ],
+            {"job_identifier": "first"},
         ),
     ],
 )

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -1646,6 +1646,40 @@ def test_get_artifacts(chroot, build, additional_build, result):
             True,
             id="multiple_test_jobs_build_required_internal_job_skip_build",
         ),
+        pytest.param(
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=False,
+                ),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={
+                        "package": CommonPackageConfig(
+                            identifier="public",
+                        )
+                    },
+                    manual_trigger=False,
+                ),
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    skip_build=True,
+                    manual_trigger=True,
+                    packages={
+                        "package": CommonPackageConfig(
+                            use_internal_tf=True,
+                        )
+                    },
+                ),
+            ],
+            {"event_type": "PullRequestGithubEvent"},
+            True,
+            id="multiple_test_jobs_build_required_internal_job_skip_build_manual_trigger",
+        ),
     ],
 )
 def test_check_if_actor_can_run_job_and_report(jobs, event, should_pass):


### PR DESCRIPTION
This PR adds logic that when user specify `manual_trigger: True` in job definition, the handler will not consider this job as executable automatically, only via comment.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [ ] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes https://github.com/packit/packit-service/issues/1806

Related to https://github.com/packit/packit/pull/1984

Merge after https://github.com/packit/packit/pull/1984

---

RELEASE NOTES BEGIN
￼ TODO
RELEASE NOTES END
