### PR TITLE
Consider neutral as final state when reporting

### DIFF
--- a/packit_service/worker/helpers/job_helper.py
+++ b/packit_service/worker/helpers/job_helper.py
@@ -199,14 +199,9 @@ class BaseJobHelper:
                 " For more details see our [guide](https://packit.dev/docs/guide#gitlab)."
             )
 
-            final_commit_states = (
-                BaseCommitStatus.success,
-                BaseCommitStatus.failure,
-                BaseCommitStatus.error,
-            )
             # We are only commenting final states to avoid multiple comments for a build
             # Ignoring all other states eg. pending, running
-            if state not in final_commit_states:
+            if not StatusReporter.is_final_state(state):
                 return
 
         self.status_reporter.report(

--- a/packit_service/worker/reporting/reporters/base.py
+++ b/packit_service/worker/reporting/reporters/base.py
@@ -160,6 +160,7 @@ class StatusReporter:
             BaseCommitStatus.success,
             BaseCommitStatus.error,
             BaseCommitStatus.failure,
+            BaseCommitStatus.neutral,
         }
 
     def _add_commit_comment_with_status(


### PR DESCRIPTION
These can be e.g.configuration errors and we should notify about those users.
Fixes #2325 

RELEASE NOTES BEGIN

We have fixed the reporting of configuration errors in GitLab.

RELEASE NOTES END
