### PR TITLE
Don't run tests in CoprBuildEndHandler if manual_trigger enabled

### DIFF
--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -398,6 +398,7 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
             for job_config in self.copr_build_helper.job_tests_all:
                 if (
                     not job_config.skip_build
+                    and not job_config.manual_trigger
                     and self.copr_event.chroot
                     in self.copr_build_helper.build_targets_for_test_job(job_config)
                 ):

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -1013,6 +1013,139 @@ def test_copr_build_end_testing_farm_different_pr_branch(copr_build_end, copr_bu
     )
 
 
+def test_copr_build_end_testing_farm_manual_trigger(copr_build_end, copr_build_pr):
+    ServiceConfig.get_service_config().testing_farm_api_url = (
+        "https://api.dev.testing-farm.io/v0.1/"
+    )
+    ServiceConfig.get_service_config().testing_farm_secret = "secret token"
+
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
+    flexmock(GithubProject).should_receive("get_pr").and_return(
+        flexmock(
+            source_project=flexmock(
+                get_web_url=lambda: "https://github.com/source/bar"
+            ),
+            target_project=flexmock(
+                get_web_url=lambda: "https://github.com/target/bar"
+            ),
+            head_commit="0011223344",
+            target_branch_head_commit="deadbeef",
+            source_branch="the-source-branch",
+            target_branch="the-target-branch",
+        )
+        .should_receive("comment")
+        .mock()
+    )
+    urls.DASHBOARD_URL = "https://dashboard.localhost"
+
+    config = PackageConfig(
+        packages={
+            "package": CommonPackageConfig(
+                specfile_path="test.spec",
+            )
+        },
+        jobs=[
+            JobConfig(
+                type=JobType.copr_build,
+                trigger=JobConfigTriggerType.pull_request,
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-rawhide"],
+                        specfile_path="test.spec",
+                    )
+                },
+            ),
+            JobConfig(
+                type=JobType.tests,
+                trigger=JobConfigTriggerType.pull_request,
+                manual_trigger=True,
+                packages={
+                    "package": CommonPackageConfig(
+                        _targets=["fedora-rawhide"],
+                        specfile_path="test.spec",
+                    )
+                },
+            ),
+        ],
+    )
+
+    flexmock(AbstractCoprBuildEvent).should_receive("get_packages_config").and_return(
+        config
+    )
+    flexmock(CoprHelper).should_receive("get_copr_client").and_return(
+        Client(config={"username": "packit", "copr_url": "https://dummy.url"})
+    )
+    flexmock(PackageConfigGetter).should_receive(
+        "get_package_config_from_repo"
+    ).and_return(config)
+
+    flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
+
+    flexmock(CoprBuildTargetModel).should_receive("get_by_build_id").and_return(
+        copr_build_pr
+    )
+    flexmock(CoprBuildTargetModel).should_receive("get_by_id").and_return(copr_build_pr)
+    copr_build_pr.should_call("set_status").with_args(BuildStatus.success).once()
+    copr_build_pr.should_receive("set_end_time").once()
+    flexmock(requests).should_receive("get").and_return(requests.Response())
+    flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
+    # check if packit-service set correct PR status
+    url = get_copr_build_info_url(1)
+    flexmock(StatusReporter).should_receive("report").with_args(
+        state=BaseCommitStatus.success,
+        description="RPMs were built successfully.",
+        url=url,
+        check_names=EXPECTED_BUILD_CHECK_NAME,
+        markdown_content=None,
+        links_to_external_services=None,
+        update_feedback_time=object,
+    ).once()
+
+    flexmock(StatusReporter).should_receive("report").with_args(
+        state=BaseCommitStatus.pending,
+        description="RPMs were built successfully.",
+        url=url,
+        check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
+        markdown_content=None,
+        links_to_external_services=None,
+        update_feedback_time=object,
+    ).once()
+
+    flexmock(GithubProject).should_receive("get_web_url").and_return(
+        "https://github.com/foo/bar"
+    )
+
+    flexmock(Signature).should_receive("apply_async").once()
+
+    # skip SRPM url since it touches multiple classes
+    flexmock(CoprBuildEndHandler).should_receive("set_srpm_url").and_return(None)
+
+    (
+        flexmock(CoprBuildJobHelper)
+        .should_receive("get_build_chroot")
+        .with_args(1, "some-target")
+        .and_return(flexmock(ended_on=1666889710))
+        .at_least()
+        .once()
+    )
+
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+
+    processing_results = SteveJobs().process_message(copr_build_end)
+    event_dict, job, job_config, package_config = get_parameters_from_results(
+        processing_results
+    )
+    assert json.dumps(event_dict)
+
+    flexmock(CoprBuildJobHelper).should_receive("get_built_packages").and_return([])
+
+    run_copr_build_end_handler(
+        package_config=package_config,
+        event=event_dict,
+        job_config=job_config,
+    )
+
+
 def test_copr_build_end_push_testing_farm(copr_build_end_push, copr_build_branch_push):
     config = PackageConfig(
         packages={


### PR DESCRIPTION
In CoprBuildEndHandler, when triggering the followup tests, check for each test job config whether the manual_trigger is not enabled. If it is, do not run the tests.

Related to #1806


---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
