### PR TITLE
Move upstream tag check to sync release task

### DIFF
--- a/packit_service/worker/checker/distgit.py
+++ b/packit_service/worker/checker/distgit.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-import re
 
 from packit.config.aliases import get_branches
 from packit_service.constants import MSG_GET_IN_TOUCH
@@ -17,7 +16,6 @@ from packit_service.worker.events.pagure import PullRequestCommentPagureEvent
 from packit_service.worker.handlers.mixin import GetProjectToSyncMixin
 from packit_service.worker.mixin import (
     GetPagurePullRequestMixin,
-    GetSyncReleaseTagMixin,
 )
 from packit_service.worker.reporting import report_in_issue_repository
 
@@ -199,26 +197,3 @@ class ValidInformationForPullFromUpstream(Checker, GetPagurePullRequestMixin):
             )
 
         return valid
-
-
-class IsUpstreamTagMatchingConfig(Checker, GetSyncReleaseTagMixin):
-    def pre_check(self) -> bool:
-        if upstream_tag_include := self.job_config.upstream_tag_include:
-            matching_include_regex = re.match(upstream_tag_include, self.tag)
-            if not matching_include_regex:
-                logger.info(
-                    f"Tag {self.tag} doesn't match the upstream_tag_include {upstream_tag_include} "
-                    f"from the config. Skipping the syncing."
-                )
-                return False
-
-        if upstream_tag_exclude := self.job_config.upstream_tag_exclude:
-            matching_exclude_regex = re.match(upstream_tag_exclude, self.tag)
-            if matching_exclude_regex:
-                logger.info(
-                    f"Tag {self.tag} matches the upstream_tag_exclude {upstream_tag_exclude} "
-                    f"from the config. Skipping the syncing."
-                )
-                return False
-
-        return True

--- a/tests/unit/test_checkers.py
+++ b/tests/unit/test_checkers.py
@@ -17,7 +17,6 @@ from packit_service.worker.checker.copr import (
     IsJobConfigTriggerMatching as IsJobConfigTriggerMatchingCopr,
     IsPackageMatchingJobView,
 )
-from packit_service.worker.checker.distgit import IsUpstreamTagMatchingConfig
 from packit_service.worker.checker.koji import (
     IsJobConfigTriggerMatching as IsJobConfigTriggerMatchingKoji,
 )
@@ -590,71 +589,6 @@ def test_tf_comment_labels(comment, result):
 
     checker = IsLabelFromCommentMatching(
         package_config=package_config, job_config=job_config, event=event
-    )
-
-    assert checker.pre_check() == result
-
-
-@pytest.mark.parametrize(
-    "upstream_tag_include, upstream_tag_exclude, result",
-    (
-        pytest.param(
-            None,
-            None,
-            True,
-        ),
-        pytest.param(
-            None,
-            r"^.+\.2\..+",
-            True,
-        ),
-        pytest.param(
-            None,
-            r"^.+\.1\..+",
-            False,
-        ),
-        pytest.param(
-            r"^.+\.2\..+",
-            None,
-            False,
-        ),
-        pytest.param(
-            r"^.+\.1\..+",
-            None,
-            True,
-        ),
-        pytest.param(
-            r"^.+\.1\..+",
-            r"^2\..+",
-            False,
-        ),
-    ),
-)
-def test_sync_release_matching_tag(upstream_tag_include, upstream_tag_exclude, result):
-    package_config = flexmock(jobs=[])
-    job_config = flexmock(
-        type=JobType.pull_from_upstream,
-        trigger=JobConfigTriggerType.release,
-        targets={"fedora-37"},
-        upstream_tag_include=upstream_tag_include,
-        upstream_tag_exclude=upstream_tag_exclude,
-    )
-    git_project = flexmock(
-        namespace="packit",
-        repo="ogr",
-    )
-    flexmock(ConfigFromEventMixin).should_receive("project").and_return(git_project)
-
-    db_project_event = flexmock(
-        job_config_trigger_type=JobConfigTriggerType.release,
-        pr_id=1,
-    )
-    flexmock(EventData).should_receive("db_project_event").and_return(db_project_event)
-
-    checker = IsUpstreamTagMatchingConfig(
-        package_config=package_config,
-        job_config=job_config,
-        event={"tag_name": "2.1.1"},
     )
 
     assert checker.pre_check() == result


### PR DESCRIPTION
It has to be run in the task directly, and not as a pre-check, since pre-check is part of `process_message` task that doesn't run in the long-running worker. Long-running worker is needed here as the Local project is being accessed.

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
