### PR TITLE
Implement commenting on failure based on config

### DIFF
--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -311,6 +311,7 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
                 chroot=self.copr_event.chroot,
             )
             self.measure_time_after_reporting()
+            self.copr_build_helper.notify_about_failure_if_configured()
             self.build.set_status(BuildStatus.failure)
             return TaskResults(success=False, details={"msg": failed_msg})
 
@@ -370,6 +371,7 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
                 description=failed_msg,
                 url=url,
             )
+            self.copr_build_helper.notify_about_failure_if_configured()
             self.build.set_status(BuildStatus.failure)
             self.copr_build_helper.monitor_not_submitted_copr_builds(
                 len(self.copr_build_helper.build_targets), "srpm_failure"

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -225,6 +225,8 @@ class KojiTaskReportHandler(
                 url=url,
                 chroot=build.target,
             )
+            if self.koji_task_event.state == KojiTaskState.failed:
+                build_job_helper.notify_about_failure_if_configured()
 
         koji_build_logs = KojiTaskEvent.get_koji_build_logs_url(
             rpm_build_task_id=int(build.build_id),

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -404,6 +404,7 @@ class TestingFarmResultsHandler(
                 success=True, details={"msg": "Testing farm results already processed"}
             )
 
+        failure = False
         if self.result == TestingFarmResult.running:
             status = BaseCommitStatus.running
             summary = self.summary or "Tests are running ..."
@@ -416,6 +417,7 @@ class TestingFarmResultsHandler(
         else:
             status = BaseCommitStatus.failure
             summary = self.summary or "Tests failed ..."
+            failure = True
 
         if self.result == TestingFarmResult.running:
             self.pushgateway.test_runs_started.inc()
@@ -437,6 +439,8 @@ class TestingFarmResultsHandler(
             else self.log_url,
             links_to_external_services={"Testing Farm": self.log_url},
         )
+        if failure:
+            self.testing_farm_job_helper.notify_about_failure_if_configured()
 
         test_run_model.set_status(self.result, created=self.created)
 


### PR DESCRIPTION
If there is the failure_comment_message defined in the config, notify users via comment on failure using the configured message. Comment only once per commit SHA and job (utilising check of previous identical Packit comment).

Fixes #1911

TODO:


- [x] Update or write new documentation in `packit/packit.dev`. (packit/packit.dev#735)

---

RELEASE NOTES BEGIN
We have introduced a new configuration option `notifications.failure_comment.message` that enables notifying users on failure via a comment using the configured message.
RELEASE NOTES END
