### PR TITLE
Make pull-from-upstream retrigger work with upstream project

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -520,12 +520,12 @@ class PullFromUpstreamHandler(AbstractSyncReleaseHandler):
             celery_task=celery_task,
             sync_release_run_id=sync_release_run_id,
         )
-        # allow self.project and upstream git_project to be None
-        self._project_required = False
-        self.packit_api.up._project_required = False
         if self.data.event_type in (PullRequestCommentPagureEvent.__name__,):
             # use upstream project URL when retriggering from dist-git PR
             self._project_url = package_config.upstream_project_url
+        # allow self.project and upstream git_project to be None
+        self._project_required = False
+        self.packit_api.up._project_required = False
 
     @staticmethod
     def get_checkers() -> Tuple[Type[Checker], ...]:


### PR DESCRIPTION
`_project_url` has to be set before accessing `Upstream` instance, otherwise it's too late as `GitProject` is already instantiated from dist-git repo.

Follow-up to #2137.