### PR TITLE
Don't overwrite final state of Copr build

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1610,6 +1610,10 @@ class BuildStatus(str, enum.Enum):
     waiting_for_srpm = "waiting_for_srpm"
     retry = "retry"
 
+    @staticmethod
+    def is_final_state(status: "BuildStatus"):
+        return status in {BuildStatus.success, BuildStatus.failure, BuildStatus.error}
+
 
 class CoprBuildTargetModel(GroupAndTargetModelConnector, Base):
     """

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -175,10 +175,21 @@ class CoprBuildStartHandler(AbstractCoprBuildReportHandler):
             return TaskResults(success=False, details={"msg": msg})
 
         if self.build.build_start_time is not None:
-            logger.debug(
+            msg = (
                 f"Copr build start for {self.copr_event.build_id} is already"
                 f" processed."
             )
+            logger.debug(msg)
+            return TaskResults(success=True, details={"msg": msg})
+
+        if BuildStatus.is_final_state(self.build.status):
+            msg = (
+                "Copr build start is being processed, but the DB build "
+                "is already in the final state, setting only start time."
+            )
+            logger.debug(msg)
+            self.set_start_time()
+            return TaskResults(success=True, details={"msg": msg})
 
         self.set_logs_url()
 


### PR DESCRIPTION
In case the end was already processed, only set the start time and do not overwrite the end status and do not report this to user.

Fixes #2252

RELEASE NOTES BEGIN

We have fixed the bug about Packit overwriting the final state of the build in case the build start is being processed later than the end of the build.

RELEASE NOTES END
