### PR TITLE
Fix results events reporting from packit-service

### DIFF
--- a/packit_service/worker/events/copr.py
+++ b/packit_service/worker/events/copr.py
@@ -14,13 +14,13 @@ from packit_service.models import (
     AbstractProjectEventDbType,
     SRPMBuildModel,
 )
-from packit_service.worker.events.event import AbstractForgeIndependentEvent
+from packit_service.worker.events.event import AbstractResultEvent
 from packit_service.worker.events.enums import FedmsgTopic
 
 logger = getLogger(__name__)
 
 
-class AbstractCoprBuildEvent(AbstractForgeIndependentEvent):
+class AbstractCoprBuildEvent(AbstractResultEvent):
     build: Optional[Union[SRPMBuildModel, CoprBuildTargetModel]]
 
     def __init__(

--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -492,3 +492,12 @@ class AbstractForgeIndependentEvent(Event):
             models=CoprBuildTargetModel.get_all_by_commit(commit_sha=self.commit_sha),
             statuses_to_filter_with=statuses_to_filter_with,
         )
+
+
+class AbstractResultEvent(AbstractForgeIndependentEvent):
+    """
+    This class is used only as an Abstract for result events to
+    allow Steve properly filter jobs with manual trigger.
+    """
+
+    pass

--- a/packit_service/worker/events/koji.py
+++ b/packit_service/worker/events/koji.py
@@ -20,12 +20,12 @@ from packit_service.models import (
     PipelineModel,
 )
 from packit_service.worker.events.event import (
-    AbstractForgeIndependentEvent,
     use_for_job_config_trigger,
+    AbstractResultEvent,
 )
 
 
-class AbstractKojiEvent(AbstractForgeIndependentEvent):
+class AbstractKojiEvent(AbstractResultEvent):
     def __init__(
         self,
         build_id: int,

--- a/packit_service/worker/events/testing_farm.py
+++ b/packit_service/worker/events/testing_farm.py
@@ -12,10 +12,10 @@ from packit_service.models import (
     PullRequestModel,
     TFTTestRunTargetModel,
 )
-from packit_service.worker.events.event import AbstractForgeIndependentEvent
+from packit_service.worker.events.event import AbstractResultEvent
 
 
-class TestingFarmResultsEvent(AbstractForgeIndependentEvent):
+class TestingFarmResultsEvent(AbstractResultEvent):
     __test__ = False
 
     def __init__(

--- a/packit_service/worker/events/vm_image.py
+++ b/packit_service/worker/events/vm_image.py
@@ -7,12 +7,12 @@ from packit_service.models import (
     VMImageBuildStatus,
 )
 from packit_service.worker.events.event import (
-    AbstractForgeIndependentEvent,
     AbstractProjectEventDbType,
+    AbstractResultEvent,
 )
 
 
-class VMImageBuildResultEvent(AbstractForgeIndependentEvent):
+class VMImageBuildResultEvent(AbstractResultEvent):
     def __init__(
         self,
         build_id: str,

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -38,6 +38,7 @@ from packit_service.worker.events.comment import (
     AbstractCommentEvent,
     AbstractIssueCommentEvent,
 )
+from packit_service.worker.events.event import AbstractResultEvent
 from packit_service.worker.handlers import (
     CoprBuildHandler,
     GithubAppInstallationHandler,
@@ -71,7 +72,7 @@ from packit_service.worker.result import TaskResults
 logger = logging.getLogger(__name__)
 
 
-MANUAL_EVENTS = [AbstractCommentEvent, CheckRerunEvent]
+MANUAL_OR_RESULT_EVENTS = [AbstractCommentEvent, AbstractResultEvent, CheckRerunEvent]
 
 
 def get_handlers_for_comment(
@@ -635,7 +636,7 @@ class SteveJobs:
                     not job.manual_trigger
                     or any(
                         isinstance(self.event, event_type)
-                        for event_type in MANUAL_EVENTS
+                        for event_type in MANUAL_OR_RESULT_EVENTS
                     )
                 )
             ):

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -43,8 +43,10 @@ from packit_service.worker.events import (
     CheckRerunReleaseEvent,
     ReleaseGitlabEvent,
     CheckRerunEvent,
+    VMImageBuildResultEvent,
+    AbstractCoprBuildEvent,
 )
-from packit_service.worker.events.koji import KojiBuildEvent
+from packit_service.worker.events.koji import KojiBuildEvent, AbstractKojiEvent
 from packit_service.worker.handlers import (
     CoprBuildEndHandler,
     CoprBuildStartHandler,
@@ -3193,6 +3195,90 @@ def test_handler_doesnt_match_to_job(
                 ),
             ],
             {"job_identifier": "first"},
+        ),
+        pytest.param(
+            TestingFarmResultsEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            VMImageBuildResultEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            AbstractCoprBuildEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            {},
+        ),
+        pytest.param(
+            AbstractKojiEvent,
+            JobConfigTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={"package": CommonPackageConfig()},
+                    manual_trigger=True,
+                ),
+            ],
+            {},
         ),
     ],
 )


### PR DESCRIPTION
Fixes issue introduced in https://github.com/packit/packit-service/pull/2069. When `manual_trigger=True` the results event are filtered and the results are not propagated properly back to je github/gitlab.

- [x] Write new tests or update the old ones to cover new functionality.


