### PR TITLE
Use project event model ID in reporting external ID

### DIFF
--- a/packit_service/worker/helpers/job_helper.py
+++ b/packit_service/worker/helpers/job_helper.py
@@ -159,8 +159,8 @@ class BaseJobHelper:
                 project=self.project,
                 commit_sha=self.metadata.commit_sha,
                 packit_user=self.service_config.get_github_account_name(),
-                project_object_id=self._db_project_object.id
-                if self._db_project_object
+                project_event_id=self.db_project_event.id
+                if self.db_project_event
                 else None,
                 pr_id=self.metadata.pr_id,
             )

--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -100,7 +100,7 @@ class StatusReporter:
         project: GitProject,
         commit_sha: str,
         packit_user: str,
-        project_object_id: Optional[int] = None,
+        project_event_id: Optional[int] = None,
         pr_id: Optional[int] = None,
     ):
         logger.debug(
@@ -111,7 +111,7 @@ class StatusReporter:
         self._packit_user = packit_user
 
         self.commit_sha: str = commit_sha
-        self.project_object_id: int = project_object_id
+        self.project_event_id: int = project_event_id
         self.pr_id: Optional[int] = pr_id
 
     @classmethod
@@ -120,7 +120,7 @@ class StatusReporter:
         project: GitProject,
         commit_sha: str,
         packit_user: str,
-        project_object_id: Optional[int] = None,
+        project_event_id: Optional[int] = None,
         pr_id: Optional[int] = None,
     ) -> "StatusReporter":
         """
@@ -133,7 +133,7 @@ class StatusReporter:
             reporter = StatusReporterGitlab
         elif isinstance(project, PagureProject):
             reporter = StatusReporterPagure
-        return reporter(project, commit_sha, packit_user, project_object_id, pr_id)
+        return reporter(project, commit_sha, packit_user, project_event_id, pr_id)
 
     @property
     def project_with_commit(self) -> GitProject:
@@ -517,9 +517,7 @@ class StatusReporterGithubChecks(StatusReporterGithubStatuses):
                 state_to_set if isinstance(state_to_set, GithubCheckRunResult) else None
             )
 
-            external_id = (
-                str(self.project_object_id) if self.project_object_id else None
-            )
+            external_id = str(self.project_event_id) if self.project_event_id else None
 
             self.project_with_commit.create_check_run(
                 name=check_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -377,7 +377,7 @@ def add_pull_request_event_with_sha_0011223344():
         project_event_model_type=ProjectEventModelType.pull_request,
     )
     db_project_event = (
-        flexmock()
+        flexmock(id=123)
         .should_receive("get_project_event_object")
         .and_return(db_project_object)
         .mock()

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -255,7 +255,7 @@ def test_run_copr_build_from_source_script(github_pr_event, srpm_build_deps):
     ).and_return(db_project_object)
     helper = build_helper(
         event=github_pr_event,
-        db_project_event=flexmock()
+        db_project_event=flexmock(id=123)
         .should_receive("get_project_event_object")
         .and_return(db_project_object)
         .mock(),
@@ -355,7 +355,7 @@ def test_run_copr_build_from_source_script_github_outage_retry(
 ):
     helper = build_helper(
         event=github_pr_event,
-        db_project_event=flexmock()
+        db_project_event=flexmock(id=123)
         .should_receive("get_project_event_object")
         .and_return(
             flexmock(

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -227,7 +227,7 @@ def test_set_status_github_check(
         project=project,
         commit_sha=commit_sha,
         pr_id=pr_id,
-        project_object_id=project_object_id,
+        project_event_id=project_object_id,
         packit_user="packit",
     )
     act_upon = flexmock(GithubProject)
@@ -444,7 +444,7 @@ def test_status_instead_check(
     reporter = StatusReporter.get_instance(
         project=project,
         commit_sha=commit_sha,
-        project_object_id=event_id,
+        project_event_id=event_id,
         pr_id=pr_id,
         packit_user="packit",
     )

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -164,7 +164,7 @@ def test_testing_farm_response(
         )
         .should_receive("get_project_event_model")
         .and_return(
-            flexmock()
+            flexmock(id=123)
             .should_receive("get_project_event_object")
             .and_return(
                 flexmock(


### PR DESCRIPTION
When creating a Github check run, use the db ID of project event model and not project object model so that it can be correctly parsed backed when rerunning.

Fixes #2160


---

RELEASE NOTES BEGIN
We have fixed a bug causing broken retriggering of Github checks.
RELEASE NOTES END
