### PR TITLE
Add another non copyable object to the list

### DIFF
--- a/packit_service/worker/events/copr.py
+++ b/packit_service/worker/events/copr.py
@@ -133,10 +133,12 @@ class AbstractCoprBuildEvent(AbstractResultEvent):
 
         return True
 
+    def get_non_serializable_attributes(self):
+        return super().get_non_serializable_attributes() + ["build"]
+
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
         result = super().get_dict()
         result["topic"] = result["topic"].value
-        result.pop("build")
         return result
 
     def get_copr_build_url(self) -> str:

--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -267,12 +267,18 @@ class Event:
         """
         return {k: copy.deepcopy(v) for k, v in d.items() if k not in skip}
 
+    def get_non_serializable_attributes(self):
+        return [
+            "_db_project_event",
+            "_project",
+            "_base_project",
+            "_package_config",
+        ]
+
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
         d = default_dict or self.__dict__
         # whole dict has to be JSON serializable because of redis
-        d = self.make_serializable(
-            d, ["_db_project_event", "_project", "_base_project", "_package_config"]
-        )
+        d = self.make_serializable(d, self.get_non_serializable_attributes())
         d["event_type"] = self.__class__.__name__
 
         # we are trying to be lazy => don't touch database if it is not needed


### PR DESCRIPTION
The build object belongs only to the copr events.

Should fix #2120 which is still failing.