### PR TITLE
A skipped release is not a failure

### DIFF
--- a/alembic/versions/3de8647515ae_add_skipped_status_report_to_sync_.py
+++ b/alembic/versions/3de8647515ae_add_skipped_status_report_to_sync_.py
@@ -1,0 +1,34 @@
+"""add skipped status report to sync release jobs
+
+Revision ID: 3de8647515ae
+Revises: 99841c3f8ba8
+Create Date: 2023-11-13 11:29:10.383794
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "3de8647515ae"
+down_revision = "99841c3f8ba8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE syncreleasetargetstatus ADD VALUE 'skipped'")
+
+
+def downgrade():
+    op.execute(
+        "ALTER TYPE syncreleasetargetstatus RENAME TO syncreleasetargetstatus_old"
+    )
+    op.execute(
+        "CREATE TYPE syncreleasetargetstatus AS ENUM "
+        "('queued', 'running', 'error', 'retry', 'submitted')"
+    )
+    op.execute(
+        "ALTER TABLE sync_release_run_targets "
+        "ALTER COLUMN status TYPE syncreleasetargetstatus USING status::syncreleasetargetstatus"
+    )
+    op.execute("DROP TYPE syncreleasetargetstatus_old")

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -2442,6 +2442,7 @@ class SyncReleaseTargetStatus(str, enum.Enum):
     error = "error"
     retry = "retry"
     submitted = "submitted"
+    skipped = "skipped"
 
 
 class SyncReleaseTargetModel(ProjectAndEventsConnector, Base):


### PR DESCRIPTION
When Packit skips a release do not mark it as a failure.

Merge after packit/packit#2156
Merge before packit/dashboard#356 and packit/packit.dev#772
