### PR TITLE
Add API endpoint for Bodhi updates

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1856,6 +1856,23 @@ class BodhiUpdateTargetModel(GroupAndTargetModelConnector, Base):
 
             return update
 
+    @classmethod
+    def get_by_id(cls, id_: int) -> Optional["BodhiUpdateTargetModel"]:
+        return sa_session().query(BodhiUpdateTargetModel).filter_by(id=id_).first()
+
+    @classmethod
+    def get_all(cls) -> Iterable["BodhiUpdateTargetModel"]:
+        return sa_session().query(BodhiUpdateTargetModel)
+
+    @classmethod
+    def get_range(cls, first: int, last: int) -> Iterable["BodhiUpdateTargetModel"]:
+        return (
+            sa_session()
+            .query(BodhiUpdateTargetModel)
+            .order_by(desc(BodhiUpdateTargetModel.id))
+            .slice(first, last)
+        )
+
 
 class BodhiUpdateGroupModel(ProjectAndEventsConnector, GroupModel, Base):
     __tablename__ = "bodhi_update_groups"

--- a/packit_service/service/api/__init__.py
+++ b/packit_service/service/api/__init__.py
@@ -18,6 +18,7 @@ from packit_service.service.api.propose_downstream import ns as propose_downstre
 from packit_service.service.api.usage import usage_ns
 from packit_service.service.api.pull_from_upstream import ns as pull_from_upstream_ns
 from packit_service.service.api.system import ns as system_ns
+from packit_service.service.api.bodhi_updates import ns as bodhi_updates_ns
 
 # https://flask-restplus.readthedocs.io/en/stable/scaling.html
 blueprint = Blueprint("api", __name__, url_prefix="/api")
@@ -42,3 +43,4 @@ api.add_namespace(propose_downstream_ns)
 api.add_namespace(usage_ns)
 api.add_namespace(pull_from_upstream_ns)
 api.add_namespace(system_ns)
+api.add_namespace(bodhi_updates_ns)

--- a/packit_service/service/api/bodhi_updates.py
+++ b/packit_service/service/api/bodhi_updates.py
@@ -1,0 +1,113 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+from http import HTTPStatus
+from logging import getLogger
+
+from flask_restx import Namespace, Resource
+
+from packit_service.models import (
+    optional_timestamp,
+    BodhiUpdateTargetModel,
+    BodhiUpdateGroupModel,
+)
+from packit_service.service.api.parsers import indices, pagination_arguments
+from packit_service.service.api.utils import get_project_info_from_build, response_maker
+
+logger = getLogger("packit_service")
+
+ns = Namespace("bodhi-updates", description="Bodhi updates")
+
+
+@ns.route("")
+class BodhiUpdatesList(Resource):
+    @ns.expect(pagination_arguments)
+    @ns.response(HTTPStatus.PARTIAL_CONTENT, "Bodhi updates list follows")
+    def get(self):
+        """List all Bodhi updates."""
+        first, last = indices()
+        result = []
+
+        for update in BodhiUpdateTargetModel.get_range(first, last):
+            update_dict = {
+                "packit_id": update.id,
+                "status": update.status,
+                "branch": update.target,
+                "web_url": update.web_url,
+                "koji_nvr": update.koji_nvr,
+                "alias": update.alias,
+                "pr_id": update.get_pr_id(),
+                "branch_name": update.get_branch_name(),
+                "release": update.get_release_tag(),
+            }
+
+            if project := update.get_project():
+                update_dict["project_url"] = project.project_url
+                update_dict["repo_namespace"] = project.namespace
+                update_dict["repo_name"] = project.repo_name
+
+            result.append(update_dict)
+
+        resp = response_maker(
+            result,
+            status=HTTPStatus.PARTIAL_CONTENT,
+        )
+        resp.headers["Content-Range"] = f"bodhi-updates {first + 1}-{last}/*"
+        return resp
+
+
+@ns.route("/<int:id>")
+@ns.param("id", "Packit id of the update")
+class BodhiUpdateItem(Resource):
+    @ns.response(HTTPStatus.OK, "OK, Bodhi update details follow")
+    @ns.response(HTTPStatus.NOT_FOUND.value, "No info about Bodhi update stored in DB")
+    def get(self, id):
+        """A specific Bodhi updates details."""
+        update = BodhiUpdateTargetModel.get_by_id(int(id))
+
+        if not update:
+            return response_maker(
+                {"error": "No info about update stored in DB"},
+                status=HTTPStatus.NOT_FOUND,
+            )
+
+        update_dict = {
+            "status": update.status,
+            "branch": update.target,
+            "web_url": update.web_url,
+            "koji_nvr": update.koji_nvr,
+            "alias": update.alias,
+            "run_ids": sorted(run.id for run in update.group_of_targets.runs),
+        }
+
+        update_dict.update(get_project_info_from_build(update))
+        return response_maker(update_dict)
+
+
+@ns.route("/groups/<int:id>")
+@ns.param("id", "Packit id of the Bodhi update group")
+class BodhiUpdateGroup(Resource):
+    @ns.response(HTTPStatus.OK, "OK, Bodhi update group details follow")
+    @ns.response(
+        HTTPStatus.NOT_FOUND.value, "No info about Bodhi update group stored in DB"
+    )
+    def get(self, id):
+        """A specific Bodhi update group details."""
+        group_model = BodhiUpdateGroupModel.get_by_id(int(id))
+
+        if not group_model:
+            return response_maker(
+                {"error": "No info about group stored in DB"},
+                status=HTTPStatus.NOT_FOUND,
+            )
+
+        group_dict = {
+            "submitted_time": optional_timestamp(group_model.submitted_time),
+            "run_ids": sorted(run.id for run in group_model.runs),
+            "update_target_ids": sorted(
+                build.id for build in group_model.grouped_targets
+            ),
+        }
+
+        group_dict.update(get_project_info_from_build(group_model))
+        return response_maker(group_dict)

--- a/packit_service/service/api/utils.py
+++ b/packit_service/service/api/utils.py
@@ -17,6 +17,7 @@ from packit_service.models import (
     SyncReleaseModel,
     SyncReleaseTargetModel,
     optional_timestamp,
+    BodhiUpdateTargetModel,
 )
 
 
@@ -37,6 +38,7 @@ def get_project_info_from_build(
         TFTTestRunTargetModel,
         TFTTestRunGroupModel,
         SyncReleaseModel,
+        BodhiUpdateTargetModel,
     ]
 ) -> Dict[str, Any]:
     if not (project := build.get_project()):

--- a/tests_openshift/service/test_api.py
+++ b/tests_openshift/service/test_api.py
@@ -826,3 +826,46 @@ def test_project_usage_info(
         )
         == 1
     )
+
+
+def test_bodhi_update_list(
+    client,
+    clean_before_and_after,
+    multiple_bodhi_update_runs,
+):
+    response = client.get(url_for("api.bodhi-updates_bodhi_updates_list"))
+    response_dict = response.json
+
+    assert len(response_dict) == 2
+
+    response_dict.reverse()
+    assert response_dict[0]["status"] == "queued"
+    assert response_dict[0]["koji_nvr"] == SampleValues.nvr
+    assert response_dict[0]["branch"] == SampleValues.dist_git_branch
+    assert response_dict[0]["branch_name"] == SampleValues.branch
+
+    assert response_dict[1]["koji_nvr"] == SampleValues.different_nvr
+    assert response_dict[1]["branch"] == SampleValues.different_dist_git_branch
+
+    assert response_dict[0]["repo_namespace"] == SampleValues.repo_namespace
+    assert response_dict[0]["repo_name"] == SampleValues.repo_name
+    assert response_dict[0]["project_url"] == SampleValues.project_url
+
+
+def test_bodhi_update_info(
+    client,
+    clean_before_and_after,
+    bodhi_update_model,
+):
+    response = client.get(
+        url_for("api.bodhi-updates_bodhi_update_item", id=bodhi_update_model.id)
+    )
+    response_dict = response.json
+    assert response_dict["alias"] == SampleValues.alias
+    assert response_dict["branch"] == SampleValues.dist_git_branch
+    assert response_dict["web_url"] == SampleValues.bodhi_url
+    assert response_dict["koji_nvr"] == SampleValues.nvr
+    assert response_dict["branch_name"] == SampleValues.branch
+    assert response_dict["repo_name"] == SampleValues.repo_name
+    assert response_dict["repo_namespace"] == SampleValues.repo_namespace
+    assert response_dict["status"] == "error"


### PR DESCRIPTION
Fixes #1891


---

RELEASE NOTES BEGIN
There is a new API endpoint `/bodhi-updates` for getting information about Bodhi updates submitted by Packit.
RELEASE NOTES END
