### PR TITLE
Implement retriggering of pull-from-upstream via comment in dist-git PR

### DIFF
--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -452,15 +452,6 @@ class AbstractForgeIndependentEvent(Event):
             fail_when_missing=self.fail_when_config_file_missing,
         )
 
-        # TODO do we need to do this?
-        # job config change note:
-        #   this is used in sync-from-downstream which is buggy - we don't need to change this
-        if packages_config:
-            for (
-                package_config_view
-            ) in packages_config.get_package_config_views().values():
-                package_config_view.upstream_project_url = self.project_url
-
         return packages_config
 
     def get_all_tf_targets_by_status(

--- a/packit_service/worker/helpers/sync_release/pull_from_upstream.py
+++ b/packit_service/worker/helpers/sync_release/pull_from_upstream.py
@@ -10,6 +10,8 @@ from packit.config import JobType, PackageConfig, JobConfig
 from packit_service.config import ServiceConfig
 from packit_service.models import AbstractProjectEventDbType
 from packit_service.worker.events import EventData
+from packit_service.worker.events.pagure import PullRequestCommentPagureEvent
+from packit_service.worker.events.new_hotness import NewHotnessUpdateEvent
 from packit_service.worker.helpers.sync_release.sync_release import SyncReleaseHelper
 
 logger = logging.getLogger(__name__)
@@ -44,9 +46,13 @@ class PullFromUpstreamHelper(SyncReleaseHelper):
         Get the default branch of the distgit project.
         """
         if not self._default_dg_branch:
-            git_project = self.service_config.get_project(
-                url=self.metadata.event_dict.get("distgit_project_url")
-            )
+            if self.metadata.event_type in (NewHotnessUpdateEvent.__name__,):
+                distgit_project_url = self.metadata.event_dict.get(
+                    "distgit_project_url"
+                )
+            elif self.metadata.event_type in (PullRequestCommentPagureEvent.__name__,):
+                distgit_project_url = self.metadata.event_dict.get("project_url")
+            git_project = self.service_config.get_project(url=distgit_project_url)
             self._default_dg_branch = git_project.default_branch
         return self._default_dg_branch
 

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -599,6 +599,15 @@ class SteveJobs:
                     # A koji_build job with comment trigger
                     # can be re-triggered by a Pagure comment in a PR
                     matching_jobs.append(job)
+                elif (
+                    job.type == JobType.pull_from_upstream
+                    and job.trigger == JobConfigTriggerType.release
+                    and self.event.job_config_trigger_type
+                    == JobConfigTriggerType.pull_request
+                ):
+                    # A pull_from_upstream job with release trigger
+                    # can be re-triggered by a comment in a dist-git PR
+                    matching_jobs.append(job)
         elif isinstance(self.event, AbstractIssueCommentEvent):
             for job in self.event.packages_config.get_job_views():
                 if (

--- a/tests/unit/test_bodhi_update_error_msgs.py
+++ b/tests/unit/test_bodhi_update_error_msgs.py
@@ -63,6 +63,9 @@ def package_config__job_config__pull_request_event(package_config__job_config):
     flexmock(PullRequestCommentPagureEvent).should_receive("commit_sha").and_return(
         "abcdef"
     )
+    flexmock(PullRequestCommentPagureEvent).should_receive(
+        "get_packages_config"
+    ).and_return(package_config)
     data = PullRequestCommentPagureEvent(
         pr_id=123,
         action=PullRequestAction.opened,


### PR DESCRIPTION
I'll be glad for any feedback. I'm particularly not happy with this:
https://github.com/packit/packit-service/blob/b797adbab1ef2086ad1a5d6f0376ab5bbfa186ce/packit_service/worker/helpers/sync_release/sync_release.py#L82-L87

I thought about using a "hack" similar to this in `PullRequestModel`:
https://github.com/packit/packit-service/blob/cfb5e7f31a0e524bf9bae49c2f67d77db1da8853/packit_service/models.py#L1001-L1002

That works for this case but breaks some other jobs.

Fixes: #1829.

RELEASE NOTES BEGIN
`pull_from_upstream` jobs can now be retriggered with a comment `/packit pull-from-upstream` in a dist-git pull request.
RELEASE NOTES END
