### PR TITLE
Disable jitter for Bodhi task

### DIFF
--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -126,7 +126,9 @@ class HandlerTaskWithRetry(Task):
 class BodhiHandlerTaskWithRetry(HandlerTaskWithRetry):
     # hardcode for creating bodhi updates to account for the tagging race condition
     max_retries = 5
-    retry_kwargs = {"max_retries": max_retries}
+    # also disable jitter for the same reason
+    retry_jitter = False
+    retry_kwargs = {"max_retries": max_retries, "retry_jitter": retry_jitter}
 
 
 @celery_app.task(


### PR DESCRIPTION
Let's try to disable the jitter so that we don't hit the race condition about build not being tagged yet.
Related to #1615


---

RELEASE NOTES BEGIN
We have disabled the jitter for retrying Bodhi update tasks to prevent race conditions causing not created updates.
RELEASE NOTES END
