### PR TITLE
Add flask-talisman dependency to API

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -25,6 +25,7 @@
           - python3-lazy-object-proxy
           - python3-flask-restx
           - python3-flask-cors
+          - python3-flask-talisman
           - python3-flexmock # because of the hack during the alembic upgrade
           # (see d90948124e46_add_tables_for_triggers_koji_and_tests.py )
           - python-jwt


### PR DESCRIPTION
[Talisman](https://github.com/wntrblm/flask-talisman) is a small Flask extension that handles setting HTTP headers that can help protect against a few common web application security issues.

Merge before #2100 