### PR TITLE
Adjust Copr build epoch handling for None

### DIFF
--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -70,7 +70,8 @@ def get_package_nvrs(built_packages: List[dict]) -> List[str]:
         if package["arch"] == "src":
             continue
 
-        epoch = f"{package['epoch']}:" if package["epoch"] != 0 else ""
+        epoch = f"{package['epoch']}:" if package["epoch"] else ""
+
         packages.append(
             f"{package['name']}-{epoch}{package['version']}-{package['release']}.{package['arch']}"
         )

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -325,6 +325,20 @@ def test_distro2compose_for_aarch64(target, compose, use_internal_tf):
             ],
             ["cool-project-0.1.0-2.el8.x86_64"],
         ),
+        (
+            "123456",
+            "centos-stream-x86_64",
+            [
+                {
+                    "arch": "x86_64",
+                    "epoch": None,
+                    "name": "cool-project",
+                    "release": "2.el8",
+                    "version": "0.1.0",
+                },
+            ],
+            ["cool-project-0.1.0-2.el8.x86_64"],
+        ),
     ],
 )
 def test_artifact(


### PR DESCRIPTION
Adjust how we include the epoch in the Testing Farm payload. We get the value from Copr API and the behaviour there recently changed: https://github.com/fedora-copr/copr/pull/2876


---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
