### PR TITLE
Check TF composes using regex matching

### DIFF
--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -1291,8 +1291,8 @@ def test_pr_test_command_handler_compose_not_present(
         "Testing Farm infrastructure.",
         check_names="testing-farm:fedora-rawhide-x86_64",
         url="",
-        markdown_content="The compose Fedora-Rawhide (from target fedora-rawhide) is not in "
-        "the list of available composes:\n"
+        markdown_content="The compose Fedora-Rawhide (from target fedora-rawhide) does not match "
+        "any compose in the list of available composes:\n"
         "{'some-other-compose'}. Please, check the targets defined in your test job configuration. "
         "If you think your configuration is correct, get "
         "in touch with [us](https://packit.dev/#contact).",

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -1,5 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+import re
 from datetime import datetime, timezone
 from typing import List
 
@@ -355,6 +356,20 @@ def test_artifact(
         artifact["packages"] = packages_to_send
 
     assert result == artifact
+
+
+@pytest.mark.parametrize(
+    ("compose", "composes", "result"),
+    [
+        ("Fedora-Cloud-Base-39", {re.compile("Fedora-Cloud-Base-.+")}, True),
+        ("Fedora-Cloud-Base-", {re.compile("Fedora-Cloud-Base-.+")}, False),
+        ("debezium-tf1", {re.compile("debezium-tf.*")}, True),
+        ("Fedora 38", {re.compile("Fedora 38")}, True),
+        ("Fedora 3", {re.compile("Fedora 38")}, False),
+    ],
+)
+def test_is_compose_matching(compose, composes, result):
+    assert TFJobHelper.is_compose_matching(compose, composes) is result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
TF started additionally exposing regexes on top of the exact compose names in the /composes/ endpoints, these changes adjust our code to that.

---

RELEASE NOTES BEGIN
Testing Farm started additionally exposing regexes on top of the exact compose names in the /composes/ endpoints, and we now support this as well when checking the validity of compose.
RELEASE NOTES END
