### PR TITLE
Adjust check of dist-git PRs for Koji builds

### DIFF
--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -925,10 +925,14 @@ def test_precheck_koji_build_push_pr(
     flexmock(PagureProject).should_receive("get_pr_list").and_return(
         [
             flexmock(
+                id=5,
                 author=pr_author,
                 head_commit="ad0c308af91da45cf40b253cd82f07f63ea9cbbf",
             )
         ]
+    )
+    flexmock(PagureProject).should_receive("get_pr_files_diff").with_args(5).and_return(
+        {"package.spec": []}
     )
     package_config = (
         PackageConfig(


### PR DESCRIPTION
If the dist-git push comes from a PR, check that
the specfile was changed in that PR.

Related to #2271
Needs packit/ogr#826

TODO:

- [x] Write new tests or update the old ones to cover new functionality.


---

RELEASE NOTES BEGIN
We have fixed a bug of not running Koji builds for Packit PRs with multiple commits if the last commit of the PR did not contain the specfile change.
RELEASE NOTES END
