### PR TITLE
ci(tests): pin pytest

### DIFF
--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -16,7 +16,7 @@
       ansible.builtin.pip:
         name:
           - requre
-          - pytest
+          - pytest==8.0.2
           - pytest-cov
           - pytest-flask
           - deepdiff


### PR DESCRIPTION
With pytest-8.1.0 it has been discovered that there are breaking changes which affect flexmock (https://github.com/flexmock/flexmock/issues/152).

This release has already been “yanked” from the pip, yet it's making our life miserable, so pin the pytest to the last working version until this mess is resolved.
