### PR TITLE
Make /packit test trigger build if the last was not successful

### DIFF
--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -1126,6 +1126,24 @@ def test_get_request_details():
         (
             flexmock(
                 commit_sha="1111111111111111111111111111111111111111",
+                status=BuildStatus.failure,
+                group_of_targets=flexmock(runs=[flexmock(test_run_group=None)]),
+            ),
+            True,
+            False,
+        ),
+        (
+            flexmock(
+                commit_sha="1111111111111111111111111111111111111111",
+                status=BuildStatus.error,
+                group_of_targets=flexmock(runs=[flexmock(test_run_group=None)]),
+            ),
+            True,
+            False,
+        ),
+        (
+            flexmock(
+                commit_sha="1111111111111111111111111111111111111111",
                 status=BuildStatus.success,
                 group_of_targets=flexmock(runs=[flexmock(test_run_group=None)]),
             ),


### PR DESCRIPTION
Fixes #2219

---

RELEASE NOTES BEGIN
Packit now triggers the build for the `/packit test` comment command if the last build was not successful.
RELEASE NOTES END
