### PR TITLE
Change parsing of comment command arguments

### DIFF
--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -200,8 +200,8 @@ def get_packit_commands_from_comment(
     comment_lines = comment_parts.split("\n")
 
     for line in filter(None, map(str.strip, comment_lines)):
-        (packit_mark, *packit_command) = line.split(maxsplit=3)
-        # packit_command[0] has the first cmd and [1] has the second, if needed.
+        (packit_mark, *packit_command) = line.split()
+        # packit_command[0] has the cmd and other list items are the arguments
         if packit_mark == packit_comment_command_prefix and packit_command:
             return packit_command
 

--- a/packit_service/worker/events/pagure.py
+++ b/packit_service/worker/events/pagure.py
@@ -134,7 +134,7 @@ class PullRequestCommentPagureEvent(AbstractPRCommentEvent, AbstractPagureEvent)
         if not commands:
             return super().get_packages_config()
         command = commands[0]
-        args = commands[1] if len(commands) > 1 else ""
+        args = commands[1:] if len(commands) > 1 else []
         if command == "pull-from-upstream" and "--with-pr-config" in args:
             # take packages config from the corresponding branch
             # for pull-from-upstream --with-pr-config

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2600,7 +2600,7 @@ def test_bodhi_update_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added)
 def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added):
     pagure_pr_comment_added["pullrequest"]["comments"][0][
         "comment"
-    ] = "/packit pull-from-upstream --resolved-bugs rhbz#123,rhbz#124"
+    ] = "/packit pull-from-upstream --with-pr-config --resolved-bugs rhbz#123,rhbz#124"
 
     model = flexmock(status="queued", id=1234, branch="main")
     flexmock(SyncReleaseTargetModel).should_receive("create").with_args(


### PR DESCRIPTION
So that if there are multiple arguments in the command, all of them are separate items of list returned by get_packit_commands_from_comment. This fixed parsing of resolved bugzillas in comment like '/packit pull-from-upstream --with-pr-config --resolved-bugs rhbz#123'

---

RELEASE NOTES BEGIN
 We have fixed parsing of resolved bugzillas in comments with multiple arguments specified e.g. `/packit pull-from-upstream --with-pr-config --resolved-bugs rhbz#123`
RELEASE NOTES END
