### PR TITLE
Implement pre-check for filtering tags when syncing release

### DIFF
--- a/packit_service/worker/checker/distgit.py
+++ b/packit_service/worker/checker/distgit.py
@@ -2,22 +2,22 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import re
 
 from packit.config.aliases import get_branches
-
 from packit_service.constants import MSG_GET_IN_TOUCH
-
 from packit_service.worker.checker.abstract import Checker, ActorChecker
 from packit_service.worker.events import (
     PushPagureEvent,
     IssueCommentEvent,
     IssueCommentGitlabEvent,
 )
-from packit_service.worker.events.pagure import PullRequestCommentPagureEvent
 from packit_service.worker.events.new_hotness import NewHotnessUpdateEvent
+from packit_service.worker.events.pagure import PullRequestCommentPagureEvent
 from packit_service.worker.handlers.mixin import GetProjectToSyncMixin
 from packit_service.worker.mixin import (
     GetPagurePullRequestMixin,
+    GetSyncReleaseTagMixin,
 )
 from packit_service.worker.reporting import report_in_issue_repository
 
@@ -199,3 +199,26 @@ class ValidInformationForPullFromUpstream(Checker, GetPagurePullRequestMixin):
             )
 
         return valid
+
+
+class IsUpstreamTagMatchingConfig(Checker, GetSyncReleaseTagMixin):
+    def pre_check(self) -> bool:
+        if upstream_tag_include := self.job_config.upstream_tag_include:
+            matching_include_regex = re.match(upstream_tag_include, self.tag)
+            if not matching_include_regex:
+                logger.info(
+                    f"Tag {self.tag} doesn't match the upstream_tag_include {upstream_tag_include} "
+                    f"from the config. Skipping the syncing."
+                )
+                return False
+
+        if upstream_tag_exclude := self.job_config.upstream_tag_exclude:
+            matching_exclude_regex = re.match(upstream_tag_exclude, self.tag)
+            if matching_exclude_regex:
+                logger.info(
+                    f"Tag {self.tag} matches the upstream_tag_exclude {upstream_tag_exclude} "
+                    f"from the config. Skipping the syncing."
+                )
+                return False
+
+        return True

--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -196,6 +196,19 @@ class PackitAPIWithUpstreamMixin(PackitAPIProtocol):
             self._packit_api.clean()
 
 
+class GetSyncReleaseTagMixin(PackitAPIWithUpstreamMixin):
+    _tag: Optional[str] = None
+
+    @property
+    def tag(self) -> Optional[str]:
+        self._tag = self.data.tag_name
+        if not self._tag:
+            # there is no tag information when retriggering pull-from-upstream
+            # from dist-git PR
+            self._tag = self.packit_api.up.get_last_tag()
+        return self._tag
+
+
 class LocalProjectMixin(Config):
     _local_project: Optional[LocalProject] = None
 


### PR DESCRIPTION
Fixes #2118

---

RELEASE NOTES BEGIN
It is now possible to filter out tags Packit should react to for syncing the release via new configuration options `upstream_tag_include` and `upstream_tag_exclude` that accept Python regexes.
RELEASE NOTES END
