### PR TITLE
fix(tf): pass `merge_sha` to the TF

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -366,13 +366,12 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             # We assign a commit hash for merging only if:
             # • there are no custom fmf tests set
             # • we merge and have a PR
-            # TODO: Remove once it's fixed on TF side
-            # if (
-            #     not self.custom_fmf
-            #     and self.job_config.merge_pr_in_ci
-            #     and self.target_branch_sha
-            # ):
-            #     fmf["merge_sha"] = self.target_branch_sha
+            if (
+                not self.custom_fmf
+                and self.job_config.merge_pr_in_ci
+                and self.target_branch_sha
+            ):
+                fmf["merge_sha"] = self.target_branch_sha
 
         if self.tmt_plan:
             fmf["name"] = self.tmt_plan

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -587,7 +587,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
             "fmf": {
                 "url": "https://github.com/source/bar",
                 "ref": "0011223344",
-                # "merge_sha": "deadbeef",
+                "merge_sha": "deadbeef",
                 "path": ".",
             }
         },

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -909,7 +909,7 @@ def test_pr_test_command_handler_retries(
             "fmf": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
-                # "merge_sha": "deadbeef",
+                "merge_sha": "deadbeef",
                 "path": ".",
             }
         },
@@ -1134,7 +1134,7 @@ def test_pr_test_command_handler_skip_build_option(pr_embedded_command_comment_e
             "fmf": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
-                # "merge_sha": "deadbeef",
+                "merge_sha": "deadbeef",
                 "path": ".",
             }
         },
@@ -2302,7 +2302,7 @@ def test_pr_test_command_handler_multiple_builds(pr_embedded_command_comment_eve
             "fmf": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
-                # "merge_sha": "deadbeef",
+                "merge_sha": "deadbeef",
                 "path": ".",
             }
         },

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -702,7 +702,7 @@ def test_payload(
     expected_test = {
         "url": project_url,
         "ref": commit_sha,
-        # "merge_sha": "abcdefgh",
+        "merge_sha": "abcdefgh",
         "path": ".",
     }
     if tmt_plan:
@@ -1057,13 +1057,13 @@ def test_test_repo(
 
     # if custom fmf tests are not defined or we're not merging, we don't pass the
     # merge SHA
-    # merge_sha_should_be_none = fmf_url or not merge_pr_in_ci
-    # assert (
-    #     merge_sha_should_be_none and payload["test"]["fmf"].get("merge_sha") is None
-    # ) or (
-    #     not merge_sha_should_be_none
-    #     and payload["test"]["fmf"].get("merge_sha") == "abcdefgh"
-    # )
+    merge_sha_should_be_none = fmf_url or not merge_pr_in_ci
+    assert (
+        merge_sha_should_be_none and payload["test"]["fmf"].get("merge_sha") is None
+    ) or (
+        not merge_sha_should_be_none
+        and payload["test"]["fmf"].get("merge_sha") == "abcdefgh"
+    )
 
 
 def test_get_request_details():


### PR DESCRIPTION
This reverts commit 02d8098642b94d25c3ccbdb1ffdfeacc95a79f94, since the issues have been resolved by the TF Team, thanks a lot <3

Fixes #1224

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

---

RELEASE NOTES BEGIN
We have finally fixed the issue that could've caused inconsistencies when tests from PR to were supposed to be merged during the test runs on the Testing Farm.
RELEASE NOTES END
