### PR TITLE
Celery 5.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-BASE_IMAGE ?= quay.io/packit/base
 # true|false
 PULL_BASE_IMAGE ?= true
 SERVICE_IMAGE ?= quay.io/packit/packit-service:dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   postgres:
     container_name: postgres
-    image: quay.io/sclorg/postgresql-13-c9s
+    image: quay.io/sclorg/postgresql-15-c9s
     environment:
       POSTGRESQL_USER: packit
       POSTGRESQL_PASSWORD: secret-password

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -50,7 +50,7 @@
           - urllib3<1.27
           - sentry-sdk
           - syslog-rfc5424-formatter # Logging to Splunk
-          - celery==5.2.* # celery-5.3.0b1 doesn't play well with flower
+          - celery==5.3.* # RHBZ#2032543
     - name: Check if all pip packages have all dependencies installed
       command: pip check
     - import_tasks: tasks/setup-copr-repos.yaml

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -40,7 +40,7 @@
           - urllib3<1.27
           - sentry-sdk[flask]
           - syslog-rfc5424-formatter
-          - celery==5.2.* # RPM not available on c9s
+          - celery==5.3.* # RHBZ#2032543
           - flask-cors # RHBZ#2100076
           - flexmock # because of alembic (d90948124e46_..._.py )
     - name: Check if all pip packages have all dependencies installed


### PR DESCRIPTION
After bumping the base image to `F37` we switched (c57eef6a) from `celery-5.3.0b1.fc37` RPM to `5.2.7` from PyPI because Flower thought retried tasks had failed.

Meanwhile, celery moved from `5.3.0b1` to `5.3.1` and Flower from `v1.2.0` to `v2.0.0`, so let's try again.

There's however no celery in EPEL so we need to use 5.3 from PyPI.