### PR TITLE
Share Copr project for monorepo Copr builds

### DIFF
--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -36,6 +36,7 @@ from packit_service.worker.checker.copr import (
     IsGitForgeProjectAndEventOk,
     BuildNotAlreadyStarted,
     IsJobConfigTriggerMatching,
+    IsPackageMatchingJobView,
 )
 from packit_service.worker.events import (
     CoprBuildEndEvent,
@@ -129,7 +130,7 @@ class AbstractCoprBuildReportHandler(
 ):
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker], ...]:
-        return (AreOwnerAndProjectMatchingJob,)
+        return (AreOwnerAndProjectMatchingJob, IsPackageMatchingJobView)
 
 
 @configured_as(job_type=JobType.copr_build)

--- a/packit_service/worker/handlers/mixin.py
+++ b/packit_service/worker/handlers/mixin.py
@@ -3,7 +3,7 @@
 
 import logging
 from abc import abstractmethod
-from typing import Any, Optional, Protocol, Iterator
+from typing import Any, Optional, Protocol, Iterator, Union
 from dataclasses import dataclass
 from packit.exceptions import PackitException
 from packit.config import PackageConfig, JobConfig
@@ -284,7 +284,7 @@ class GetSRPMBuild(Protocol):
 
 
 class GetCoprSRPMBuildMixin(GetSRPMBuild, GetCoprBuildEventMixin):
-    _build: Optional[SRPMBuildModel] = None
+    _build: Optional[Union[CoprBuildTargetModel, SRPMBuildModel]] = None
     _db_project_event: Optional[AbstractProjectEventDbType] = None
 
     @property

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -140,6 +140,10 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             else ""
         )
 
+        # do not add the package identifier if handling monorepo job
+        if self.job_config.package:
+            configured_identifier = ""
+
         copr_project_name = (
             f"{service_prefix}{namespace}-{self.project.repo}-{ref_identifier}"
             f"{configured_identifier}"

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -111,4 +111,5 @@ def test_system_api(client):
     for package in ["ogr", "packit", "specfile", "packit_service"]:
         assert package in response_data
         assert "version" in response_data[package]
-        assert len(response_data[package]["commit"]) == 7
+        if response_data[package]["commit"]:
+            assert len(response_data[package]["commit"]) == 7


### PR DESCRIPTION
Fixes #2055 #2058

---

RELEASE NOTES BEGIN
Copr builds configured as a monorepo job will now be built in one Copr project together. The bug with overwriting the statuses for monorepo jobs was fixed as well.
RELEASE NOTES END
