### PR TITLE
Install epel-rpm-macros package on worker

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -40,6 +40,8 @@
           - python3-websocket-client
           # for full support of %autorelease and %autochangelog
           - rpmautospec-rpm-macros
+          # for additional macros needed to parse certain spec files
+          - epel-rpm-macros
           # for the `pkg_tool` switch to allow centpkg
           - centpkg
         state: present


### PR DESCRIPTION
This makes for example spec files using `%gometa -L` parseable.