### PR TITLE
Fix getting test targets with build target overrides

### DIFF
--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -331,7 +331,7 @@ class BaseBuildJobHelper(BaseJobHelper):
 
         return (
             configured_targets & targets_override
-            if targets_override
+            if self.build_targets_override or self.tests_targets_override
             else configured_targets
         )
 

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -1321,6 +1321,24 @@ def test_build_targets_overrides(
             {"centos-7-ppc64le"},
             id="default_mapping_test_override_different_arch",
         ),
+        pytest.param(
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    packages={
+                        "package": CommonPackageConfig(
+                            _targets=["epel-7-x86_64"],
+                        )
+                    },
+                )
+            ],
+            JobConfigTriggerType.pull_request,
+            {"fedora-rawhide-x86_64"},
+            None,
+            set(),
+            id="build-target-not-in-test",
+        ),
     ],
 )
 def test_tests_targets_overrides(


### PR DESCRIPTION
The targets_override can be empty if there is not matching configured test target, therefore check the *_override respectively

Fixes #2119


---

RELEASE NOTES BEGIN
We have fixed the bug resulting in incorrect reporting for tests when retriggering a build of a different target that was not configured for tests.
RELEASE NOTES END
