### PR TITLE
Specify add_pr_instructions in sync_release

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -229,6 +229,7 @@ class AbstractSyncReleaseHandler(
                 local_pr_branch_suffix=branch_suffix,
                 use_downstream_specfile=is_pull_from_upstream_job,
                 sync_default_files=not is_pull_from_upstream_job,
+                add_pr_instructions=True,
             )
         except PackitDownloadFailedException as ex:
             # the archive has not been uploaded to PyPI yet

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -136,6 +136,7 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         local_pr_branch_suffix="update-pull_from_upstream",
         use_downstream_specfile=True,
         sync_default_files=False,
+        add_pr_instructions=True,
     ).and_return(flexmock(url="some_url")).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2666,6 +2666,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
         local_pr_branch_suffix="update-pull_from_upstream",
         use_downstream_specfile=True,
         sync_default_files=False,
+        add_pr_instructions=True,
     ).and_return(flexmock(url="some_url")).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -164,6 +164,7 @@ def test_dist_git_push_release_handle(github_release_webhook, propose_downstream
         local_pr_branch_suffix="update-propose_downstream",
         use_downstream_specfile=False,
         sync_default_files=True,
+        add_pr_instructions=True,
     ).and_return(flexmock(url="some_url")).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -286,6 +287,7 @@ def test_dist_git_push_release_handle_multiple_branches(
             local_pr_branch_suffix="update-propose_downstream",
             use_downstream_specfile=False,
             sync_default_files=True,
+            add_pr_instructions=True,
         ).and_return(flexmock(url="some_url")).once()
 
         flexmock(ProposeDownstreamJobHelper).should_receive(
@@ -407,6 +409,7 @@ def test_dist_git_push_release_handle_one_failed(
                 local_pr_branch_suffix="update-propose_downstream",
                 use_downstream_specfile=False,
                 sync_default_files=True,
+                add_pr_instructions=True,
             ).and_return(flexmock(url="some_url")).once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
@@ -424,6 +427,7 @@ def test_dist_git_push_release_handle_one_failed(
                 local_pr_branch_suffix="update-propose_downstream",
                 use_downstream_specfile=False,
                 sync_default_files=True,
+                add_pr_instructions=True,
             ).and_raise(Exception, f"Failed {model.branch}").once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
@@ -652,6 +656,7 @@ def test_retry_propose_downstream_task(
         local_pr_branch_suffix="update-propose_downstream",
         use_downstream_specfile=False,
         sync_default_files=True,
+        add_pr_instructions=True,
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()
@@ -756,6 +761,7 @@ def test_dont_retry_propose_downstream_task(
         local_pr_branch_suffix="update-propose_downstream",
         use_downstream_specfile=False,
         sync_default_files=True,
+        add_pr_instructions=True,
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -151,6 +151,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
         local_pr_branch_suffix="update-propose_downstream",
         use_downstream_specfile=False,
         sync_default_files=True,
+        add_pr_instructions=True,
     ).and_return(flexmock(url="some_url")).times(1 if success else 0)
     flexmock(shutil).should_receive("rmtree").with_args("")
 


### PR DESCRIPTION
Related to packit/packit#1915

---

RELEASE NOTES BEGIN
Packit now includes instructions on how to checkout the dist-git PR locally when syncing the release.
RELEASE NOTES END
