### PR TITLE
Get the build id from the event.

### DIFF
--- a/packit_service/worker/checker/copr.py
+++ b/packit_service/worker/checker/copr.py
@@ -87,7 +87,7 @@ class IsPackageMatchingJobView(Checker, GetCoprSRPMBuildMixin):
             return True
 
         logger.debug(
-            f"The Copr build {self.build.build_id} (pkg={build_for_package}) "
+            f"The Copr build {self.copr_event.build_id} (pkg={build_for_package}) "
             f"does not match the package from the configuration "
             f"({self.job_config.package})."
         )

--- a/tests/unit/test_checkers.py
+++ b/tests/unit/test_checkers.py
@@ -35,6 +35,7 @@ from packit_service.worker.checker.vm_image import (
 )
 from packit_service.worker.events import (
     PullRequestGithubEvent,
+    AbstractCoprBuildEvent,
 )
 from packit_service.worker.events.event import EventData
 from packit_service.worker.events.github import (
@@ -363,13 +364,17 @@ def test_copr_build_is_package_matching_job_view():
         )
     ]
 
+    flexmock(AbstractCoprBuildEvent).should_receive("from_event_dict").and_return(
+        flexmock(build_id=123)
+    )
+
     checker = IsPackageMatchingJobView(
         flexmock(),
         jobs[0],
         {"pkg": "package"},
     )
     checker._build = (
-        flexmock(build_id=123)
+        flexmock()
         .should_receive("get_package_name")
         .and_return("package-b")
         .once()


### PR DESCRIPTION
The SRPMBuildModel, unlike the CoprBuildModel,
 has not a build id associated.

Take the build id  from the event even though the package name is taken from the db.