### PR TITLE
Fix caching of usage API endpoints

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -60,7 +60,7 @@ from packit_service.constants import ALLOWLIST_CONSTANTS
 logger = logging.getLogger(__name__)
 
 _CACHE_MAXSIZE = 100
-_CACHE_TTL = timedelta(hours=1).seconds
+_CACHE_TTL = timedelta(hours=1).total_seconds()
 
 
 def get_pg_url() -> str:

--- a/packit_service/service/api/usage.py
+++ b/packit_service/service/api/usage.py
@@ -743,7 +743,7 @@ def _get_past_usage_data(datetime_from=None, datetime_to=None, top=5):
 @usage_ns.route("/past-day")
 class UsagePastDay(Resource):
     @usage_ns.response(HTTPStatus.OK, "Providing data about Packit usage")
-    @ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(hours=1).seconds)
+    @ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(hours=1).total_seconds())
     def get(self):
         yesterday_date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
         return _get_past_usage_data(datetime_from=yesterday_date)
@@ -752,7 +752,7 @@ class UsagePastDay(Resource):
 @usage_ns.route("/past-week")
 class UsagePastWeek(Resource):
     @usage_ns.response(HTTPStatus.OK, "Providing data about Packit usage")
-    @ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(hours=1).seconds)
+    @ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(hours=1).total_seconds())
     def get(self):
         past_week_date = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
         return _get_past_usage_data(datetime_from=past_week_date)
@@ -761,7 +761,7 @@ class UsagePastWeek(Resource):
 @usage_ns.route("/past-month")
 class UsagePastMonth(Resource):
     @usage_ns.response(HTTPStatus.OK, "Providing data about Packit usage")
-    @ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(days=1).seconds)
+    @ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(days=1).total_seconds())
     def get(self):
         now = datetime.now()
         past_month_past_day = now.replace(day=1) - timedelta(days=1)
@@ -774,7 +774,7 @@ class UsagePastMonth(Resource):
 @usage_ns.route("/past-year")
 class UsagePastYear(Resource):
     @usage_ns.response(HTTPStatus.OK, "Providing data about Packit usage")
-    @ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(days=1).seconds)
+    @ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(days=1).total_seconds())
     def get(self):
         now = datetime.now()
         past_year_date = now.replace(year=now.year - 1).strftime("%Y-%m-%d")
@@ -784,7 +784,7 @@ class UsagePastYear(Resource):
 @usage_ns.route("/total")
 class UsageTotal(Resource):
     @usage_ns.response(HTTPStatus.OK, "Providing data about Packit usage")
-    @ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(days=1).seconds)
+    @ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(days=1).total_seconds())
     def get(self):
         past_date = _DATE_IN_THE_PAST.strftime("%Y-%m-%d")
         return _get_past_usage_data(datetime_from=past_date)
@@ -794,7 +794,7 @@ class UsageTotal(Resource):
 CHART_DATA_TYPE = list[dict[str, Union[str, int]]]
 
 
-@ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(hours=1).seconds)
+@ttl_cache(maxsize=_CACHE_MAXSIZE, ttl=timedelta(hours=1).total_seconds())
 def _get_usage_interval_data(
     days: int, hours: int, count: int
 ) -> dict[str, Union[str, CHART_DATA_TYPE, dict[str, CHART_DATA_TYPE]]]:


### PR DESCRIPTION
For the cases when we use timedelta(days=1) in defining ttl caching, use total_seconds() instead of seconds argument, as timedelta(days=1).seconds returns 0.

Related to packit/dashboard#374

---

RELEASE NOTES BEGIN
We have fixed the caching of data for the usage API endpoint.
RELEASE NOTES END
