### PR TITLE
fix(api): add CORS

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -24,6 +24,7 @@
           - python3-redis # celery[redis]
           - python3-lazy-object-proxy
           - python3-flask-restx
+          - python3-flask-cors
           - python3-flexmock # because of the hack during the alembic upgrade
           # (see d90948124e46_add_tables_for_triggers_koji_and_tests.py )
           - python-jwt

--- a/packit_service/service/api/utils.py
+++ b/packit_service/service/api/utils.py
@@ -25,7 +25,6 @@ def response_maker(result: Any, status: HTTPStatus = HTTPStatus.OK):
     """response_maker is a wrapper around flask's make_response"""
     resp = make_response(dumps(result), status.value)
     resp.headers["Content-Type"] = "application/json"
-    resp.headers["Access-Control-Allow-Origin"] = "*"
     return resp
 
 

--- a/packit_service/service/app.py
+++ b/packit_service/service/app.py
@@ -6,6 +6,7 @@ from os import getenv
 from socket import gaierror
 
 from flask import Flask
+from flask_cors import CORS
 
 # Mypy errors out with Module 'flask' has no attribute '__version__'.
 # Python can find flask's version but mypy cannot.
@@ -77,6 +78,7 @@ def get_flask_application():
 
 
 packit_as_a_service = Proxy(get_flask_application)
+CORS(packit_as_a_service)
 
 # Make Prometheus Client serve the /metrics endpoint
 application = DispatcherMiddleware(packit_as_a_service, {"/metrics": prometheus_app()})


### PR DESCRIPTION
<!-- notes for reviewers -->

In the issues of flask-cors there are some mentions that in development/debugging environment flask behaves differently than in production one.

It definitely works for correct requests, even after removing our own “hack” with manual addition of the CORS. However I am not able to get the correct headers via `podman-compose` even with the CORS wrapper. It just doesn't return it, not sure if it is related to the note above regarding the environment, or not.

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #1883