### PR TITLE
Add a new endpoint with the package versions

### DIFF
--- a/packit_service/service/api/__init__.py
+++ b/packit_service/service/api/__init__.py
@@ -17,6 +17,7 @@ from packit_service.service.api.runs import ns as runs_ns
 from packit_service.service.api.propose_downstream import ns as propose_downstream_ns
 from packit_service.service.api.usage import usage_ns
 from packit_service.service.api.pull_from_upstream import ns as pull_from_upstream_ns
+from packit_service.service.api.system import ns as system_ns
 
 # https://flask-restplus.readthedocs.io/en/stable/scaling.html
 blueprint = Blueprint("api", __name__, url_prefix="/api")
@@ -40,3 +41,4 @@ api.add_namespace(runs_ns)
 api.add_namespace(propose_downstream_ns)
 api.add_namespace(usage_ns)
 api.add_namespace(pull_from_upstream_ns)
+api.add_namespace(system_ns)

--- a/packit_service/service/api/system.py
+++ b/packit_service/service/api/system.py
@@ -1,0 +1,64 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+import re
+from http import HTTPStatus
+from logging import getLogger
+
+from typing import Optional
+
+from setuptools_scm import get_version
+
+import packit
+
+import ogr
+from flask_restx import Namespace, Resource
+
+import specfile
+
+import packit_service
+from packit_service.service.api.utils import response_maker
+
+logger = getLogger("packit_service")
+
+ns = Namespace("system", description="System information")
+
+
+def get_commit_from_version(version) -> Optional[str]:
+    """
+    Version can look like this:
+        0.76.0.post18+g116edc5
+        0.1.dev1+gc03b1bd.d20230615
+        0.18.0.post4+g28cb117
+        0.45.1.dev2+g3b0fc3b
+
+    The 7 characters after the "+g" is the short version of the git commit hash.
+    """
+    if matches := re.search(r"\+g([A-Za-z0-9]{7})", version):
+        return matches.groups()[0]
+    return None
+
+
+@ns.route("")
+class SystemInformation(Resource):
+    @ns.response(HTTPStatus.OK.value, "OK")
+    def get(self):
+        """System information"""
+        packages_and_versions = {
+            project: project.__version__ for project in [ogr, specfile, packit]
+        }
+        # packit_service might not be installed (i.e. when running locally)
+        # so it's treated differently
+        packages_and_versions[packit_service] = get_version(
+            root="..", relative_to=packit_service.__file__
+        )
+
+        response_data = {
+            project.__name__: {
+                "commit": get_commit_from_version(version),
+                "version": version,
+            }
+            for project, version in packages_and_versions.items()
+            if version
+        }
+
+        return response_maker(response_data)

--- a/packit_service/service/api/system.py
+++ b/packit_service/service/api/system.py
@@ -48,7 +48,9 @@ class SystemInformation(Resource):
         }
         # packit_service might not be installed (i.e. when running locally)
         # so it's treated differently
-        packages_and_versions[packit_service] = get_version(
+        packages_and_versions[
+            packit_service
+        ] = packit_service.__version__ or get_version(
             root="..", relative_to=packit_service.__file__
         )
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import pytest
 
 from packit_service.models import optional_time
+from packit_service.service.api.system import get_commit_from_version
 
 
 @pytest.mark.parametrize(
@@ -16,3 +17,16 @@ def test_optional_time(input_object, expected_type):
     # optional_time returns a string if its passed a datetime object
     # None if passed a NoneType object
     assert isinstance(optional_time(input_object), expected_type)
+
+
+@pytest.mark.parametrize(
+    "version,commit",
+    [
+        ("0.76.0.post18+g116edc5", "116edc5"),
+        ("0.1.dev1+gc03b1bd.d20230615", "c03b1bd"),
+        ("0.18.0.post4+g28cb117", "28cb117"),
+        ("0.45.1.dev2+g3b0fc3b", "3b0fc3b"),
+    ],
+)
+def test_get_commit_from_version(version, commit):
+    assert get_commit_from_version(version) == commit

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -102,3 +102,13 @@ def test_get_srpm_logs(client):
 
     logs_url = get_srpm_build_info_url(2)
     assert logs_url == "https://localhost/results/srpm-builds/2"
+
+
+def test_system_api(client):
+    response = client.get("/api/system")
+    assert response.status_code == 200
+    response_data = response.json
+    for package in ["ogr", "packit", "specfile", "packit_service"]:
+        assert package in response_data
+        assert "version" in response_data[package]
+        assert len(response_data[package]["commit"]) == 7


### PR DESCRIPTION
This is to provide better traceability
and to be able to show this to the users.

We are showing the packit-related packages:
* packit_service
* packit
* ogr
* specfile

TODO:

- [x] Write new tests or update the old ones to cover the new functionality.
- [x] Update doc-strings where appropriate.
