### PR TITLE
Use Talisman to set HTTP security headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,6 @@ You can also run only certain pieces of packit-service for local development
 (e.g. worker, database or service/httpd).
 You also need to populate `secrets/packit/dev/` manually, for instructions
 see [deployment repo](https://github.com/packit/deployment/tree/main/secrets).
-Be sure to copy the content you need from `extra-vars.yml` to `packit-service.yaml`
 
 When you are running service/httpd and making requests to it,
 make sure that `server_name` configuration file in `packit-service.yaml` is set.

--- a/files/run_httpd.sh
+++ b/files/run_httpd.sh
@@ -32,8 +32,6 @@ exec mod_wsgi-express-3 start-server \
     --access-log \
     --log-to-terminal \
     --https-port "${HTTPS_PORT:-8443}" \
-    --https-only \
-    --hsts-policy "max-age=31536000;includeSubDomains" \
     --ssl-certificate-file /secrets/fullchain.pem \
     --ssl-certificate-key-file /secrets/privkey.pem \
     --server-name "${SERVER_NAME}" \

--- a/tests_openshift/service/conftest.py
+++ b/tests_openshift/service/conftest.py
@@ -11,11 +11,11 @@ def client():
     application.config["TESTING"] = True
     # this affects all tests actually, heads up!
     application.config["SERVER_NAME"] = "localhost:5000"
-    application.config["PREFERRED_URL_SCHEME"] = "http"
+    application.config["PREFERRED_URL_SCHEME"] = "https"
 
     with application.test_client() as client:
         # the first call usually fails
-        client.get("http://localhost:5000/api/")
+        client.get("https://localhost:5000/api/")
         yield client
 
 


### PR DESCRIPTION
See [Talisman docs](https://github.com/wntrblm/flask-talisman#talisman-http-security-headers-for-flask) for what it does by default.

Regarding the content-security-policy:
- I started with the default value, i.e. `default-src: 'self', 'object-src': 'none'`
- added the `image-src` to be able to load icons
- added the `style-src` & `script-src` because of python-restx/flask-restx#252

Related to packit/private#28