### PR TITLE
Adjust pre-check for matching tag in sync release

### DIFF
--- a/packit_service/worker/checker/distgit.py
+++ b/packit_service/worker/checker/distgit.py
@@ -17,7 +17,6 @@ from packit_service.worker.events.pagure import PullRequestCommentPagureEvent
 from packit_service.worker.handlers.mixin import GetProjectToSyncMixin
 from packit_service.worker.mixin import (
     GetPagurePullRequestMixin,
-    GetSyncReleaseTagMixin,
 )
 from packit_service.worker.reporting import report_in_issue_repository
 
@@ -201,22 +200,29 @@ class ValidInformationForPullFromUpstream(Checker, GetPagurePullRequestMixin):
         return valid
 
 
-class IsUpstreamTagMatchingConfig(Checker, GetSyncReleaseTagMixin):
+class IsUpstreamTagMatchingConfig(Checker):
     def pre_check(self) -> bool:
+        tag = self.data.tag_name
+
+        # if the tag in event is None (pull-from-upstream retriggering), we will filter
+        # only matching tags in the handler directly
+        if not tag:
+            return True
+
         if upstream_tag_include := self.job_config.upstream_tag_include:
-            matching_include_regex = re.match(upstream_tag_include, self.tag)
+            matching_include_regex = re.match(upstream_tag_include, tag)
             if not matching_include_regex:
                 logger.info(
-                    f"Tag {self.tag} doesn't match the upstream_tag_include {upstream_tag_include} "
+                    f"Tag {tag} doesn't match the upstream_tag_include {upstream_tag_include} "
                     f"from the config. Skipping the syncing."
                 )
                 return False
 
         if upstream_tag_exclude := self.job_config.upstream_tag_exclude:
-            matching_exclude_regex = re.match(upstream_tag_exclude, self.tag)
+            matching_exclude_regex = re.match(upstream_tag_exclude, tag)
             if matching_exclude_regex:
                 logger.info(
-                    f"Tag {self.tag} matches the upstream_tag_exclude {upstream_tag_exclude} "
+                    f"Tag {tag} matches the upstream_tag_exclude {upstream_tag_exclude} "
                     f"from the config. Skipping the syncing."
                 )
                 return False


### PR DESCRIPTION
If the tag in the event is None (pull-from-upstream triggered by comment), don't check the match with `upstream_tag_include` and `upstream_tag_exclude` as the tags will be filtered out considering these values when obtaining the tag directly in the handler task.


---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
