### PR TITLE
fix: typo in the footers of GitHub check runs

### DIFF
--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -35,7 +35,7 @@ NEWS_FOOTER = [
     "Take a look [here](https://packit.dev/posts/downstream-automation/) to know more.",
     "Want to use a build from a different project when testing? "
     "Take a look [here](https://packit.dev/posts/testing-farm-triggering/) to know more.",
-    "Courious how Packit handles the Release field during propose-downstream? "
+    "Curious how Packit handles the Release field during propose-downstream? "
     "Take a look [here](https://packit.dev/posts/release-field-handling/) to know more.",
     "Did you know Packit is on Mastodon? Or, more specifically, on Fosstodon? "
     "Follow [@packit@fosstodon.org](https://fosstodon.org/@packit) "


### PR DESCRIPTION
Fixes #2151