### PR TITLE
Get the latest release including pre-releases 

### DIFF
--- a/packit_service/worker/events/comment.py
+++ b/packit_service/worker/events/comment.py
@@ -161,8 +161,8 @@ class AbstractIssueCommentEvent(AddIssueEventToDb, AbstractCommentEvent):
     def tag_name(self):
         if not self._tag_name:
             self._tag_name = ""
-            if latest_release := self.project.get_latest_release():
-                self._tag_name = latest_release.tag_name
+            if releases := self.project.get_releases():
+                self._tag_name = releases[0].tag_name
         return self._tag_name
 
     @property

--- a/tests/integration/test_github_fas_verification.py
+++ b/tests/integration/test_github_fas_verification.py
@@ -38,7 +38,7 @@ def test_verification_successful():
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
+    flexmock(GithubProject).should_receive("get_releases").and_return([])
     flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(None)
@@ -100,7 +100,7 @@ def test_verification_not_successful():
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
+    flexmock(GithubProject).should_receive("get_releases").and_return([])
     flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(None)
@@ -170,7 +170,7 @@ def test_verification_incorrect_format(comment):
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
+    flexmock(GithubProject).should_receive("get_releases").and_return([])
     flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(None)
@@ -224,7 +224,7 @@ def test_verification_already_approved():
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
+    flexmock(GithubProject).should_receive("get_releases").and_return([])
     flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(None)
@@ -275,7 +275,7 @@ def test_verification_wrong_repository():
     flexmock(Pushgateway).should_receive("push").times(1).and_return()
     flexmock(Signature).should_receive("apply_async").never()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
+    flexmock(GithubProject).should_receive("get_releases").and_return([])
     flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(None)
@@ -303,7 +303,7 @@ def test_verification_wrong_issue():
     flexmock(Pushgateway).should_receive("push").times(1).and_return()
     flexmock(Signature).should_receive("apply_async").never()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
+    flexmock(GithubProject).should_receive("get_releases").and_return([])
     flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(None)
@@ -331,7 +331,7 @@ def test_verification_not_original_triggerer():
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(GithubProject).should_receive("get_latest_release").and_return(None)
+    flexmock(GithubProject).should_receive("get_releases").and_return([])
     flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(None)

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -130,7 +130,7 @@ jobs:
         tarball_url="https://foo/bar",
         git_tag=flexmock(GitTag),
     )
-    flexmock(project_class).should_receive("get_latest_release").and_return(gr)
+    flexmock(project_class).should_receive("get_releases").and_return([gr])
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     lp = flexmock(git_project=flexmock(default_branch="main"))
     lp.working_dir = ""
@@ -313,7 +313,7 @@ You can retrigger the update by adding a comment (`/packit propose-downstream`) 
         project=PagureProject, fail_when_missing=False
     ).and_return(PackageConfig)
 
-    project.should_receive("get_latest_release").and_return(flexmock(tag_name="123"))
+    project.should_receive("get_releases").and_return([flexmock(tag_name="123")])
     project.should_receive("get_sha_from_tag").and_return("abcdef")
     project.should_receive("has_write_access").and_return(True)
     db_project_object = flexmock(

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -563,8 +563,8 @@ class TestEvents:
         assert event_object.project.full_repo_name == "packit-service/packit"
         assert not event_object.base_project
 
-        flexmock(event_object.project).should_receive("get_latest_release").and_return(
-            flexmock(tag_name="0.5.0")
+        flexmock(event_object.project).should_receive("get_releases").and_return(
+            [flexmock(tag_name="0.5.0")]
         )
         flexmock(GithubProject, get_sha_from_tag=lambda tag_name: "123456")
         flexmock(PackageConfigGetter).should_receive(
@@ -588,9 +588,7 @@ class TestEvents:
         assert event_object.project.full_repo_name == "packit-service/packit"
         assert not event_object.base_project
 
-        flexmock(event_object.project).should_receive("get_latest_release").and_return(
-            None
-        )
+        flexmock(event_object.project).should_receive("get_releases").and_return([])
         flexmock(GithubProject).should_receive("get_sha_from_tag").never()
         flexmock(PackageConfigGetter).should_receive(
             "get_package_config_from_repo"
@@ -625,8 +623,8 @@ class TestEvents:
         assert isinstance(event_object.project, GitlabProject)
         assert event_object.project.full_repo_name == "testing/packit/hello-there"
 
-        flexmock(event_object.project).should_receive("get_latest_release").and_return(
-            flexmock(tag_name="0.5.0")
+        flexmock(event_object.project).should_receive("get_releases").and_return(
+            [flexmock(tag_name="0.5.0")]
         )
         flexmock(event_object.project, get_sha_from_tag=lambda tag_name: "123456")
         flexmock(PackageConfigGetter).should_receive(


### PR DESCRIPTION
For GitHub projects, `GitProject.get_latest_release()` considers only stable releases. If sync_release failed for a pre-release, the retrieved git ref is incorrect. Fix that.

Fixes https://github.com/packit/specfile/issues/325.