### PR TITLE
Adjust condition for retrying download error for release sync

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -97,6 +97,9 @@ DEFAULT_RETRY_LIMIT_OUTAGE = 5
 # retry in 0-7s, 0-14s, 0-28s, 0-48s, 0-96s
 # because jitter is enabled by default, celery makes these retries random:
 # https://docs.celeryq.dev/en/latest/userguide/tasks.html#Task.retry_jitter
+
+RETRY_LIMIT_RELEASE_ARCHIVE_DOWNLOAD_ERROR = 6
+
 DEFAULT_RETRY_BACKOFF = 7
 BASE_RETRY_INTERVAL_IN_MINUTES_FOR_OUTAGES = 1
 BASE_RETRY_INTERVAL_IN_SECONDS_FOR_INTERNAL_ERRORS = 10

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -830,7 +830,7 @@ def test_dont_retry_propose_downstream_task(
             git=flexmock(clear_cache=lambda: None),
         )
     )
-    flexmock(Context, retries=2)
+    flexmock(Context, retries=6)
     flexmock(shutil).should_receive("rmtree").with_args("")
     flexmock(Task).should_receive("retry").never()
     flexmock(Pushgateway).should_receive("push").times(3).and_return()


### PR DESCRIPTION
The previously used is_last_try method just checks the attribute of the task object itself, but we are overriding it with the argument to retry method.

Related to packit/packit#1954

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
