### PR TITLE
Support `--id` and `-i` as a test job identifier

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -79,7 +79,7 @@ class CommentArguments:
             self.packit_command = match.group("packit_command")
             logger.debug(f"Parsed packit_command: {self.packit_command}")
 
-        match = re.search(r"--identifier[\s=](?P<identifier>\S+)", comment)
+        match = re.search(r"(--identifier|--id|-i)[\s=](?P<identifier>\S+)", comment)
         if match:
             self.identifier = match.group("identifier")
             logger.debug(f"Parsed test argument -> identifier: {self.identifier}")

--- a/tests/unit/test_checkers.py
+++ b/tests/unit/test_checkers.py
@@ -485,6 +485,16 @@ def test_koji_branch_merge_queue():
             id="Matching identifier specified",
         ),
         pytest.param(
+            "/packit-dev test --id my-id-1",
+            True,
+            id="Matching identifier specified",
+        ),
+        pytest.param(
+            "/packit-dev test -i my-id-1",
+            True,
+            id="Matching identifier specified",
+        ),
+        pytest.param(
             "/packit-dev test",
             True,
             id="No identifier specified",

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -1846,6 +1846,18 @@ def test_is_supported_architecture(target, use_internal_tf, supported):
             ["label1"],
             "namespace-2/repo-2#36",
         ),
+        (
+            "/packit-dev test namespace-2/repo-2#36 --labels label1 --id my-id-2",
+            "my-id-2",
+            ["label1"],
+            "namespace-2/repo-2#36",
+        ),
+        (
+            "/packit-dev test namespace-2/repo-2#36 --labels label1 -i my-id-2",
+            "my-id-2",
+            ["label1"],
+            "namespace-2/repo-2#36",
+        ),
     ],
 )
 def test_parse_comment_arguments(


### PR DESCRIPTION
Add support for shorter version of the `--identifier` option to save many keystrokes when triggering custom jobs.

Fix #2259.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
