### PR TITLE
Utilise default labels and identifier from config for test comment

### DIFF
--- a/packit_service/worker/checker/testing_farm.py
+++ b/packit_service/worker/checker/testing_farm.py
@@ -138,6 +138,16 @@ class IsIdentifierFromCommentMatching(Checker, GetTestingFarmJobHelperMixin):
 
     def pre_check(self) -> bool:
         if (
+            not self.testing_farm_job_helper.comment_arguments.labels
+            and not self.testing_farm_job_helper.comment_arguments.identifier
+            and (default_identifier := self.job_config.test_command.default_identifier)
+        ):
+            logger.info(
+                f"Using the default identifier for test command: {default_identifier}"
+            )
+            return self.job_config.identifier == default_identifier
+
+        if (
             not self.testing_farm_job_helper.comment_arguments.identifier
             or self.testing_farm_job_helper.comment_arguments.identifier
             == self.job_config.identifier
@@ -160,6 +170,17 @@ class IsLabelFromCommentMatching(Checker, GetTestingFarmJobHelperMixin):
     """
 
     def pre_check(self) -> bool:
+        if (
+            not self.testing_farm_job_helper.comment_arguments.labels
+            and not self.testing_farm_job_helper.comment_arguments.identifier
+            and (default_labels := self.job_config.test_command.default_labels)
+        ):
+            logger.info(f"Using the default labels for test command: {default_labels}")
+            if not self.job_config.labels:
+                return False
+
+            return any(x in default_labels for x in self.job_config.labels)
+
         if not self.testing_farm_job_helper.comment_arguments.labels or (
             self.job_config.labels
             and any(


### PR DESCRIPTION
For `/packit test` comment command without arguments, utilise the values from the configurations.

Fixes packit/packit#2056
Merge after packit/packit#2180

TODO:

- [x] fix the tests
- [ ] docs
---

RELEASE NOTES BEGIN
We have introduced new configuration options `test_command.default_labels` and `test_command.default_identifier` that are used by default when running `/packit test` comment command without any arguments (instead of specifying them via `--labels`/`--identifier`).
RELEASE NOTES END
