### PR TITLE
Fix diverging heads for alembic migrations

### DIFF
--- a/alembic/versions/31111f804dec_add_onboarded_check_in_gitprojectmodel_.py
+++ b/alembic/versions/31111f804dec_add_onboarded_check_in_gitprojectmodel_.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "31111f804dec"
-down_revision = "a3a17014c282"
+down_revision = "ab4c11acf5e1"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Both me and Matej have created a migration on top of the same version, making migrations diverging.
