### PR TITLE
Install sandcastle dependencies as RPMs

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -30,6 +30,14 @@
           - python3-fasjson-client
           - python3-gevent # concurrency pool, see run_worker.sh
           - bodhi-client
+          # sandcastle deps
+          - python3-certifi
+          - python3-charset-normalizer
+          - python3-google-auth
+          - python3-oauthlib
+          - python3-pyyaml
+          - python3-requests-oauthlib
+          - python3-websocket-client
         state: present
         install_weak_deps: False
     - name: Install pip deps


### PR DESCRIPTION
Trying to workaround [failing reverse-dep-packit-service-tests in packit](https://softwarefactory-project.io/logs/08/2008/22b8bfa7af810e8c75cfdab8edcfb208b1442d53/check/reverse-dep-packit-service-tests/b340316/job-output.txt.gz):
```
packit_service/worker/helpers/build/build_helper.py:10: in <module>
    from kubernetes.client.rest import ApiException
/usr/local/lib/python3.9/site-packages/kubernetes/__init__.py:20: in <module>
    import kubernetes.config
/usr/local/lib/python3.9/site-packages/kubernetes/config/__init__.py:17: in <module>
    from .kube_config import (list_kube_config_contexts, load_kube_config,
/usr/local/lib/python3.9/site-packages/kubernetes/config/kube_config.py:33: in <module>
    from requests_oauthlib import OAuth2Session
/usr/local/lib/python3.9/site-packages/requests_oauthlib/__init__.py:4: in <module>
    from .oauth1_session import OAuth1Session
/usr/local/lib/python3.9/site-packages/requests_oauthlib/oauth1_session.py:12: in <module>
    from oauthlib.oauth1 import SIGNATURE_HMAC, SIGNATURE_RSA, SIGNATURE_TYPE_AUTH_HEADER
E   ImportError: cannot import name 'SIGNATURE_RSA' from 'oauthlib.oauth1' (/usr/lib/python3.9/site-packages/oauthlib/oauth1/__init__.py)
```

I don't know what's going on there (I haven't been able to reproduce), but the `/usr/local/lib/python3.9` vs. `/usr/lib/python3.9` looks suspicious to me.