### PR TITLE
Do not require a GitProject instance in pull-from-upstream

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -520,6 +520,9 @@ class PullFromUpstreamHandler(AbstractSyncReleaseHandler):
             celery_task=celery_task,
             sync_release_run_id=sync_release_run_id,
         )
+        # allow self.project and upstream git_project to be None
+        self._project_required = False
+        self.packit_api.up._project_required = False
         if self.data.event_type in (PullRequestCommentPagureEvent.__name__,):
             # use upstream project URL when retriggering from dist-git PR
             self._project_url = package_config.upstream_project_url

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -136,7 +136,8 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         "https://src.fedoraproject.org/rpms/redis"
     ).and_return(distgit_project)
     flexmock(service_config).should_receive("get_project").with_args(
-        "https://github.com/packit-service/hello-world"
+        "https://github.com/packit-service/hello-world",
+        False,
     ).and_return(project)
 
     flexmock(PackitAPI).should_receive("sync_release").with_args(

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2460,13 +2460,13 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
         True
     )
 
+    def _get_project(url, *_, **__):
+        if url == pagure_pr_comment_added["pullrequest"]["project"]["full_url"]:
+            return distgit_project
+        return project
+
     service_config = ServiceConfig().get_service_config()
-    flexmock(service_config).should_receive("get_project").with_args(
-        pagure_pr_comment_added["pullrequest"]["project"]["full_url"]
-    ).and_return(distgit_project)
-    flexmock(service_config).should_receive("get_project").with_args(
-        "https://github.com/packit-service/hello-world"
-    ).and_return(project)
+    flexmock(service_config).should_receive("get_project").replace_with(_get_project)
 
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="main",

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -165,7 +165,9 @@ def test_dist_git_push_release_handle(github_release_webhook, propose_downstream
     )
 
     flexmock(Allowlist, check_and_report=True)
-    ServiceConfig().get_service_config().get_project = lambda url: project
+    ServiceConfig().get_service_config().get_project = (
+        lambda url, required=True: project
+    )
 
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="main",
@@ -267,7 +269,9 @@ def test_dist_git_push_release_handle_multiple_branches(
     )
 
     flexmock(Allowlist, check_and_report=True)
-    ServiceConfig().get_service_config().get_project = lambda url: project
+    ServiceConfig().get_service_config().get_project = (
+        lambda url, required=True: project
+    )
 
     for model in propose_downstream_target_models:
         url = get_propose_downstream_info_url(model.id)
@@ -383,7 +387,9 @@ def test_dist_git_push_release_handle_one_failed(
         )
     )
     flexmock(Allowlist, check_and_report=True)
-    ServiceConfig().get_service_config().get_project = lambda url: project
+    ServiceConfig().get_service_config().get_project = (
+        lambda url, required=True: project
+    )
     failed_branch = fedora_branches[1]
 
     for model in propose_downstream_target_models:
@@ -538,7 +544,9 @@ def test_dist_git_push_release_handle_all_failed(
     )
 
     flexmock(Allowlist, check_and_report=True)
-    ServiceConfig().get_service_config().get_project = lambda url: project
+    ServiceConfig().get_service_config().get_project = (
+        lambda url, required=True: project
+    )
 
     flexmock(PackitAPI).should_receive("sync_release").and_raise(
         Exception, "Failed"
@@ -641,7 +649,9 @@ def test_retry_propose_downstream_task(
     )
 
     flexmock(Allowlist, check_and_report=True)
-    ServiceConfig().get_service_config().get_project = lambda url: project
+    ServiceConfig().get_service_config().get_project = (
+        lambda url, required=True: project
+    )
 
     flexmock(AddReleaseEventToDb).should_receive("db_project_object").and_return(
         flexmock(
@@ -746,7 +756,9 @@ def test_dont_retry_propose_downstream_task(
     flexmock(DistGit).should_receive("local_project").and_return(lp)
 
     flexmock(Allowlist, check_and_report=True)
-    ServiceConfig().get_service_config().get_project = lambda url: project
+    ServiceConfig().get_service_config().get_project = (
+        lambda url, required=True: project
+    )
 
     flexmock(AddReleaseEventToDb).should_receive("db_project_object").and_return(
         flexmock(


### PR DESCRIPTION
Fixes #1907.

Merge after https://github.com/packit/packit/pull/2032.

Notes for reviewers:

Not sure if setting namespace and repo name to `None` won't break anything in dashboard for example. Would it be better to try to somehow extract the values from `project_url`?

https://github.com/packit/packit-service/blob/313cb23407e18b54bedb61dcf28b9c669ad9f8a2/packit_service/worker/events/event.py#L203

RELEASE NOTES BEGIN
pull-from-upstream can now be used with upstream repos that are not hosted on a supported git forge.
RELEASE NOTES END
