### PR TITLE
Move local-project dir inside sandcastle subfolder

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -256,3 +256,9 @@ DENIED_MSG = (
     f"You were denied from using Packit Service. If you think this was done by mistake, "
     f"please, [let us know]({CONTACTS_URL})."
 )
+
+# We want to be able to access both
+# upstream and downstream repos through the
+# shared sandcastle dir
+SANDCASTLE_DG_REPO_DIR = "dist-git"
+SANDCASTLE_LOCAL_PROJECT_DIR = "local-project"

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -399,8 +399,8 @@ class AbstractSyncReleaseHandler(
             )
         finally:
             # remove temporary dist-git clone after we're done here - context:
-            # 1. the dist-git repo is cloned on worker, not sandbox
-            # 2. it's stored in /tmp, not in the mirrored sandbox PV
+            # 1. the dist-git repo could be cloned on worker, not sandbox
+            # 2. in such case it's stored in /tmp, not in the mirrored sandbox PV
             # 3. it's not being cleaned up and it wastes pod's filesystem space
             shutil.rmtree(self.packit_api.dg.local_project.working_dir)
 

--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -4,6 +4,7 @@
 from abc import abstractmethod
 import logging
 import re
+from pathlib import Path
 from typing import Optional, Protocol, Union, List
 
 from fasjson_client import Client
@@ -27,6 +28,8 @@ from packit_service.worker.helpers.job_helper import BaseJobHelper
 
 from packit_service.constants import (
     FASJSON_URL,
+    SANDCASTLE_LOCAL_PROJECT_DIR,
+    SANDCASTLE_DG_REPO_DIR,
 )
 
 logger = logging.getLogger(__name__)
@@ -191,6 +194,8 @@ class PackitAPIWithUpstreamMixin(PackitAPIProtocol):
                 self.service_config,
                 self.job_config,
                 upstream_local_project=self.local_project,
+                dist_git_clone_path=Path(self.service_config.command_handler_work_dir)
+                / SANDCASTLE_DG_REPO_DIR,
             )
         return self._packit_api
 
@@ -219,7 +224,8 @@ class LocalProjectMixin(Config):
     def local_project(self) -> LocalProject:
         if not self._local_project:
             kwargs = dict(
-                working_dir=self.service_config.command_handler_work_dir,
+                working_dir=Path(self.service_config.command_handler_work_dir)
+                / SANDCASTLE_LOCAL_PROJECT_DIR,
                 cache=RepositoryCache(
                     cache_path=self.service_config.repository_cache,
                     add_new=self.service_config.add_repositories_to_repository_cache,

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -332,6 +332,10 @@ def test_dist_git_push_release_handle_multiple_branches(
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").times(3).and_return()
 
+    from packit_service.worker.handlers.distgit import shutil
+
+    flexmock(shutil).should_receive("rmtree").and_return()
+
     processing_results = SteveJobs().process_message(github_release_webhook)
     event_dict, job, job_config, package_config = get_parameters_from_results(
         processing_results
@@ -465,6 +469,10 @@ def test_dist_git_push_release_handle_one_failed(
 
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").times(3).and_return()
+
+    from packit_service.worker.handlers.distgit import shutil
+
+    flexmock(shutil).should_receive("rmtree").and_return()
 
     processing_results = SteveJobs().process_message(github_release_webhook)
     event_dict, job, job_config, package_config = get_parameters_from_results(


### PR DESCRIPTION
We need both upstream and dowstream repos in sandcastle shared folder.
For this reason I need to move the upstream repo from the root to a subfolder.

Fixes #1956 

Merge after packit/packit#2054

---

RELEASE NOTES BEGIN
Packit now sets `PACKIT_UPSTREAM_REPO` and `PACKIT_DOWNSTREAM_REPO` environment variables for release syncing actions. The variables represent paths where the respective git repositories are cloned
RELEASE NOTES END
