### PR TITLE
fix(tf): switch to ‹test.tmt›

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -356,13 +356,13 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         payload_["notification"]["webhook"].pop("token")
         return payload_
 
-    def _construct_fmf_payload(self) -> dict:
-        fmf = {
+    def _construct_test_payload(self) -> dict:
+        tmt = {
             "url": self.fmf_url,
             "path": self.fmf_path,
         }
         if self.fmf_ref:
-            fmf["ref"] = self.fmf_ref
+            tmt["ref"] = self.fmf_ref
 
             # We assign a commit hash for merging only if:
             # • there are no custom fmf tests set
@@ -372,12 +372,12 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
                 and self.job_config.merge_pr_in_ci
                 and self.target_branch_sha
             ):
-                fmf["merge_sha"] = self.target_branch_sha
+                tmt["merge_sha"] = self.target_branch_sha
 
         if self.tmt_plan:
-            fmf["name"] = self.tmt_plan
+            tmt["name"] = self.tmt_plan
 
-        return fmf
+        return tmt
 
     @classmethod
     def _merge_payload_with_extra_params(cls, payload: Any, params: Any):
@@ -440,7 +440,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             build: The related copr build.
         """
         distro, arch = target.rsplit("-", 1)
-        fmf = self._construct_fmf_payload()
+        tmt = self._construct_test_payload()
 
         if build is not None:
             build_log_url = build.build_logs_url
@@ -516,7 +516,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         payload = {
             "api_key": self.tft_token,
             "test": {
-                "fmf": fmf,
+                "tmt": tmt,
             },
             "environments": [environment],
             "notification": {
@@ -550,8 +550,8 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
     def _payload_install_test(self, build_id: int, target: str, compose: str) -> dict:
         """
-        If the project doesn't use fmf, but still wants to run tests in TF.
-        TF provides 'installation test', we request it in ['test']['fmf']['url'].
+        If the project doesn't use tmt, but still wants to run tests in TF.
+        TF provides 'installation test', we request it in ['test']['tmt']['url'].
         We don't specify 'artifacts' as in _payload(), but 'variables'.
         """
         copr_build = CoprBuildTargetModel.get_by_build_id(build_id)
@@ -559,7 +559,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         return {
             "api_key": self.service_config.testing_farm_secret,
             "test": {
-                "fmf": {
+                "tmt": {
                     "url": TESTING_FARM_INSTALLABILITY_TEST_URL,
                     "ref": TESTING_FARM_INSTALLABILITY_TEST_REF,
                     "name": "/packit/installation",

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -584,7 +584,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     payload = {
         "api_key": "secret token",
         "test": {
-            "fmf": {
+            "tmt": {
                 "url": "https://github.com/source/bar",
                 "ref": "0011223344",
                 "merge_sha": "deadbeef",

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -859,7 +859,7 @@ def test_pr_test_command_handler_retries(
     payload = {
         "api_key": "secret-token",
         "test": {
-            "fmf": {
+            "tmt": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
                 "merge_sha": "deadbeef",
@@ -1064,7 +1064,7 @@ def test_pr_test_command_handler_skip_build_option(
     payload = {
         "api_key": "secret-token",
         "test": {
-            "fmf": {
+            "tmt": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
                 "merge_sha": "deadbeef",
@@ -2121,7 +2121,7 @@ def test_pr_test_command_handler_multiple_builds(
     payload = {
         "api_key": "secret-token",
         "test": {
-            "fmf": {
+            "tmt": {
                 "url": "https://github.com/someone/hello-world",
                 "ref": "0011223344",
                 "merge_sha": "deadbeef",

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -729,7 +729,7 @@ def test_payload(
     if tmt_plan:
         expected_test["name"] = tmt_plan
 
-    assert payload["test"]["fmf"] == expected_test
+    assert payload["test"]["tmt"] == expected_test
 
     expected_environments = [
         {
@@ -1084,19 +1084,19 @@ def test_test_repo(
 
     payload = job_helper._payload(chroot, compose=compose, build=copr_build)
     assert payload.get("test")
-    assert payload["test"].get("fmf")
-    assert payload["test"]["fmf"].get("url") == result_url
-    assert payload["test"]["fmf"].get("ref") == result_ref
-    assert payload["test"]["fmf"].get("path") == result_path
+    assert payload["test"].get("tmt")
+    assert payload["test"]["tmt"].get("url") == result_url
+    assert payload["test"]["tmt"].get("ref") == result_ref
+    assert payload["test"]["tmt"].get("path") == result_path
 
     # if custom fmf tests are not defined or we're not merging, we don't pass the
     # merge SHA
     merge_sha_should_be_none = fmf_url or not merge_pr_in_ci
     assert (
-        merge_sha_should_be_none and payload["test"]["fmf"].get("merge_sha") is None
+        merge_sha_should_be_none and payload["test"]["tmt"].get("merge_sha") is None
     ) or (
         not merge_sha_should_be_none
-        and payload["test"]["fmf"].get("merge_sha") == "abcdefgh"
+        and payload["test"]["tmt"].get("merge_sha") == "abcdefgh"
     )
 
 


### PR DESCRIPTION
After talking to @fernflower on Slack about the TF configuration issue, I have noticed that Testing Farm is planning to deprecate the ‹test.fmf› part of the schema in favor of ‹test.tmt›, schemas of both match 1:1 and TF Team suggests preffering the new one, if possible.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
  - [x] I should probably check whether we're not using `test.fmf` in some of the examples
