### PR TITLE
Post comment with dashboard link to sync release PRs

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -358,6 +358,10 @@ class AbstractSyncReleaseHandler(
             model.set_finished_time(finished_time=datetime.utcnow())
             model.set_logs(collect_packit_logs(buffer=buffer, handler=handler))
 
+        dashboard_url = self.get_dashboard_url(model.id)
+        downstream_pr.comment(
+            f"Logs and details of the syncing: [Packit dashboard]({dashboard_url})"
+        )
         self.sync_release_helper.report_status_for_branch(
             branch=branch,
             description=f"{self.job_name_for_reporting.capitalize()} "

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -159,20 +159,19 @@ def test_issue_comment_propose_downstream_handler(
     event_type,
 ):
     project_class, comment_event = mock_comment
-
-    flexmock(PackitAPI).should_receive("sync_release").and_return(
-        PullRequestReadOnly(
-            title="foo",
-            description="bar",
-            target_branch="baz",
-            source_branch="yet",
-            id=1,
-            status=PRStatus.open,
-            url="https://xyz",
-            author="me",
-            created=datetime.now(),
-        )
+    pr = PullRequestReadOnly(
+        title="foo",
+        description="bar",
+        target_branch="baz",
+        source_branch="yet",
+        id=1,
+        status=PRStatus.open,
+        url="https://xyz",
+        author="me",
+        created=datetime.now(),
     )
+    flexmock(pr).should_receive("comment")
+    flexmock(PackitAPI).should_receive("sync_release").and_return(pr)
     flexmock(
         project_class,
         get_files=lambda ref, recursive: [".packit.yaml", "tox.ini"],

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -141,6 +141,7 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         False,
     ).and_return(project)
 
+    pr = flexmock(url="some_url").should_receive("comment").mock()
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="main",
         tag="7.0.3",
@@ -150,7 +151,7 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         sync_default_files=False,
         add_pr_instructions=True,
         resolved_bugs=["rhbz#2106196"],
-    ).and_return(flexmock(url="some_url")).once()
+    ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 
     flexmock(model).should_receive("set_status").with_args(

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2471,7 +2471,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
 
     service_config = ServiceConfig().get_service_config()
     flexmock(service_config).should_receive("get_project").replace_with(_get_project)
-
+    pr = flexmock(url="some_url").should_receive("comment").mock()
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="main",
         tag="7.0.3",
@@ -2481,7 +2481,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
         sync_default_files=False,
         add_pr_instructions=True,
         resolved_bugs=["rhbz#123", "rhbz#124"],
-    ).and_return(flexmock(url="some_url")).once()
+    ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 
     flexmock(model).should_receive("set_status").with_args(

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -169,7 +169,7 @@ def test_dist_git_push_release_handle(github_release_webhook, propose_downstream
     ServiceConfig().get_service_config().get_project = (
         lambda url, required=True: project
     )
-
+    pr = flexmock(url="some_url").should_receive("comment").mock()
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="main",
         tag="0.3.0",
@@ -179,7 +179,7 @@ def test_dist_git_push_release_handle(github_release_webhook, propose_downstream
         sync_default_files=True,
         add_pr_instructions=True,
         resolved_bugs=[],
-    ).and_return(flexmock(url="some_url")).once()
+    ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 
     flexmock(model).should_receive("set_status").with_args(
@@ -289,6 +289,7 @@ def test_dist_git_push_release_handle_multiple_branches(
         flexmock(model).should_receive("set_start_time").once()
         flexmock(model).should_receive("set_finished_time").once()
         flexmock(model).should_receive("set_logs").once()
+        pr = flexmock(url="some_url").should_receive("comment").mock()
         flexmock(PackitAPI).should_receive("sync_release").with_args(
             dist_git_branch=model.branch,
             tag="0.3.0",
@@ -298,7 +299,7 @@ def test_dist_git_push_release_handle_multiple_branches(
             sync_default_files=True,
             add_pr_instructions=True,
             resolved_bugs=[],
-        ).and_return(flexmock(url="some_url")).once()
+        ).and_return(pr).once()
 
         flexmock(ProposeDownstreamJobHelper).should_receive(
             "report_status_for_branch"
@@ -418,6 +419,7 @@ def test_dist_git_push_release_handle_one_failed(
             flexmock(model).should_receive("set_downstream_pr_url").with_args(
                 downstream_pr_url="some_url"
             )
+            pr = flexmock(url="some_url").should_receive("comment").mock()
             flexmock(PackitAPI).should_receive("sync_release").with_args(
                 dist_git_branch=model.branch,
                 tag="0.3.0",
@@ -427,7 +429,7 @@ def test_dist_git_push_release_handle_one_failed(
                 sync_default_files=True,
                 add_pr_instructions=True,
                 resolved_bugs=[],
-            ).and_return(flexmock(url="some_url")).once()
+            ).and_return(pr).once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
             ).with_args(

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -153,7 +153,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
     flexmock(propose_downstream_model).should_receive("set_status").with_args(
         status=SyncReleaseStatus.finished
     ).times(1 if success else 0)
-
+    pr = flexmock(url="some_url").should_receive("comment").mock()
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="main",
         tag="1.2.3",
@@ -163,7 +163,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
         sync_default_files=True,
         add_pr_instructions=True,
         resolved_bugs=[],
-    ).and_return(flexmock(url="some_url")).times(1 if success else 0)
+    ).and_return(pr).times(1 if success else 0)
     flexmock(shutil).should_receive("rmtree").with_args("")
 
     flexmock(Allowlist, check_and_report=True)


### PR DESCRIPTION
Fixes #2128


---

RELEASE NOTES BEGIN
Packit now posts a comment with a link to the Packit dashboard to the pull requests created in Fedora dist-git when syncing the release.
RELEASE NOTES END
