### PR TITLE
Handle race condition causing ENOPRSTATS

### DIFF
--- a/packit_service/worker/checker/distgit.py
+++ b/packit_service/worker/checker/distgit.py
@@ -34,7 +34,10 @@ class PermissionOnDistgit(Checker, GetPagurePullRequestMixin):
             return True
 
         pr_id = self.pull_request.id
-        diff = self.project.get_pr_files_diff(pr_id) or {}
+        logger.debug(f"PR {pr_id} status: {self.pull_request.status}")
+        # Pagure API tends to return ENOPRSTATS error when a pull request is transitioning
+        # from open to merged state, give it some extra time
+        diff = self.project.get_pr_files_diff(pr_id, retries=3, wait_seconds=3) or {}
         if not any(change.endswith(".spec") for change in diff):
             logger.info(f"PR {pr_id} does not contain a specfile change.")
             return False

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -40,6 +40,8 @@ from packit_service.worker.tasks import (
     run_downstream_koji_build,
     run_sync_from_downstream_handler,
 )
+
+from ogr.abstract import PRStatus
 from tests.spellbook import DATA_DIR, first_dict_value, get_parameters_from_results
 
 
@@ -928,12 +930,13 @@ def test_precheck_koji_build_push_pr(
                 id=5,
                 author=pr_author,
                 head_commit="ad0c308af91da45cf40b253cd82f07f63ea9cbbf",
+                status=PRStatus.open,
             )
         ]
     )
-    flexmock(PagureProject).should_receive("get_pr_files_diff").with_args(5).and_return(
-        {"package.spec": []}
-    )
+    flexmock(PagureProject).should_receive("get_pr_files_diff").with_args(
+        5, retries=3, wait_seconds=3
+    ).and_return({"package.spec": []})
     package_config = (
         PackageConfig(
             jobs=jobs,


### PR DESCRIPTION
Fixes #2287

Merge after packit/ogr#827

RELEASE NOTES BEGIN

We have handled an exception causing Koji builds and Bodhi updates not be run after merging a Packit downstream pull request.

RELEASE NOTES END
