### PR TITLE
Fix bypassing compose name sanitization

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -655,22 +655,14 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             return None
 
         compiled_composes = {re.compile(compose) for compose in composes}
-
-        if self.is_compose_matching(target, compiled_composes):
-            logger.debug(
-                f"Target {target} directly matches a compose in the compose list."
-            )
-            return target
-
         distro, arch = target.rsplit("-", 1)
 
-        # we append -x86_64 to target by default
-        # when that happens and the user precisely specified the compose via target
+        # if the user precisely specified the compose via target
         # we should just use it instead of continuing below with our logic
         # some of those changes can change the target and result in a failure
-        if self.is_compose_matching(distro, compiled_composes) and arch == "x86_64":
+        if self.is_compose_matching(distro, compiled_composes):
             logger.debug(
-                f"Distro {distro} directly matches a compose in the compose list for x86_64."
+                f"Distro {distro} directly matches a compose in the compose list."
             )
             return distro
 

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -224,9 +224,8 @@ def test_testing_farm_response(
         ("centos-8-Latest-x86_64", "CentOS-8-latest", True),
         ("centos-8.4-x86_64", "CentOS-8.4", True),
         # If target is present in the available composes, just return it
-        ("RHEL-7.8-ZStream", "RHEL-7.8-ZStream", True),
         ("RHEL-7.8-ZStream-x86_64", "RHEL-7.8-ZStream", True),
-        ("RHEL-7.9-rhui", "RHEL-7.9-rhui", True),
+        ("RHEL-7.9-rhui-x86_64", "RHEL-7.9-rhui", True),
     ],
 )
 def test_distro2compose(target, compose, use_internal_tf):


### PR DESCRIPTION
distro2compose always accepts target (including arch), therefore we cannot match the whole target as a compose.

See https://redhat-internal.slack.com/archives/C04MU29TES1/p1696945995707489

CC @thrix 
