### PR TITLE
Allow to retrigger pull-from-upstream with config from a PR

### DIFF
--- a/packit_service/worker/events/pagure.py
+++ b/packit_service/worker/events/pagure.py
@@ -114,7 +114,11 @@ class PullRequestCommentPagureEvent(AbstractPRCommentEvent, AbstractPagureEvent)
         commands = get_packit_commands_from_comment(
             comment, ServiceConfig.get_service_config().comment_command_prefix
         )
-        if commands and commands[0] == "pull-from-upstream":
+        if not commands:
+            return super().get_packages_config()
+        command = commands[0]
+        args = commands[1] if len(commands) > 1 else ""
+        if command == "pull-from-upstream" and "--with-pr-config" not in args:
             # when retriggering pull-from-upstream from PR comment
             # take packages config from the downstream default branch
             logger.debug(


### PR DESCRIPTION
It makes sense for `/packit pull-from-upstream` to retrigger the job with config taken from the main dist-git branch, but sometimes it could be useful to test config changes in an open dist-git PR, before merging it.

This commit allows that using `/packit pull-from-upstream --with-pr-config`.

Related to #2140.