### PR TITLE
Revert "Temporarily lock deepdiff version to fix CI failures"

### DIFF
--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -19,6 +19,4 @@
           - pytest
           - pytest-cov
           - pytest-flask
-          # the version lock can be removed once this is resolved:
-          # https://github.com/seperman/deepdiff/issues/416
-          - deepdiff==6.3.1
+          - deepdiff


### PR DESCRIPTION
This reverts commit f0ae0e49988f428c9969d2b0055db3f9e2bd401b.

The deepdiff bug has been fixed: https://github.com/seperman/deepdiff/commit/410019e