### PR TITLE
Fix multiple run models exception for API

### DIFF
--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -108,8 +108,8 @@ def mock_pr_functionality(request):
 
     pr_model = (
         flexmock(PullRequestModel(pr_id=123))
-        .should_receive("get_project_event")
-        .and_return(flexmock(commit_sha="12345"))
+        .should_receive("get_project_event_models")
+        .and_return([flexmock(commit_sha="12345")])
         .mock()
     )
     project_event = (
@@ -155,8 +155,8 @@ def mock_push_functionality(request):
 
     branch_model = (
         flexmock(GitBranchModel(name="main"))
-        .should_receive("get_project_event")
-        .and_return(flexmock(commit_sha="12345"))
+        .should_receive("get_project_event_models")
+        .and_return([flexmock(commit_sha="12345")])
         .mock()
     )
     project_event = (
@@ -203,8 +203,8 @@ def mock_release_functionality(request):
 
     release_model = (
         flexmock(ProjectReleaseModel(tag_name="0.1.0"))
-        .should_receive("get_project_event")
-        .and_return(flexmock(commit_sha="12345"))
+        .should_receive("get_project_event_models")
+        .and_return([flexmock(commit_sha="12345")])
         .mock()
     )
     project_event = (

--- a/tests_openshift/conftest.py
+++ b/tests_openshift/conftest.py
@@ -428,6 +428,24 @@ def srpm_build_model_with_new_run_for_pr(pr_project_event_model):
 
 
 @pytest.fixture()
+def srpm_build_model_with_new_run_for_pr_different_commit(pr_project_event_model):
+    _, event = ProjectEventModel.add_pull_request_event(
+        pr_id=SampleValues.pr_id,
+        namespace=SampleValues.repo_namespace,
+        repo_name=SampleValues.repo_name,
+        project_url=SampleValues.project_url,
+        commit_sha="different-sha",
+    )
+    srpm_model, run_model = SRPMBuildModel.create_with_new_run(
+        project_event_model=event,
+        package_name=SampleValues.package_name,
+    )
+    srpm_model.set_logs(SampleValues.srpm_logs)
+    srpm_model.set_status(BuildStatus.success)
+    yield srpm_model, run_model
+
+
+@pytest.fixture()
 def srpm_build_model_with_new_run_and_tf_for_branch(
     srpm_build_model_with_new_run_for_branch,
 ):
@@ -511,6 +529,28 @@ def different_issue_model(different_issue_project_event_model):
 @pytest.fixture()
 def a_copr_build_for_pr(srpm_build_model_with_new_run_for_pr):
     _, run_model = srpm_build_model_with_new_run_for_pr
+    group = CoprBuildGroupModel.create(run_model)
+    copr_build_model = CoprBuildTargetModel.create(
+        build_id=SampleValues.build_id,
+        project_name=SampleValues.project,
+        owner=SampleValues.owner,
+        web_url=SampleValues.copr_web_url,
+        target=SampleValues.target,
+        status=SampleValues.status_pending,
+        copr_build_group=group,
+    )
+    copr_build_model.set_build_logs_url(
+        "https://copr.somewhere/results/owner/package/target/build.logs"
+    )
+    copr_build_model.set_built_packages(SampleValues.built_packages)
+    yield copr_build_model
+
+
+@pytest.fixture()
+def a_copr_build_for_pr_different_commit(
+    srpm_build_model_with_new_run_for_pr_different_commit,
+):
+    _, run_model = srpm_build_model_with_new_run_for_pr_different_commit
     group = CoprBuildGroupModel.create(run_model)
     copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,

--- a/tests_openshift/database/test_models.py
+++ b/tests_openshift/database/test_models.py
@@ -776,6 +776,16 @@ def test_pr_get_copr_builds(
     assert not different_pr_model.get_copr_builds()
 
 
+def test_pr_multiple_commits_copr_builds(
+    clean_before_and_after, a_copr_build_for_pr, a_copr_build_for_pr_different_commit
+):
+    pr_model = a_copr_build_for_pr_different_commit.get_project_event_object()
+    copr_builds = pr_model.get_copr_builds()
+    assert a_copr_build_for_pr in copr_builds
+    assert a_copr_build_for_pr_different_commit in copr_builds
+    assert len(copr_builds) == 2
+
+
 def test_pr_get_koji_builds(
     clean_before_and_after, a_koji_build_for_pr, different_pr_model
 ):


### PR DESCRIPTION
The exception should not be raised, as we are getting project event from the project objects such as PR/branch push/release/issues and for these, there can be multiple project events (e.g. PR with multiple pushes). Fixes #2153

TODO:

- [x] Write new tests or update the old ones to cover new functionality.

---

RELEASE NOTES BEGIN
TODO
RELEASE NOTES END
