### PR TITLE
React to retriggering comments for downstream jobs

### DIFF
--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -19,6 +19,7 @@ from celery.canvas import Signature
 from ogr.abstract import GitProject
 from packit.config import JobConfig, JobType, PackageConfig
 from packit.constants import DATETIME_FORMAT
+from packit_service.config import ServiceConfig
 
 from packit_service.models import (
     AbstractProjectObjectDbType,
@@ -264,6 +265,16 @@ class Handler(PackitAPIProtocol, Config):
             checks_pass = checks_pass and checker.pre_check()
 
         return checks_pass
+
+    @staticmethod
+    def get_handler_specific_task_accepted_message(
+        service_config: ServiceConfig,
+    ) -> str:
+        """
+        Get a message specific to a particular handler that will be appended
+        to the 'Task was accepted' message posted once Packit picks up a job.
+        """
+        return ""
 
     def clean(self):
         """clean up the mess once we're done"""

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -10,8 +10,9 @@ from typing import Tuple, Type
 
 from celery import Task
 
-from packit.config import JobConfig, JobType, PackageConfig
+from packit.config import JobConfig, JobType, PackageConfig, Deployment
 from packit.exceptions import PackitException
+from packit_service.config import ServiceConfig
 from packit_service.constants import (
     MSG_RETRIGGER,
     MSG_GET_IN_TOUCH,
@@ -121,6 +122,22 @@ class BodhiUpdateHandler(
             koji_build_data: koji build data associated with the
             retriggered Bodhi update
         """
+
+    @staticmethod
+    def get_handler_specific_task_accepted_message(
+        service_config: ServiceConfig,
+    ) -> str:
+        user = (
+            "packit" if service_config.deployment == Deployment.prod else "packit-stg"
+        )
+
+        return (
+            f"You can check the recent Bodhi update activity of `{user}` in "
+            f"[the Bodhi interface](https://bodhi.fedoraproject.org/users/{user}) (we "
+            f"have also planned adding support for viewing the updates"
+            f" in [Packit dashboard]({service_config.dashboard_url}), "
+            f"see [this issue](https://github.com/packit/dashboard/issues/187))."
+        )
 
     def report_in_issue_repository(
         self, koji_build_data: KojiBuildData, error: str

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -302,6 +302,7 @@ Packit failed on creating pull-requests in dist-git (https://src.fedoraproject.o
 You can retrigger the update by adding a comment (`/packit propose-downstream`) into this issue.
         """,
         get_comments=lambda: [],
+        comment=lambda message: None,
     )
     project = (
         flexmock(GithubProject).should_receive("get_issue").and_return(issue).mock()


### PR DESCRIPTION
When the downstream jobs are retriggered via comments (both in dist-git projects or issues in issue_repository), react to the comment by posting the `Task was accepted` commend with additional information where to check the job progress.

Fixes #2214
Fixes #1989

---

RELEASE NOTES BEGIN
Packit now reacts to retriggering comments for downstream jobs by commenting on the same issue/PR and providing information about the jobs.
RELEASE NOTES END
