### PR TITLE
Temporarily lock deepdiff version to fix CI failures

### DIFF
--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -19,4 +19,6 @@
           - pytest
           - pytest-cov
           - pytest-flask
-          - deepdiff
+          # the version lock can be removed once this is resolved:
+          # https://github.com/seperman/deepdiff/issues/416
+          - deepdiff==6.3.1


### PR DESCRIPTION
See: https://github.com/seperman/deepdiff/issues/416