### PR TITLE
Do not require Copr project and owner defined for VM image build

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1537,10 +1537,11 @@ class CoprBuildTargetModel(GroupAndTargetModelConnector, Base):
 
     @staticmethod
     def get_all_by(
-        project_name: str,
         commit_sha: str,
+        project_name: str = None,
         owner: str = None,
         target: str = None,
+        status: BuildStatus = None,
     ) -> Iterable["CoprBuildTargetModel"]:
         """
         All owner/project_name builds sorted from latest to oldest

--- a/tests/unit/test_checkers.py
+++ b/tests/unit/test_checkers.py
@@ -281,42 +281,9 @@ def test_pr_event_checker(configured_branch, success, event, trigger, checker_kl
         ),
         pytest.param(
             False,
-            [
-                flexmock(
-                    project_name="knx-stack",
-                    owner="mmassari",
-                    target="fedora-36-x86_64",
-                    status="failed",
-                    built_packages=[],
-                ),
-            ],
-            (
-                "No successful Copr build found for project mmassari/knx-stack"
-                " commit 1 and chroot (target) fedora-36-x86_64"
-            ),
-            id="No successful copr build for project found",
-        ),
-        pytest.param(
-            False,
-            [
-                flexmock(
-                    project_name="knx-stack",
-                    owner="mmassari",
-                    target="fedora-38-arm_32",
-                    status="failed",
-                    built_packages=[],
-                ),
-            ],
-            (
-                "No successful Copr build found for project mmassari/knx-stack"
-                " commit 1 and chroot (target) fedora-36-x86_64"
-            ),
-            id="No copr build for target found",
-        ),
-        pytest.param(
-            False,
             [],
-            "No Copr build found for commit sha 1",
+            "No successful Copr build found for project mmassari/knx-stack, "
+            "commit 1 and chroot (target) fedora-36-x86_64",
             id="No copr build found",
         ),
     ),
@@ -326,9 +293,7 @@ def test_vm_image_is_copr_build_ok_for_chroot(
 ):
     package_config, job_config, _, _ = fake_package_config_job_config_project_db_trigger
 
-    flexmock(CoprBuildTargetModel).should_receive("get_all_by_commit").and_return(
-        copr_builds
-    )
+    flexmock(CoprBuildTargetModel).should_receive("get_all_by").and_return(copr_builds)
 
     checker = IsCoprBuildForChrootOk(
         package_config,


### PR DESCRIPTION
If the Copr project/owner is not defined, we will just use the latest builds with corresponding commit SHA.
Fixes #2034
TODO:
- [ ] update docs
---

RELEASE NOTES BEGIN
If the `vm_image_build` job doesn't have configured Copr project/owner, the Copr project used for the latest Copr build of the pull request will be now used.
RELEASE NOTES END
