### PR TITLE
feat(tf): provide ‹initiator› tmt context

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -503,7 +503,14 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         environment: Dict[str, Any] = {
             "arch": arch,
             "os": {"compose": compose},
-            "tmt": {"context": {"distro": distro, "arch": arch, "trigger": "commit"}},
+            "tmt": {
+                "context": {
+                    "distro": distro,
+                    "arch": arch,
+                    "trigger": "commit",
+                    "initiator": "packit",
+                }
+            },
             "variables": predefined_environment,
         }
         if artifacts:

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -605,6 +605,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
                         "distro": "fedora-rawhide",
                         "arch": "x86_64",
                         "trigger": "commit",
+                        "initiator": "packit",
                     }
                 },
                 "artifacts": [

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -875,6 +875,7 @@ def test_pr_test_command_handler_retries(
                         "distro": "fedora-rawhide",
                         "arch": "x86_64",
                         "trigger": "commit",
+                        "initiator": "packit",
                     }
                 },
                 "variables": {
@@ -1080,6 +1081,7 @@ def test_pr_test_command_handler_skip_build_option(
                         "distro": "fedora-rawhide",
                         "arch": "x86_64",
                         "trigger": "commit",
+                        "initiator": "packit",
                     }
                 },
                 "variables": {
@@ -2137,6 +2139,7 @@ def test_pr_test_command_handler_multiple_builds(
                         "distro": "fedora-rawhide",
                         "arch": "x86_64",
                         "trigger": "commit",
+                        "initiator": "packit",
                     }
                 },
                 "variables": {

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -765,7 +765,14 @@ def test_payload(
             "arch": arch,
             "os": {"compose": compose},
             "artifacts": artifacts,
-            "tmt": {"context": {"distro": distro, "arch": arch, "trigger": "commit"}},
+            "tmt": {
+                "context": {
+                    "distro": distro,
+                    "arch": arch,
+                    "trigger": "commit",
+                    "initiator": "packit",
+                }
+            },
             "variables": {
                 "PACKIT_BUILD_LOG_URL": log_url,
                 "PACKIT_COMMIT_SHA": commit_sha,


### PR DESCRIPTION
Provide initiator context for tmt that allows users run or skip certain tests when they are triggered by Packit.

Fixes #2175

<!-- notes for reviewers -->


---

RELEASE NOTES BEGIN
Packit now passes `initiator` context for tmt to the Testing Farm. You can use this option to run or skip certain tests when they're run by Packit.
RELEASE NOTES END
