### PR TITLE
Fix checking of PR labels

### DIFF
--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -243,7 +243,7 @@ def pr_labels_match_configuration(
         f"(label.present: {configured_labels_present}, label.absent: {configured_labels_absent})"
     )
 
-    pr_labels = pull_request.labels
+    pr_labels = [label.name for label in pull_request.labels]
     logger.info(f"Labels on PR: {pr_labels}")
 
     return (

--- a/tests/unit/test_checkers.py
+++ b/tests/unit/test_checkers.py
@@ -1000,10 +1000,15 @@ def test_koji_check_allowed_accounts(
     "pr_labels,labels_present,labels_absent,should_pass",
     (
         ([], [], [], True),
-        (["allowed-1"], [], ["skip-ci"], True),
-        (["allowed-1"], ["allowed-1"], ["skip-ci"], True),
-        (["allowed-1"], ["allowed-1"], ["skip-ci"], True),
-        (["allowed-1", "skip-ci"], ["allowed-1"], ["skip-ci"], False),
+        ([flexmock(name="allowed-1")], [], ["skip-ci"], True),
+        ([flexmock(name="allowed-1")], ["allowed-1"], ["skip-ci"], True),
+        ([flexmock(name="allowed-1")], ["allowed-1"], ["skip-ci"], True),
+        (
+            [flexmock(name="allowed-1"), flexmock(name="skip-ci")],
+            ["allowed-1"],
+            ["skip-ci"],
+            False,
+        ),
     ),
 )
 def test_labels_on_distgit_pr(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -90,31 +90,31 @@ def test_only_once_with_args_and_kwargs():
         pytest.param(
             [],
             ["my-label"],
-            ["my-label"],
+            [flexmock(name="my-label")],
             True,
         ),
         pytest.param(
             ["skip-ci"],
             ["my-label"],
-            ["my-label"],
+            [flexmock(name="my-label")],
             True,
         ),
         pytest.param(
             ["skip-ci"],
             ["my-label"],
-            ["my-label", "skip-ci"],
+            [flexmock(name="my-label"), flexmock(name="skip-ci")],
             False,
         ),
         pytest.param(
             ["skip-ci"],
             ["my-label"],
-            ["skip-ci"],
+            [flexmock(name="skip-ci")],
             False,
         ),
         pytest.param(
             ["skip-ci"],
             [],
-            ["skip-ci"],
+            [flexmock(name="skip-ci")],
             False,
         ),
         pytest.param(
@@ -126,19 +126,19 @@ def test_only_once_with_args_and_kwargs():
         pytest.param(
             ["skip-ci"],
             ["first", "second"],
-            ["second"],
+            [flexmock(name="second")],
             True,
         ),
         pytest.param(
             ["skip-ci"],
             ["first", "second"],
-            ["third"],
+            [flexmock(name="third")],
             False,
         ),
         pytest.param(
             ["skip-ci", "block-ci"],
             ["first", "second"],
-            ["block-ci"],
+            [flexmock(name="block-ci")],
             False,
         ),
         pytest.param(
@@ -150,7 +150,7 @@ def test_only_once_with_args_and_kwargs():
         pytest.param(
             [],
             [],
-            ["some-label"],
+            [flexmock(name="some-label")],
             True,
         ),
     ],


### PR DESCRIPTION
The labels are GithubLabel objects and not strings, so we need to check their name attribute.

---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
