### PR TITLE
fix(event): use fallback for accepted time

### DIFF
--- a/packit_service/worker/events/event.py
+++ b/packit_service/worker/events/event.py
@@ -113,11 +113,12 @@ class EventData:
         commit_sha = event.get("commit_sha")
         identifier = event.get("identifier")
         issue_id = event.get("issue_id")
+
+        time = event.get("task_accepted_time")
         task_accepted_time = (
-            datetime.fromtimestamp(event.get("task_accepted_time"), timezone.utc)
-            if event.get("task_accepted_time")
-            else None
+            datetime.fromtimestamp(time, timezone.utc) if time else None
         )
+
         build_targets_override = event.get("build_targets_override")
         tests_targets_override = event.get("tests_targets_override")
         branches_override = event.get("branches_override")

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -394,6 +394,17 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         Measure the time it took to set the failed status in case of event (e.g. failed SRPM)
         that prevents Copr build to be submitted.
         """
+
+        # NOTE: When there is no ‹task_accepted_time›, we skip the submission to
+        # the metrics, since there is no delay between the submission and
+        # failure. We could probably track those by a separate metric as
+        # suggested by Maja in the PR.
+        if self.metadata.task_accepted_time is None:
+            logger.warning(
+                "No task_accepted_time for failed Copr build with reason: %s", reason
+            )
+            return
+
         time = elapsed_seconds(
             begin=self.metadata.task_accepted_time, end=datetime.now(timezone.utc)
         )


### PR DESCRIPTION
When submitting failed Copr builds to the Pushgateway, we're using time of accepting the task, in some cases we don't have time of accepting, so use ‹created_at› as a fallback.

Fixes #2258

<!-- notes for reviewers -->

Not sure about this change, since for the last occurrence in Sentry the difference between the reported time of failure and `created_at` is 5 minutes. I can the ‹task_accepted_time› only in DB, but this is happening even before the build starts, cause it's coming from an issue caused **by submitting** the build, so I would say that we should use the `datetime.now()`? But OTOH it doesn't feel like it's skipping the Celere queue and being handled _right away_.