### PR TITLE
Fix getting info about sync release run in API

### DIFF
--- a/packit_service/service/api/utils.py
+++ b/packit_service/service/api/utils.py
@@ -56,12 +56,13 @@ def get_project_info_from_build(
 
 
 def get_sync_release_target_info(sync_release_model: SyncReleaseTargetModel):
+    pr_model = sync_release_model.pull_request
     job_result_dict = {
         "status": sync_release_model.status,
         "branch": sync_release_model.branch,
         "downstream_pr_url": sync_release_model.downstream_pr_url,
-        "downstream_pr_id": sync_release_model.pull_request.pr_id,
-        "downstream_pr_project": sync_release_model.pull_request.project.project_url,
+        "downstream_pr_id": pr_model.pr_id if pr_model else None,
+        "downstream_pr_project": pr_model.project.project_url if pr_model else None,
         "submitted_time": optional_timestamp(sync_release_model.submitted_time),
         "start_time": optional_timestamp(sync_release_model.start_time),
         "finished_time": optional_timestamp(sync_release_model.finished_time),

--- a/tests_openshift/conftest.py
+++ b/tests_openshift/conftest.py
@@ -360,6 +360,24 @@ def pull_from_upstream_target_model(release_project_event_model):
 
 
 @pytest.fixture()
+def pull_from_upstream_target_model_without_pr_model(release_project_event_model):
+    pull_from_upstream_model, _ = SyncReleaseModel.create_with_new_run(
+        status=SyncReleaseStatus.running,
+        project_event_model=release_project_event_model,
+        job_type=SyncReleaseJobType.pull_from_upstream,
+    )
+
+    target_model = SyncReleaseTargetModel.create(
+        status=SyncReleaseTargetStatus.submitted, branch=SampleValues.branch
+    )
+    target_model.set_finished_time(finished_time=datetime.datetime.utcnow())
+    target_model.set_logs(logs="random logs")
+
+    pull_from_upstream_model.sync_release_targets.append(target_model)
+    yield target_model
+
+
+@pytest.fixture()
 def propose_downstream_model_issue(an_issue_project_event_model):
     propose_downstream_model, _ = SyncReleaseModel.create_with_new_run(
         status=SyncReleaseStatus.running,

--- a/tests_openshift/service/test_api.py
+++ b/tests_openshift/service/test_api.py
@@ -672,6 +672,21 @@ def test_detailed_propose_info_issue(
     assert response_dict["issue_id"] == SampleValues.issue_id
 
 
+def test_detailed_pull_from_upstream_without_pr_model(
+    client, clean_before_and_after, pull_from_upstream_target_model_without_pr_model
+):
+    response = client.get(
+        url_for(
+            "api.pull-from-upstream_pull_result",
+            id=pull_from_upstream_target_model_without_pr_model.id,
+        )
+    )
+    response_dict = response.json
+
+    assert response_dict["downstream_pr_project"] is None
+    assert response_dict["downstream_pr_id"] is None
+
+
 @pytest.mark.parametrize(
     "key_to_check",
     [


### PR DESCRIPTION
If the run fails, there is no PR and therefore no PR model which resulted in AttributeError when accessing the attributes of it.

Fixes #2354


---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
