### PR TITLE
Add a python-setuptools_scm dependency to the image for the new API endpoint

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -30,6 +30,8 @@
           - python-jwt
           # v6 = bodhi-client, v5 = python3-bodhi{,-client}
           - bodhi-client
+          # This is to be able to provide service version via API
+          - python-setuptools_scm
         state: present
         install_weak_deps: False
     - name: Install pip deps


### PR DESCRIPTION
To be able to run the tests for the implementation using this dependency.

Required for the tests in #2095 
