### PR TITLE
Cover the rest of the parsers

### DIFF
--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -59,12 +59,14 @@ class TestingFarmResults(Resource):
             logger.info(f"/testing-farm/results {exc}")
             return str(exc), HTTPStatus.UNAUTHORIZED
 
-        # There's only one key in the msg,
-        # so make sure we don't confuse this with something else
-        msg["source"] = "testing-farm"
+        msg["source"] = "testing-farm"  # TODO: remove me
         celery_app.send_task(
             name=getenv("CELERY_MAIN_TASK_NAME") or CELERY_DEFAULT_MAIN_TASK_NAME,
-            kwargs={"event": msg},
+            kwargs={
+                "event": msg,
+                "source": "testing-farm",
+                "event_type": "results",
+            },
         )
 
         return "Test results accepted", HTTPStatus.OK

--- a/packit_service/service/api/webhooks.py
+++ b/packit_service/service/api/webhooks.py
@@ -199,7 +199,11 @@ class GitlabWebhook(Resource):
 
         celery_app.send_task(
             name=getenv("CELERY_MAIN_TASK_NAME") or CELERY_DEFAULT_MAIN_TASK_NAME,
-            kwargs={"event": msg},
+            kwargs={
+                "event": msg,
+                "source": "gitlab",
+                "event_type": request.headers.get("X-Gitlab-Event"),
+            },
         )
 
         return "Webhook accepted. We thank you, Gitlab.", HTTPStatus.ACCEPTED

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1541,36 +1541,37 @@ class Parser:
             distgit_project_url=distgit_project_url,
         )
 
+    # The .__func__ are needed for Python < 3.10
     MAPPING = {
         "github": {
-            "check_run": parse_check_rerun_event,
-            "pull_request": parse_pr_event,
-            "issue_comment": parse_github_comment_event,
-            "release": parse_release_event,
-            "push": parse_github_push_event,
-            "installation": parse_installation_event,
+            "check_run": parse_check_rerun_event.__func__,  # type: ignore
+            "pull_request": parse_pr_event.__func__,  # type: ignore
+            "issue_comment": parse_github_comment_event.__func__,  # type: ignore
+            "release": parse_release_event.__func__,  # type: ignore
+            "push": parse_github_push_event.__func__,  # type: ignore
+            "installation": parse_installation_event.__func__,  # type: ignore
         },
         # https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html
         "gitlab": {
-            "Merge Request Hook": parse_mr_event,
-            "Note Hook": parse_gitlab_comment_event,
-            "Push Hook": parse_gitlab_push_event,
-            "Tag Push Hook": parse_gitlab_tag_push_event,
-            "Pipeline Hook": parse_pipeline_event,
-            "Release Hook": parse_gitlab_release_event,
+            "Merge Request Hook": parse_mr_event.__func__,  # type: ignore
+            "Note Hook": parse_gitlab_comment_event.__func__,  # type: ignore
+            "Push Hook": parse_gitlab_push_event.__func__,  # type: ignore
+            "Tag Push Hook": parse_gitlab_tag_push_event.__func__,  # type: ignore
+            "Pipeline Hook": parse_pipeline_event.__func__,  # type: ignore
+            "Release Hook": parse_gitlab_release_event.__func__,  # type: ignore
         },
         "fedora-messaging": {
-            "pagure.pull-request.flag.added": parse_pagure_pr_flag_event,
-            "pagure.pull-request.flag.updated": parse_pagure_pr_flag_event,
-            "pagure.pull-request.comment.added": parse_pagure_pull_request_comment_event,
-            "git.receive": parse_pagure_push_event,
-            "copr.build.start": parse_copr_event,
-            "copr.build.end": parse_copr_event,
-            "buildsys.task.state.change": parse_koji_task_event,
-            "buildsys.build.state.change": parse_koji_build_event,
-            "hotness.update.bug.file": parse_new_hotness_update_event,
+            "pagure.pull-request.flag.added": parse_pagure_pr_flag_event.__func__,  # type: ignore
+            "pagure.pull-request.flag.updated": parse_pagure_pr_flag_event.__func__,  # type: ignore
+            "pagure.pull-request.comment.added": parse_pagure_pull_request_comment_event.__func__,  # type: ignore # noqa: E501
+            "git.receive": parse_pagure_push_event.__func__,  # type: ignore
+            "copr.build.start": parse_copr_event.__func__,  # type: ignore
+            "copr.build.end": parse_copr_event.__func__,  # type: ignore
+            "buildsys.task.state.change": parse_koji_task_event.__func__,  # type: ignore
+            "buildsys.build.state.change": parse_koji_build_event.__func__,  # type: ignore
+            "hotness.update.bug.file": parse_new_hotness_update_event.__func__,  # type: ignore
         },
         "testing-farm": {
-            "results": parse_testing_farm_results_event,
+            "results": parse_testing_farm_results_event.__func__,  # type: ignore
         },
     }

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -154,7 +154,6 @@ class Parser:
                 Parser.parse_new_hotness_update_event,
                 Parser.parse_gitlab_release_event,
                 Parser.parse_gitlab_tag_push_event,
-                Parser.parse_vm_image_build_result_event,
             ),
         ):
             if response:
@@ -1542,39 +1541,6 @@ class Parser:
             distgit_project_url=distgit_project_url,
         )
 
-    @staticmethod
-    def parse_vm_image_build_result_event(event) -> Optional[VMImageBuildResultEvent]:
-        """a vm image build changed state"""
-        topic = event.get("topic")
-
-        if topic != "vm-image-build-state-change":
-            # Topic not supported.
-            return None
-
-        logger.info(f"VM image build state changed {event.get('status')}")
-
-        build_id = event.get("build_id")
-        copr_chroot = event.get("copr_chroot")
-        pr_id = event.get("pr_id")
-        actor = event.get("actor")
-        commit_sha = event.get("commit_sha")
-        project_url = event.get("project_url")
-        status = event.get("status")
-        message = event.get("message")
-        created_at = event.get("created_at")
-
-        return VMImageBuildResultEvent(
-            build_id,
-            copr_chroot,
-            pr_id,
-            actor,
-            commit_sha,
-            project_url,
-            status,
-            message,
-            created_at,
-        )
-
     MAPPING = {
         "github": {
             "check_run": parse_check_rerun_event,
@@ -1584,6 +1550,7 @@ class Parser:
             "push": parse_github_push_event,
             "installation": parse_installation_event,
         },
+        # https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html
         "gitlab": {
             "Merge Request Hook": parse_mr_event,
             "Note Hook": parse_gitlab_comment_event,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -362,7 +362,7 @@ def distgit_push_packit():
 
 @pytest.fixture(scope="module")
 def distgit_push_event(distgit_push_packit) -> PushPagureEvent:
-    return Parser.parse_push_pagure_event(distgit_push_packit)
+    return Parser.parse_pagure_push_event(distgit_push_packit)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Follow-up of #2067

@majamassarini I was hoping you could help me understand where we send a celery task with an event later parsed in [here](https://github.com/packit/packit-service/blob/main/packit_service/worker/parser.py#L1532). I was looking for another `celery_app.send_task()` but found none.