### PR TITLE
Store downstream Koji builds in DB

### DIFF
--- a/alembic/versions/99841c3f8ba8_adjust_kojibuildtargetmodel.py
+++ b/alembic/versions/99841c3f8ba8_adjust_kojibuildtargetmodel.py
@@ -1,0 +1,40 @@
+"""Adjust KojiBuildTargetModel
+
+Revision ID: 99841c3f8ba8
+Revises: db64a37ff1c6
+Create Date: 2023-11-02 15:19:28.923208
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "99841c3f8ba8"
+down_revision = "db64a37ff1c6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("koji_build_targets", "build_id", new_column_name="task_id")
+    op.execute(
+        "ALTER INDEX ix_koji_build_targets_build_id RENAME TO ix_koji_build_targets_task_id"
+    )
+    op.add_column(
+        "koji_build_targets", sa.Column("build_logs_urls", sa.JSON(), nullable=True)
+    )
+    # we can drop this, the logs URLs pointed to invalid URLs
+    op.drop_column("koji_build_targets", "build_logs_url")
+
+
+def downgrade():
+    op.alter_column("koji_build_targets", "task_id", new_column_name="build_id")
+    op.execute(
+        "ALTER INDEX ix_koji_build_targets_task_id RENAME TO ix_koji_build_targets_build_id"
+    )
+    op.add_column(
+        "koji_build_targets",
+        sa.Column("build_logs_url", sa.VARCHAR(), autoincrement=False, nullable=True),
+    )
+    op.drop_column("koji_build_targets", "build_logs_urls")

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1874,6 +1874,11 @@ class KojiBuildTargetModel(GroupAndTargetModelConnector, Base):
             self.scratch = value
             session.add(self)
 
+    def set_data(self, data: dict):
+        with sa_session_transaction() as session:
+            self.data = data
+            session.add(self)
+
     def get_srpm_build(self) -> Optional["SRPMBuildModel"]:
         # All SRPMBuild models for all the runs have to be same.
         return (

--- a/packit_service/service/api/koji_builds.py
+++ b/packit_service/service/api/koji_builds.py
@@ -33,6 +33,7 @@ class KojiBuildsList(Resource):
             build_dict = {
                 "packit_id": build.id,
                 "task_id": build.task_id,
+                "scratch": build.scratch,
                 "status": build.status,
                 "build_submitted_time": optional_timestamp(build.build_submitted_time),
                 "chroot": build.target,
@@ -80,6 +81,7 @@ class KojiBuildItem(Resource):
             "task_id": build.task_id,
             "status": build.status,
             "chroot": build.target,
+            "scratch": build.scratch,
             "build_start_time": optional_timestamp(build.build_start_time),
             "build_finished_time": optional_timestamp(build.build_finished_time),
             "build_submitted_time": optional_timestamp(build.build_submitted_time),

--- a/packit_service/service/api/koji_builds.py
+++ b/packit_service/service/api/koji_builds.py
@@ -32,13 +32,13 @@ class KojiBuildsList(Resource):
         for build in KojiBuildTargetModel.get_range(first, last):
             build_dict = {
                 "packit_id": build.id,
-                "build_id": build.build_id,
+                "task_id": build.task_id,
                 "status": build.status,
                 "build_submitted_time": optional_timestamp(build.build_submitted_time),
                 "chroot": build.target,
                 "web_url": build.web_url,
                 # from old data, sometimes build_logs_url is same and sometimes different to web_url
-                "build_logs_url": build.build_logs_url,
+                "build_logs_url": build.build_logs_urls,
                 "pr_id": build.get_pr_id(),
                 "branch_name": build.get_branch_name(),
                 "release": build.get_release_tag(),
@@ -77,7 +77,7 @@ class KojiBuildItem(Resource):
             )
 
         build_dict = {
-            "build_id": build.build_id,
+            "task_id": build.task_id,
             "status": build.status,
             "chroot": build.target,
             "build_start_time": optional_timestamp(build.build_start_time),
@@ -86,7 +86,7 @@ class KojiBuildItem(Resource):
             "commit_sha": build.commit_sha,
             "web_url": build.web_url,
             # from old data, sometimes build_logs_url is same and sometimes different to web_url
-            "build_logs_url": build.build_logs_url,
+            "build_logs_url": build.build_logs_urls,
             "srpm_build_id": build.get_srpm_build().id,
             "run_ids": sorted(run.id for run in build.group_of_targets.runs),
         }

--- a/packit_service/service/api/projects.py
+++ b/packit_service/service/api/projects.py
@@ -167,7 +167,7 @@ class ProjectsPRs(Resource):
 
             for build in pr.get_koji_builds():
                 build_info = {
-                    "build_id": build.build_id,
+                    "task_id": build.task_id,
                     "chroot": build.target,
                     "status": build.status,
                     "web_url": build.web_url,
@@ -275,7 +275,7 @@ class ProjectBranches(Resource):
 
             for build in branch.get_koji_builds():
                 build_info = {
-                    "build_id": build.build_id,
+                    "task_id": build.task_id,
                     "chroot": build.target,
                     "status": build.status,
                     "web_url": build.web_url,

--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime, timezone
 from io import StringIO
 from logging import StreamHandler
+from re import search
 from typing import List, Tuple
 
 from packit.config import JobConfig, PackageConfig
@@ -204,3 +205,20 @@ def get_packit_commands_from_comment(
             return packit_command
 
     return []
+
+
+def get_koji_task_id_and_url_from_stdout(stdout: str):
+    task_id, task_url = None, None
+
+    task_id_match = search(pattern=r"Created task: (\d+)", string=stdout)
+    if task_id_match:
+        task_id = int(task_id_match.group(1))
+
+    task_url_match = search(
+        pattern=r"(https://.+/koji/taskinfo\?taskID=\d+)",
+        string=stdout,
+    )
+    if task_url_match:
+        task_url = task_url_match.group(0)
+
+    return task_id, task_url

--- a/packit_service/worker/events/koji.py
+++ b/packit_service/worker/events/koji.py
@@ -27,6 +27,7 @@ class AbstractKojiEvent(AbstractResultEvent):
     ):
         super().__init__()
         self.task_id = task_id
+        # dictionary with archs and IDs, e.g. {"x86_64": 123}
         self.rpm_build_task_ids = rpm_build_task_ids
 
         # Lazy properties

--- a/packit_service/worker/helpers/build/koji_build.py
+++ b/packit_service/worker/helpers/build/koji_build.py
@@ -133,7 +133,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
                 continue
 
             koji_build = KojiBuildTargetModel.create(
-                build_id=None,
+                task_id=None,
                 web_url=None,
                 target=target,
                 status="pending",
@@ -141,7 +141,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
                 koji_build_group=build_group,
             )
             try:
-                build_id, web_url = self.run_build(target=target)
+                task_id, web_url = self.run_build(target=target)
             except Exception as ex:
                 sentry_integration.send_to_sentry(ex)
                 # TODO: Where can we show more info about failure?
@@ -156,7 +156,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
                 errors[target] = str(ex)
                 continue
             else:
-                koji_build.set_build_id(str(build_id))
+                koji_build.set_task_id(str(task_id))
                 koji_build.set_web_url(web_url)
                 url = get_koji_build_info_url(id_=koji_build.id)
                 self.report_status_to_all_for_chroot(

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -350,13 +350,18 @@ def run_sync_from_downstream_handler(
     queue="long-running",
 )
 def run_downstream_koji_build(
-    self, event: dict, package_config: dict, job_config: dict
+    self,
+    event: dict,
+    package_config: dict,
+    job_config: dict,
+    koji_group_model_id: Optional[int] = None,
 ):
     handler = DownstreamKojiBuildHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,
         celery_task=self,
+        koji_group_model_id=koji_group_model_id,
     )
     return get_handlers_task_results(handler.run_job(), event)
 
@@ -368,13 +373,18 @@ def run_downstream_koji_build(
     queue="long-running",
 )
 def run_retrigger_downstream_koji_build(
-    self, event: dict, package_config: dict, job_config: dict
+    self,
+    event: dict,
+    package_config: dict,
+    job_config: dict,
+    koji_group_model_id: Optional[int] = None,
 ):
     handler = RetriggerDownstreamKojiBuildHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,
         celery_task=self,
+        koji_group_model_id=koji_group_model_id,
     )
     return get_handlers_task_results(handler.run_job(), event)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -288,7 +288,7 @@ def koji_build_pr():
     srpm_build = flexmock(logs="asdsdf", url=None, runs=runs)
     koji_build_model = flexmock(
         id=1,
-        build_id="1",
+        task_id="1",
         commit_sha="0011223344",
         project_name="some-project",
         owner="some-owner",

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -68,7 +68,7 @@ def test_bodhi_update_for_unknown_koji_build(koji_build_completed_old_format):
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
         build_id=1864700
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
@@ -142,7 +142,7 @@ def test_bodhi_update_for_unknown_koji_build_failed(koji_build_completed_old_for
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
         build_id=1864700
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
@@ -222,7 +222,7 @@ def test_bodhi_update_for_unknown_koji_build_failed_issue_created(
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
         build_id=1864700
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
@@ -316,7 +316,7 @@ def test_bodhi_update_for_unknown_koji_build_failed_issue_comment(
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
         build_id=1864700
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
@@ -401,7 +401,7 @@ def test_bodhi_update_build_not_tagged_yet(
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
         build_id=1864700
     ).and_return(
         flexmock(
@@ -484,7 +484,7 @@ def test_bodhi_update_for_unknown_koji_build_not_for_unfinished(
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
         build_id=1864700
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
@@ -539,7 +539,7 @@ def test_bodhi_update_for_known_koji_build(koji_build_completed_old_format):
     )
 
     # Database structure
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
         build_id=1864700
     ).and_return(
         flexmock(
@@ -600,7 +600,7 @@ def test_bodhi_update_for_not_configured_branch(koji_build_completed_old_format)
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
         build_id=1864700
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
@@ -655,7 +655,7 @@ def test_bodhi_update_fedora_stable_by_default(koji_build_completed_f36):
     ).once()
 
     # Database not touched
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
         build_id=1874070
     ).times(0)
 

--- a/tests/integration/test_koji_build.py
+++ b/tests/integration/test_koji_build.py
@@ -147,8 +147,8 @@ def test_downstream_koji_build_report_unknown_build(koji_build_fixture, request)
     git_branch_model_flexmock = flexmock(
         id=1, job_config_trigger_type=JobConfigTriggerType.commit
     )
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
-        build_id=1864700
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
+        task_id=80860894
     ).and_return(None)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         git_branch_model_flexmock
@@ -162,8 +162,8 @@ def test_downstream_koji_build_report_unknown_build(koji_build_fixture, request)
         status="BUILDING",
         run_model=run_model_flexmock,
     ).and_return(flexmock(get_project_event_object=lambda: git_branch_model_flexmock))
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").with_args(
-        build_id=1874074
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
+        task_id=80860894
     ).and_return(
         flexmock(
             target="noarch",

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -2027,7 +2027,7 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
         pc_koji_build_pr
     )
 
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").and_return(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").and_return(
         koji_build_pr
     )
     url = get_koji_build_info_url(1)
@@ -2037,7 +2037,7 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
     koji_build_pr.should_receive("set_build_start_time").once()
     koji_build_pr.should_receive("set_build_finished_time").with_args(None).once()
     koji_build_pr.should_receive("set_status").with_args("running").once()
-    koji_build_pr.should_receive("set_build_logs_url")
+    koji_build_pr.should_receive("set_build_logs_urls")
     koji_build_pr.should_receive("set_web_url")
 
     # check if packit-service set correct PR status
@@ -2069,7 +2069,7 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
 
 
 def test_koji_build_start_build_not_found(koji_build_scratch_start):
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").and_return(None)
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").and_return(None)
 
     # check if packit-service set correct PR status
     flexmock(StatusReporter).should_receive("report").never()
@@ -2092,7 +2092,7 @@ def test_koji_build_end(koji_build_scratch_end, pc_koji_build_pr, koji_build_pr)
         pc_koji_build_pr
     )
 
-    flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").and_return(
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").and_return(
         koji_build_pr
     )
     url = get_koji_build_info_url(1)
@@ -2102,7 +2102,7 @@ def test_koji_build_end(koji_build_scratch_end, pc_koji_build_pr, koji_build_pr)
     koji_build_pr.should_receive("set_build_start_time").once()
     koji_build_pr.should_receive("set_build_finished_time").once()
     koji_build_pr.should_receive("set_status").with_args("success").once()
-    koji_build_pr.should_receive("set_build_logs_url")
+    koji_build_pr.should_receive("set_build_logs_urls")
     koji_build_pr.should_receive("set_web_url")
 
     # check if packit-service set correct PR status

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1064,6 +1064,9 @@ class TestEvents:
         assert event_object.task_id == 45270170
         assert event_object.state == KojiTaskState.closed
         assert event_object.rpm_build_task_ids == {"noarch": 45270227}
+        assert event_object.get_koji_build_rpm_tasks_logs_urls() == {
+            "noarch": "https://kojipkgs.fedoraproject.org//work/tasks/227/45270227/build.log"
+        }
 
         flexmock(GithubProject).should_receive("get_pr").with_args(
             pr_id=123

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1037,16 +1037,16 @@ class TestEvents:
     def test_parse_koji_build_scratch_event_start(
         self, koji_build_scratch_start, koji_build_pr
     ):
-        flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").and_return(
+        flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").and_return(
             koji_build_pr
         )
 
         event_object = Parser.parse_event(koji_build_scratch_start)
 
         assert isinstance(event_object, KojiTaskEvent)
-        assert event_object.build_id == 45270170
+        assert event_object.task_id == 45270170
         assert event_object.state == KojiTaskState.open
-        assert not event_object.rpm_build_task_id
+        assert not event_object.rpm_build_task_ids
 
         assert isinstance(event_object.project, GithubProject)
         assert event_object.project.full_repo_name == "foo/bar"
@@ -1054,16 +1054,16 @@ class TestEvents:
     def test_parse_koji_build_scratch_event_end(
         self, koji_build_scratch_end, koji_build_pr
     ):
-        flexmock(KojiBuildTargetModel).should_receive("get_by_build_id").and_return(
+        flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").and_return(
             koji_build_pr
         )
 
         event_object = Parser.parse_event(koji_build_scratch_end)
 
         assert isinstance(event_object, KojiTaskEvent)
-        assert event_object.build_id == 45270170
+        assert event_object.task_id == 45270170
         assert event_object.state == KojiTaskState.closed
-        assert event_object.rpm_build_task_id == 45270227
+        assert event_object.rpm_build_task_ids == {"noarch": 45270227}
 
         flexmock(GithubProject).should_receive("get_pr").with_args(
             pr_id=123
@@ -1080,7 +1080,7 @@ class TestEvents:
         assert event_object.build_id == 1864700
         assert event_object.state == KojiBuildState.building
         assert not event_object.old_state
-        assert event_object.rpm_build_task_id == 79721403
+        assert event_object.task_id == 79721403
         assert event_object.package_name == "packit"
         assert event_object.commit_sha == "0eb3e12005cb18f15d3054020f7ac934c01eae08"
         assert event_object.branch_name == "rawhide"
@@ -1118,7 +1118,7 @@ class TestEvents:
         assert event_object.build_id == 1874074
         assert event_object.state == KojiBuildState.building
         assert not event_object.old_state
-        assert event_object.rpm_build_task_id == 80860894
+        assert event_object.task_id == 80860894
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "e029dd5250dde9a37a2cdddb6d822d973b09e5da"
         assert event_object.branch_name == "rawhide"
@@ -1156,7 +1156,7 @@ class TestEvents:
         assert event_object.build_id == 1874070
         assert event_object.state == KojiBuildState.building
         assert not event_object.old_state
-        assert event_object.rpm_build_task_id == 80860789
+        assert event_object.task_id == 80860789
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "51b57ec04f5e6e9066ac859a1408cfbf1ead307e"
         assert event_object.branch_name == "f36"
@@ -1196,7 +1196,7 @@ class TestEvents:
         assert event_object.build_id == 1874072
         assert event_object.state == KojiBuildState.building
         assert not event_object.old_state
-        assert event_object.rpm_build_task_id == 80860791
+        assert event_object.task_id == 80860791
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "23806a208e32cc937f3a6eb151c62cbbc10d8f96"
         assert event_object.branch_name == "epel8"
@@ -1235,7 +1235,7 @@ class TestEvents:
         assert event_object.build_id == 1864700
         assert event_object.state == KojiBuildState.complete
         assert event_object.old_state == KojiBuildState.building
-        assert event_object.rpm_build_task_id == 79721403
+        assert event_object.task_id == 79721403
         assert event_object.package_name == "packit"
         assert event_object.commit_sha == "0eb3e12005cb18f15d3054020f7ac934c01eae08"
         assert event_object.branch_name == "rawhide"
@@ -1273,7 +1273,7 @@ class TestEvents:
         assert event_object.build_id == 1874074
         assert event_object.state == KojiBuildState.complete
         assert event_object.old_state == KojiBuildState.building
-        assert event_object.rpm_build_task_id == 80860894
+        assert event_object.task_id == 80860894
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "e029dd5250dde9a37a2cdddb6d822d973b09e5da"
         assert event_object.branch_name == "rawhide"
@@ -1313,7 +1313,7 @@ class TestEvents:
         assert event_object.build_id == 1874070
         assert event_object.state == KojiBuildState.complete
         assert event_object.old_state == KojiBuildState.building
-        assert event_object.rpm_build_task_id == 80860789
+        assert event_object.task_id == 80860789
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "51b57ec04f5e6e9066ac859a1408cfbf1ead307e"
         assert event_object.branch_name == "f36"
@@ -1353,7 +1353,7 @@ class TestEvents:
         assert event_object.build_id == 1874072
         assert event_object.state == KojiBuildState.complete
         assert event_object.old_state == KojiBuildState.building
-        assert event_object.rpm_build_task_id == 80860791
+        assert event_object.task_id == 80860791
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "23806a208e32cc937f3a6eb151c62cbbc10d8f96"
         assert event_object.branch_name == "epel8"

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -160,7 +160,7 @@ def test_koji_build_check_names(
     flexmock(KojiBuildGroupModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(KojiBuildTargetModel).should_receive("create").and_return(
         flexmock(id=1)
-        .should_receive("set_build_id")
+        .should_receive("set_task_id")
         .mock()
         .should_receive("set_web_url")
         .mock()
@@ -356,13 +356,13 @@ def test_koji_build_with_multiple_targets(
     flexmock(KojiBuildGroupModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(KojiBuildTargetModel).should_receive("create").and_return(
         flexmock(id=1)
-        .should_receive("set_build_id")
+        .should_receive("set_task_id")
         .mock()
         .should_receive("set_web_url")
         .mock()
     ).and_return(
         flexmock(id=2)
-        .should_receive("set_build_id")
+        .should_receive("set_task_id")
         .mock()
         .should_receive("set_web_url")
         .mock()
@@ -555,13 +555,13 @@ def test_koji_build_targets_override(
     flexmock(KojiBuildGroupModel).should_receive("create").and_return(flexmock(id=1))
     flexmock(KojiBuildTargetModel).should_receive("create").and_return(
         flexmock(id=1)
-        .should_receive("set_build_id")
+        .should_receive("set_task_id")
         .mock()
         .should_receive("set_web_url")
         .mock()
     ).and_return(
         flexmock(id=2)
-        .should_receive("set_build_id")
+        .should_receive("set_task_id")
         .mock()
         .should_receive("set_web_url")
         .mock()

--- a/tests_openshift/conftest.py
+++ b/tests_openshift/conftest.py
@@ -800,15 +800,15 @@ def a_koji_build_for_pr(srpm_build_model_with_new_run_for_pr):
     _, run_model = srpm_build_model_with_new_run_for_pr
     group = KojiBuildGroupModel.create(run_model)
     koji_build_model = KojiBuildTargetModel.create(
-        build_id=SampleValues.build_id,
+        task_id=SampleValues.build_id,
         web_url=SampleValues.koji_web_url,
         target=SampleValues.target,
         status=SampleValues.status_pending,
         scratch=True,
         koji_build_group=group,
     )
-    koji_build_model.set_build_logs_url(
-        "https://koji.somewhere/results/owner/package/target/build.logs"
+    koji_build_model.set_build_logs_urls(
+        {"x86_64": "https://koji.somewhere/results/owner/package/target/build.logs"}
     )
     yield koji_build_model
 
@@ -819,7 +819,7 @@ def a_koji_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
     group = KojiBuildGroupModel.create(run_model)
 
     yield KojiBuildTargetModel.create(
-        build_id=SampleValues.build_id,
+        task_id=SampleValues.build_id,
         web_url=SampleValues.koji_web_url,
         target=SampleValues.target,
         status=SampleValues.status_pending,
@@ -834,7 +834,7 @@ def a_koji_build_for_release(srpm_build_model_with_new_run_for_release):
     group = KojiBuildGroupModel.create(run_model)
 
     yield KojiBuildTargetModel.create(
-        build_id=SampleValues.build_id,
+        task_id=SampleValues.build_id,
         web_url=SampleValues.koji_web_url,
         target=SampleValues.target,
         status=SampleValues.status_pending,
@@ -861,7 +861,7 @@ def multiple_koji_builds(pr_project_event_model, different_pr_project_event_mode
     yield [
         # Two builds for same run
         KojiBuildTargetModel.create(
-            build_id=SampleValues.build_id,
+            task_id=SampleValues.build_id,
             web_url=SampleValues.koji_web_url,
             target=SampleValues.target,
             status=SampleValues.status_pending,
@@ -869,7 +869,7 @@ def multiple_koji_builds(pr_project_event_model, different_pr_project_event_mode
             koji_build_group=group_for_pr,
         ),
         KojiBuildTargetModel.create(
-            build_id=SampleValues.different_build_id,
+            task_id=SampleValues.different_build_id,
             web_url=SampleValues.koji_web_url,
             target=SampleValues.different_target,
             status=SampleValues.status_pending,
@@ -878,7 +878,7 @@ def multiple_koji_builds(pr_project_event_model, different_pr_project_event_mode
         ),
         # Same PR, different run
         KojiBuildTargetModel.create(
-            build_id=SampleValues.different_build_id,
+            task_id=SampleValues.different_build_id,
             web_url=SampleValues.koji_web_url,
             target=SampleValues.different_target,
             status=SampleValues.status_pending,
@@ -887,7 +887,7 @@ def multiple_koji_builds(pr_project_event_model, different_pr_project_event_mode
         ),
         # Completely different build
         KojiBuildTargetModel.create(
-            build_id=SampleValues.another_different_build_id,
+            task_id=SampleValues.another_different_build_id,
             web_url=SampleValues.koji_web_url,
             target=SampleValues.target,
             status=SampleValues.status_pending,

--- a/tests_openshift/database/test_events.py
+++ b/tests_openshift/database/test_events.py
@@ -338,7 +338,7 @@ def test_koji_build_scratch_start(
     event_object = Parser.parse_event(koji_build_scratch_start_dict)
     assert isinstance(event_object, KojiTaskEvent)
 
-    assert event_object.build_id == SampleValues.build_id
+    assert event_object.task_id == SampleValues.build_id
     assert event_object.state == KojiTaskState.open
 
     assert isinstance(event_object.db_project_object, PullRequestModel)
@@ -356,7 +356,7 @@ def test_koji_build_scratch_end(
     event_object = Parser.parse_event(koji_build_scratch_end_dict)
     assert isinstance(event_object, KojiTaskEvent)
 
-    assert event_object.build_id == SampleValues.build_id
+    assert event_object.task_id == SampleValues.build_id
     assert event_object.state == KojiTaskState.closed
 
     assert isinstance(event_object.db_project_object, PullRequestModel)

--- a/tests_openshift/database/test_models.py
+++ b/tests_openshift/database/test_models.py
@@ -176,7 +176,7 @@ def test_copr_build_set_build_logs_url(clean_before_and_after, a_copr_build_for_
 
 
 def test_create_koji_build(clean_before_and_after, a_koji_build_for_pr):
-    assert a_koji_build_for_pr.build_id == "123456"
+    assert a_koji_build_for_pr.task_id == "123456"
     assert a_koji_build_for_pr.commit_sha == "80201a74d96c"
     assert a_koji_build_for_pr.web_url == "https://koji.something.somewhere/123456"
     assert a_koji_build_for_pr.get_srpm_build().logs == "some\nboring\nlogs"
@@ -190,13 +190,13 @@ def test_create_koji_build(clean_before_and_after, a_koji_build_for_pr):
 
 def test_get_koji_build(clean_before_and_after, a_koji_build_for_pr):
     assert a_koji_build_for_pr.id
-    b = KojiBuildTargetModel.get_by_build_id(
-        a_koji_build_for_pr.build_id, SampleValues.target
+    b = KojiBuildTargetModel.get_by_task_id(
+        a_koji_build_for_pr.task_id, SampleValues.target
     )
     assert b.id == a_koji_build_for_pr.id
     # let's make sure passing int works as well
-    b = KojiBuildTargetModel.get_by_build_id(
-        int(a_koji_build_for_pr.build_id), SampleValues.target
+    b = KojiBuildTargetModel.get_by_task_id(
+        int(a_koji_build_for_pr.task_id), SampleValues.target
     )
     assert b.id == a_koji_build_for_pr.id
     b2 = KojiBuildTargetModel.get_by_id(b.id)
@@ -207,23 +207,23 @@ def test_koji_build_set_status(clean_before_and_after, a_koji_build_for_pr):
     assert a_koji_build_for_pr.status == "pending"
     a_koji_build_for_pr.set_status("awesome")
     assert a_koji_build_for_pr.status == "awesome"
-    b = KojiBuildTargetModel.get_by_build_id(
-        a_koji_build_for_pr.build_id, SampleValues.target
+    b = KojiBuildTargetModel.get_by_task_id(
+        a_koji_build_for_pr.task_id, SampleValues.target
     )
     assert b.status == "awesome"
 
 
 def test_koji_build_set_build_logs_url(clean_before_and_after, a_koji_build_for_pr):
-    url = (
-        "https://kojipkgs.fedoraproject.org//"
+    urls = {
+        "x86_64": "https://kojipkgs.fedoraproject.org//"
         "packages/python-ogr/0.11.0/1.fc30/data/logs/noarch/build.log"
+    }
+    a_koji_build_for_pr.set_build_logs_urls(urls)
+    assert a_koji_build_for_pr.build_logs_urls == urls
+    b = KojiBuildTargetModel.get_by_task_id(
+        a_koji_build_for_pr.task_id, SampleValues.target
     )
-    a_koji_build_for_pr.set_build_logs_url(url)
-    assert a_koji_build_for_pr.build_logs_url == url
-    b = KojiBuildTargetModel.get_by_build_id(
-        a_koji_build_for_pr.build_id, SampleValues.target
-    )
-    assert b.build_logs_url == url
+    assert b.build_logs_urls == urls
 
 
 def test_get_or_create_pr(clean_before_and_after):
@@ -446,7 +446,7 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
         copr_build_group=copr_group,
     )
     koji_build = KojiBuildTargetModel.create(
-        build_id="987654",
+        task_id="987654",
         web_url="https://copr.something.somewhere/123456",
         target=SampleValues.target,
         status="pending",

--- a/tests_openshift/service/test_api.py
+++ b/tests_openshift/service/test_api.py
@@ -121,8 +121,8 @@ def test_koji_builds_list(client, clean_before_and_after, multiple_koji_builds):
 
     assert response_dict[1]["build_submitted_time"] is not None
 
-    assert {response_build["build_id"] for response_build in response_dict} == {
-        build.build_id for build in multiple_koji_builds
+    assert {response_build["task_id"] for response_build in response_dict} == {
+        build.task_id for build in multiple_koji_builds
     }
 
 
@@ -131,7 +131,7 @@ def test_detailed_koji_build_info(client, clean_before_and_after, a_koji_build_f
         url_for("api.koji-builds_koji_build_item", id=a_koji_build_for_pr.id)
     )
     response_dict = response.json
-    assert response_dict["build_id"] == SampleValues.build_id
+    assert response_dict["task_id"] == SampleValues.build_id
     assert response_dict["status"] == SampleValues.status_pending
     assert response_dict["chroot"] == SampleValues.target
     assert response_dict["build_submitted_time"] is not None


### PR DESCRIPTION
TODO:

- [x] Openshift tests
- [x] TODO in code
- [ ] followup dashboard PR (the API was changed so this breaks dashboard)


Fixes #1889 
Fixes #2243 

Merge after https://github.com/packit/packit/pull/2146


---

RELEASE NOTES BEGIN
The downstream Koji builds are now stored in the database as well and exposed via `/api/koji-builds` endpoint.
RELEASE NOTES END
