### PR TITLE
Rename leftover trigger_model in project_event_model

### DIFF
--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -498,7 +498,8 @@ class BaseBuildJobHelper(BaseJobHelper):
         results: Optional[TaskResults] = None
 
         self._srpm_model, self.run_model = SRPMBuildModel.create_with_new_run(
-            trigger_model=self.db_project_event, commit_sha=self.metadata.commit_sha
+            project_event_model=self.db_project_event,
+            commit_sha=self.metadata.commit_sha,
         )
         self._srpm_model.set_start_time(datetime.datetime.utcnow())
 


### PR DESCRIPTION
Related to #2065 

Fix #2084 