### PR TITLE
Pass bugs in pull-from-upstream

### DIFF
--- a/packit_service/worker/events/new_hotness.py
+++ b/packit_service/worker/events/new_hotness.py
@@ -20,15 +20,13 @@ logger = getLogger(__name__)
 @use_for_job_config_trigger(trigger_type=JobConfigTriggerType.release)
 class NewHotnessUpdateEvent(Event):
     def __init__(
-        self,
-        package_name: str,
-        version: str,
-        distgit_project_url: str,
+        self, package_name: str, version: str, distgit_project_url: str, bug_id: int
     ):
         super().__init__()
         self.package_name = package_name
         self.version = version
         self.distgit_project_url = distgit_project_url
+        self.bug_id = bug_id
 
         self._repo_url: Optional[RepoUrl] = None
         self._db_project_object: Optional[ProjectReleaseModel]

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1532,14 +1532,18 @@ class Parser:
 
         version = nested_get(event, "trigger", "msg", "project", "version")
 
+        bug_id = nested_get(event, "bug", "bug_id")
+
         logger.info(
-            f"New hotness update event for package: {package_name}, version: {version}"
+            f"New hotness update event for package: {package_name}, version: {version},"
+            f" bug ID: {bug_id}"
         )
 
         return NewHotnessUpdateEvent(
             package_name=package_name,
             version=version,
             distgit_project_url=distgit_project_url,
+            bug_id=bug_id,
         )
 
     # The .__func__ are needed for Python < 3.10

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -149,6 +149,7 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         use_downstream_specfile=True,
         sync_default_files=False,
         add_pr_instructions=True,
+        resolved_bugs=["rhbz#2106196"],
     ).and_return(flexmock(url="some_url")).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2404,7 +2404,7 @@ def test_bodhi_update_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added)
 def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added):
     pagure_pr_comment_added["pullrequest"]["comments"][0][
         "comment"
-    ] = "/packit pull-from-upstream"
+    ] = "/packit pull-from-upstream --resolved-bugs rhbz#123,rhbz#124"
 
     model = flexmock(status="queued", id=1234, branch="main")
     flexmock(SyncReleaseTargetModel).should_receive("create").with_args(
@@ -2480,6 +2480,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
         use_downstream_specfile=True,
         sync_default_files=False,
         add_pr_instructions=True,
+        resolved_bugs=["rhbz#123", "rhbz#124"],
     ).and_return(flexmock(url="some_url")).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -178,6 +178,7 @@ def test_dist_git_push_release_handle(github_release_webhook, propose_downstream
         use_downstream_specfile=False,
         sync_default_files=True,
         add_pr_instructions=True,
+        resolved_bugs=[],
     ).and_return(flexmock(url="some_url")).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -296,6 +297,7 @@ def test_dist_git_push_release_handle_multiple_branches(
             use_downstream_specfile=False,
             sync_default_files=True,
             add_pr_instructions=True,
+            resolved_bugs=[],
         ).and_return(flexmock(url="some_url")).once()
 
         flexmock(ProposeDownstreamJobHelper).should_receive(
@@ -424,6 +426,7 @@ def test_dist_git_push_release_handle_one_failed(
                 use_downstream_specfile=False,
                 sync_default_files=True,
                 add_pr_instructions=True,
+                resolved_bugs=[],
             ).and_return(flexmock(url="some_url")).once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
@@ -442,6 +445,7 @@ def test_dist_git_push_release_handle_one_failed(
                 use_downstream_specfile=False,
                 sync_default_files=True,
                 add_pr_instructions=True,
+                resolved_bugs=[],
             ).and_raise(Exception, f"Failed {model.branch}").once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
@@ -679,6 +683,7 @@ def test_retry_propose_downstream_task(
         use_downstream_specfile=False,
         sync_default_files=True,
         add_pr_instructions=True,
+        resolved_bugs=[],
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()
@@ -786,6 +791,7 @@ def test_dont_retry_propose_downstream_task(
         use_downstream_specfile=False,
         sync_default_files=True,
         add_pr_instructions=True,
+        resolved_bugs=[],
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -162,6 +162,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
         use_downstream_specfile=False,
         sync_default_files=True,
         add_pr_instructions=True,
+        resolved_bugs=[],
     ).and_return(flexmock(url="some_url")).times(1 if success else 0)
     flexmock(shutil).should_receive("rmtree").with_args("")
 


### PR DESCRIPTION
For NewHotnessEvent, take the bug ID from the message directly. For retriggering take the bugs from comment and use them directly.

Fixes packit/packit#1920
Merge after packit/packit#2094

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update or write new documentation in `packit/packit.dev`. (packit/packit.dev#748)

---

RELEASE NOTES BEGIN
Packit now automatically adds bugzilla created by Upstream Release Monitoring as `- Resolves {bugzilla} ` to the changelog (or commit if autochangelog is used) and provides the value in `commit-message` and `changelog-entry` actions as `PACKIT_RESOLVED_BUGS` env variable. When retriggering the `pull-from-upstream` from comment, one can also specify the bug(s) as `/packit pull-from-upstream --resolved-bugs rhbz#123,rhbz#125` and Packit will do the same.
RELEASE NOTES END
