### PR TITLE
Add more customizable details to failure comments

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -262,3 +262,15 @@ DENIED_MSG = (
 # shared sandcastle dir
 SANDCASTLE_DG_REPO_DIR = "dist-git"
 SANDCASTLE_LOCAL_PROJECT_DIR = "local-project"
+
+FAILURE_COMMENT_MESSAGE_VARIABLES = {
+    # placeholder name in the user customized failure message:
+    # default value for placeholder if not given
+    placeholder: f"{{no entry for {placeholder}}}"
+    for placeholder in (
+        "commit_sha",
+        "packit_dashboard_url",
+        "external_dashboard_url",
+        "logs_url",
+    )
+}

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -225,19 +225,23 @@ class KojiTaskReportHandler(
                 url=url,
                 chroot=build.target,
             )
-            if self.koji_task_event.state == KojiTaskState.failed:
-                build_job_helper.notify_about_failure_if_configured()
+            koji_build_logs = KojiTaskEvent.get_koji_build_logs_url(
+                rpm_build_task_id=int(build.build_id),
+                koji_logs_url=self.service_config.koji_logs_url,
+            )
+            build.set_build_logs_url(koji_build_logs)
+            koji_rpm_task_web_url = KojiTaskEvent.get_koji_rpm_build_web_url(
+                rpm_build_task_id=int(build.build_id),
+                koji_web_url=self.service_config.koji_web_url,
+            )
+            build.set_web_url(koji_rpm_task_web_url)
 
-        koji_build_logs = KojiTaskEvent.get_koji_build_logs_url(
-            rpm_build_task_id=int(build.build_id),
-            koji_logs_url=self.service_config.koji_logs_url,
-        )
-        build.set_build_logs_url(koji_build_logs)
-        koji_rpm_task_web_url = KojiTaskEvent.get_koji_rpm_build_web_url(
-            rpm_build_task_id=int(build.build_id),
-            koji_web_url=self.service_config.koji_web_url,
-        )
-        build.set_web_url(koji_rpm_task_web_url)
+            if self.koji_task_event.state == KojiTaskState.failed:
+                build_job_helper.notify_about_failure_if_configured(
+                    packit_dashboard_url=url,
+                    external_dashboard_url=koji_rpm_task_web_url,
+                    logs_url=koji_build_logs,
+                )
 
         msg = (
             f"Build on {build.target} in koji changed state "

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -423,18 +423,19 @@ class TestingFarmResultsHandler(
             self.pushgateway.test_run_finished_time.observe(test_run_time)
 
         test_run_model.set_web_url(self.log_url)
-
+        url = get_testing_farm_info_url(test_run_model.id) if test_run_model else None
         self.testing_farm_job_helper.report_status_to_tests_for_test_target(
             state=status,
             description=summary,
             target=test_run_model.target,
-            url=get_testing_farm_info_url(test_run_model.id)
-            if test_run_model
-            else self.log_url,
+            url=url if url else self.log_url,
             links_to_external_services={"Testing Farm": self.log_url},
         )
         if failure:
-            self.testing_farm_job_helper.notify_about_failure_if_configured()
+            self.testing_farm_job_helper.notify_about_failure_if_configured(
+                packit_dashboard_url=url,
+                logs_url=self.log_url,
+            )
 
         test_run_model.set_status(self.result, created=self.created)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,8 @@ def srpm_build_model(
         set_build_logs_url=lambda x: None,
         url=None,
         build_start_time=None,
+        build_logs_url=None,
+        copr_web_url=None,
     )
 
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(


### PR DESCRIPTION
Fixes #2196
Merge before packit/packit.dev#769

---

RELEASE NOTES BEGIN

User can now further customize comment messages (written by Packit as a reaction of a failed job). The user can include in the customized message the following new placeholders:
  - `logs_url`:  service's logs url; Copr, Koji or Testing Farm service depending on the Packit job
  - `packit_dashboard_url`: Packit dashboard url for the job
  - `external_dashboard_url`:  service dashboard url; Copr, Koji or Testing Farm service depending on the Packit job

RELEASE NOTES END