### PR TITLE
Resolve owner and project through CoprBuildHelper

### DIFF
--- a/packit_service/worker/checker/copr.py
+++ b/packit_service/worker/checker/copr.py
@@ -18,18 +18,23 @@ from packit_service.worker.handlers.mixin import (
     GetCoprBuildJobHelperForIdMixin,
     GetCoprBuildJobHelperMixin,
     GetCoprSRPMBuildMixin,
+    ConfigFromEventMixin,
 )
 from packit_service.worker.reporting import BaseCommitStatus
 
 logger = logging.getLogger(__name__)
 
 
-class IsJobConfigTriggerMatching(Checker, GetCoprBuildJobHelperMixin):
+class IsJobConfigTriggerMatching(
+    Checker, ConfigFromEventMixin, GetCoprBuildJobHelperMixin
+):
     def pre_check(self) -> bool:
         return self.copr_build_helper.is_job_config_trigger_matching(self.job_config)
 
 
-class IsGitForgeProjectAndEventOk(Checker, GetCoprBuildJobHelperMixin):
+class IsGitForgeProjectAndEventOk(
+    Checker, ConfigFromEventMixin, GetCoprBuildJobHelperMixin
+):
     def pre_check(
         self,
     ) -> bool:
@@ -102,7 +107,9 @@ class BuildNotAlreadyStarted(Checker, GetCoprSRPMBuildMixin):
         return not bool(build.build_start_time)
 
 
-class CanActorRunTestsJob(ActorChecker, GetCoprBuildJobHelperMixin):
+class CanActorRunTestsJob(
+    ActorChecker, ConfigFromEventMixin, GetCoprBuildJobHelperMixin
+):
     """For external contributors, we need to be more careful when running jobs.
     This is a handler-specific permission check
     for a user who trigger the action on a PR.

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -65,6 +65,7 @@ from packit_service.worker.handlers.mixin import (
     GetCoprBuildEventMixin,
     GetCoprBuildJobHelperForIdMixin,
     GetCoprBuildJobHelperMixin,
+    ConfigFromEventMixin,
 )
 from packit_service.worker.mixin import PackitAPIWithDownstreamMixin
 from packit_service.worker.reporting import BaseCommitStatus, DuplicateCheckMode
@@ -90,7 +91,10 @@ logger = logging.getLogger(__name__)
 @reacts_to(CheckRerunCommitEvent)
 @reacts_to(CheckRerunReleaseEvent)
 class CoprBuildHandler(
-    RetriableJobHandler, PackitAPIWithDownstreamMixin, GetCoprBuildJobHelperMixin
+    RetriableJobHandler,
+    ConfigFromEventMixin,
+    PackitAPIWithDownstreamMixin,
+    GetCoprBuildJobHelperMixin,
 ):
     task_name = TaskName.copr_build
 

--- a/packit_service/worker/handlers/vm_image.py
+++ b/packit_service/worker/handlers/vm_image.py
@@ -31,9 +31,10 @@ from packit_service.worker.checker.vm_image import (
     GetVMImageBuildReporterFromJobHelperMixin,
 )
 from packit_service.worker.mixin import (
-    ConfigFromEventMixin,
-    GetVMImageBuilderMixin,
     PackitAPIWithDownstreamMixin,
+)
+from packit_service.worker.handlers.mixin import (
+    GetVMImageBuilderMixin,
 )
 from packit_service.models import (
     VMImageBuildTargetModel,
@@ -51,7 +52,6 @@ logger = logging.getLogger(__name__)
 @reacts_to(AbstractPRCommentEvent)
 class VMImageBuildHandler(
     RetriableJobHandler,
-    ConfigFromEventMixin,
     PackitAPIWithDownstreamMixin,
     GetVMImageBuilderMixin,
     GetVMImageBuildReporterFromJobHelperMixin,
@@ -119,7 +119,6 @@ class VMImageBuildHandler(
 @reacts_to(VMImageBuildResultEvent)
 class VMImageBuildResultHandler(
     JobHandler,
-    ConfigFromEventMixin,
     PackitAPIWithDownstreamMixin,
     GetVMImageBuilderMixin,
     GetVMImageBuildReporterFromJobHelperMixin,

--- a/packit_service/worker/helpers/build/babysit.py
+++ b/packit_service/worker/helpers/build/babysit.py
@@ -36,7 +36,8 @@ from packit_service.worker.events import (
     VMImageBuildResultEvent,
 )
 from packit_service.worker.events.enums import FedmsgTopic
-from packit_service.worker.mixin import ConfigFromUrlMixin, GetVMImageBuilderMixin
+from packit_service.worker.mixin import ConfigFromUrlMixin
+from packit_service.worker.handlers.mixin import GetVMImageBuilderMixin
 from packit_service.worker.handlers import (
     CoprBuildEndHandler,
     CoprBuildStartHandler,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -48,6 +48,7 @@ def fake_package_config_job_config_project_db_trigger():
                 specfile_path="knx-stack.spec", copr_chroot="fedora-36-x86_64"
             )
         },
+        package=None,
     )
     project = flexmock(
         namespace="mmassari",

--- a/tests/unit/test_handler_vm_image.py
+++ b/tests/unit/test_handler_vm_image.py
@@ -23,14 +23,13 @@ from packit_service.worker.handlers import (
     VMImageBuildHandler,
     VMImageBuildResultHandler,
 )
-from packit_service.worker.mixin import ConfigFromEventMixin
 from packit_service.worker.reporting import StatusReporter, BaseCommitStatus
 
 
 def test_get_vm_image_build_reporter_from_job_helper_mixin(
     fake_package_config_job_config_project_db_trigger,
 ):
-    class Test(ConfigFromEventMixin, GetVMImageBuildReporterFromJobHelperMixin):
+    class Test(GetVMImageBuildReporterFromJobHelperMixin):
         def __init__(self) -> None:
             super().__init__()
             (

--- a/tests/unit/test_mixin.py
+++ b/tests/unit/test_mixin.py
@@ -9,12 +9,15 @@ from typing import Optional
 from packit.vm_image_build import ImageBuilder
 from ogr.abstract import GitProject
 from packit_service.config import ServiceConfig
+from packit_service.worker.handlers.mixin import (
+    GetVMImageBuilderMixin,
+    GetCoprBuildJobHelperMixin,
+    GetVMImageDataMixin,
+)
 from packit_service.worker.mixin import (
     GetBranchesFromIssueMixin,
     ConfigFromDistGitUrlMixin,
-    GetVMImageBuilderMixin,
     ConfigFromEventMixin,
-    GetVMImageDataMixin,
 )
 
 from packit_service.worker.events import EventData
@@ -31,7 +34,7 @@ def test_GetVMImageBuilderMixin():
 
 
 def test_GetVMImageDataMixin(fake_package_config_job_config_project_db_trigger):
-    class Test(ConfigFromEventMixin, GetVMImageDataMixin):
+    class Test(ConfigFromEventMixin, GetCoprBuildJobHelperMixin, GetVMImageDataMixin):
         def __init__(self) -> None:
             super().__init__()
             (


### PR DESCRIPTION
If no owner and project are given in the vm_image_build job resolve them through the CoprBuildHelper defaults.

When looking for the copr_build job related with a vm_image_build and COPR owner or project are not given then
guess they are being created by the CoprBuildHelper and use it to find them.


