### PR TITLE
Increase timeouts and retries to prevent ENOPRSTATS

### DIFF
--- a/packit_service/worker/checker/distgit.py
+++ b/packit_service/worker/checker/distgit.py
@@ -38,7 +38,7 @@ class PermissionOnDistgit(Checker, GetPagurePullRequestMixin):
         logger.debug(f"PR {pr_id} status: {self.pull_request.status}")
         # Pagure API tends to return ENOPRSTATS error when a pull request is transitioning
         # from open to merged state, give it some extra time
-        diff = self.project.get_pr_files_diff(pr_id, retries=5, wait_seconds=5) or {}
+        diff = self.project.get_pr_files_diff(pr_id, retries=7, wait_seconds=7) or {}
         if not any(change.endswith(".spec") for change in diff):
             logger.info(f"PR {pr_id} does not contain a specfile change.")
             return False


### PR DESCRIPTION
ENOPRSTATS are still happening in prod.

Try to mitigate them a bit more.