### PR TITLE
Make the event-took-more-than-Xs-to-process error message consistent

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -818,7 +818,7 @@ class SteveJobs:
             # we need more info why this has happened
             logger.debug(f"Event dict: {self.event}.")
             logger.error(
-                f"Event {self.event.__class__.__name__} took ({response_time}s) to process."
+                f"Event {self.event.__class__.__name__} took more than 15s to process."
             )
         # set the time when the accepted status was set so that we
         # can use it later for measurements


### PR DESCRIPTION
With different response times, the error message looks different each time and it generates a new Sentry issue.
With this change, we'll reuse an existing Sentry issue for those events.
