### PR TITLE
Use configured failure message as suffix in comment for downstream jobs

### DIFF
--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -50,7 +50,10 @@ from packit_service.worker.mixin import (
     GetBranchesFromIssueMixin,
     PackitAPIWithDownstreamMixin,
 )
-from packit_service.worker.reporting import report_in_issue_repository
+from packit_service.worker.reporting import (
+    report_in_issue_repository,
+    update_message_with_configured_failure_comment_message,
+)
 from packit_service.worker.result import TaskResults
 
 logger = logging.getLogger(__name__)
@@ -139,6 +142,10 @@ class BodhiUpdateHandler(
         trigger_type_description = self.get_trigger_type_description(koji_build_data)
         body_msg = (
             f"{body}\n{trigger_type_description}\n\n{msg_retrigger}{MSG_GET_IN_TOUCH}\n"
+        )
+
+        body_msg = update_message_with_configured_failure_comment_message(
+            body_msg, self.job_config
         )
 
         report_in_issue_repository(

--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -17,6 +17,7 @@ from ogr.services.github.check_run import (
 )
 from ogr.services.gitlab import GitlabProject
 from ogr.services.pagure import PagureProject
+from packit.config import JobConfig
 
 from packit_service.config import ServiceConfig, PackageConfigGetter
 from packit_service.constants import (
@@ -569,3 +570,18 @@ def report_in_issue_repository(
         message=message,
         comment_to_existing=comment_to_existing,
     )
+
+
+def update_message_with_configured_failure_comment_message(
+    comment: str, job_config: JobConfig
+) -> str:
+    """
+    If there is the notifications.failure_comment.message present in the configuration,
+    append it to the existing message.
+    """
+    configured_failure_message = (
+        f"\n\n---\n{configured_message}"
+        if (configured_message := job_config.notifications.failure_comment.message)
+        else ""
+    )
+    return f"{comment}{configured_failure_message}"

--- a/tests/unit/test_distgit.py
+++ b/tests/unit/test_distgit.py
@@ -1,21 +1,22 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 import json
-import pytest
 
-from flexmock import flexmock
+import pytest
 from fasjson_client import Client
+from flexmock import flexmock
 
 from ogr.services.github import GithubService
 from packit.api import PackitAPI
+from packit.config.notifications import NotificationsConfig
+from packit_service.config import PackageConfigGetter
+from packit_service.worker.events.event import EventData
 from packit_service.worker.handlers.distgit import (
     ProposeDownstreamHandler,
     DownstreamKojiBuildHandler,
     AbstractSyncReleaseHandler,
     PullFromUpstreamHandler,
 )
-from packit_service.worker.events.event import EventData
-from packit_service.config import PackageConfigGetter
 
 
 def test_create_one_issue_for_pr():
@@ -48,7 +49,9 @@ def test_create_one_issue_for_pr():
         ]
     )
     flexmock(ProposeDownstreamHandler).should_receive("project").and_return(project)
-    handler = ProposeDownstreamHandler(None, None, {}, flexmock())
+    handler = ProposeDownstreamHandler(
+        None, flexmock(notifications=NotificationsConfig()), {}, flexmock()
+    )
     handler._report_errors_for_each_branch(
         {
             "f34": "Propose downstream failed for release 056",


### PR DESCRIPTION
When creating issues/commenting in issue_repository, use the configured notifications.failure_comment.message in downstrem jobs. Followup of #2182


---

RELEASE NOTES BEGIN
You can now configure `notifications.failure_comment.message` also for downstream jobs, where the configured message will be used as an extension of the comment added by default by Packit.
RELEASE NOTES END
