### PR TITLE
Check allowed_builders for Bodhi updates triggered by builds

### DIFF
--- a/packit_service/worker/checker/bodhi.py
+++ b/packit_service/worker/checker/bodhi.py
@@ -69,6 +69,23 @@ class IsKojiBuildCompleteAndBranchConfigured(Checker, GetKojiBuildData):
         return True
 
 
+class IsKojiBuildOwnerMatchingConfiguration(Checker, GetKojiBuildEventMixin):
+    def pre_check(self) -> bool:
+        """Check if the build submitter matches the configuration"""
+
+        if self.data.event_type in (KojiBuildEvent.__name__,):
+            if (owner := self.koji_build_event.owner) not in (
+                configured_builders := self.job_config.allowed_builders
+            ):
+                logger.info(
+                    f"Owner of the build ({owner}) does not match the"
+                    f"configuration: {configured_builders}"
+                )
+                return False
+
+        return True
+
+
 class IsKojiBuildCompleteAndBranchConfiguredCheckEvent(
     IsKojiBuildCompleteAndBranchConfigured,
     GetKojiBuildEventMixin,

--- a/packit_service/worker/events/koji.py
+++ b/packit_service/worker/events/koji.py
@@ -129,6 +129,7 @@ class KojiBuildEvent(AbstractKojiEvent):
         version: str,
         release: str,
         task_id: int,
+        owner: str,
         web_url: Optional[str] = None,
         old_state: Optional[KojiBuildState] = None,
         rpm_build_task_ids: Optional[Dict[str, int]] = None,
@@ -155,6 +156,7 @@ class KojiBuildEvent(AbstractKojiEvent):
         self.namespace = namespace
         self.repo_name = repo_name
         self.project_url = project_url
+        self.owner = owner
 
     def get_packages_config(self) -> Optional[PackageConfig]:
         logger.debug(
@@ -219,6 +221,7 @@ class KojiBuildEvent(AbstractKojiEvent):
             release=event.get("release"),
             start_time=event.get("start_time"),
             completion_time=event.get("completion_time"),
+            owner=event.get("owner"),
         )
 
 

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -33,6 +33,7 @@ from packit_service.worker.checker.bodhi import (
     HasIssueCommenterRetriggeringPermissions,
     IsKojiBuildCompleteAndBranchConfiguredCheckEvent,
     IsKojiBuildCompleteAndBranchConfiguredCheckService,
+    IsKojiBuildOwnerMatchingConfiguration,
 )
 from packit_service.worker.events import (
     PullRequestCommentPagureEvent,
@@ -251,7 +252,10 @@ class CreateBodhiUpdateHandler(
         and configured branches.
         """
         logger.debug("Bodhi update will be re-triggered via dist-git PR comment.")
-        return (IsKojiBuildCompleteAndBranchConfiguredCheckEvent,)
+        return (
+            IsKojiBuildCompleteAndBranchConfiguredCheckEvent,
+            IsKojiBuildOwnerMatchingConfiguration,
+        )
 
     def get_trigger_type_description(self) -> str:
         for koji_build_data in self:

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1336,7 +1336,8 @@ class Parser:
 
         build_id = event.get("build_id")
         task_id = event.get("task_id")
-        logger.info(f"Koji event: build_id={build_id} task_id={task_id}")
+        owner = event.get("owner")
+        logger.info(f"Koji event: build_id={build_id} task_id={task_id} owner={owner}")
 
         new_state = (
             KojiBuildState.from_number(raw_new)
@@ -1396,6 +1397,7 @@ class Parser:
             old_state=old_state,
             start_time=start_time,
             completion_time=completion_time,
+            owner=owner,
         )
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from packit_service.worker.events import (
     MergeRequestGitlabEvent,
     PushPagureEvent,
 )
+from packit_service.worker.events.koji import KojiBuildEvent
 from packit_service.worker.parser import Parser
 from tests.spellbook import SAVED_HTTPD_REQS, DATA_DIR, load_the_message_from_file
 from deepdiff import DeepDiff
@@ -523,6 +524,11 @@ def koji_build_completed_old_format():
 def koji_build_completed_rawhide():
     with open(DATA_DIR / "fedmsg" / "koji_build_completed_rawhide.json") as outfile:
         return load_the_message_from_file(outfile)
+
+
+@pytest.fixture()
+def koji_build_completed_event(koji_build_completed_rawhide) -> KojiBuildEvent:
+    return Parser.parse_koji_build_event(koji_build_completed_rawhide)
 
 
 @pytest.fixture()

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1204,6 +1204,7 @@ class TestEvents:
         assert event_object.state == KojiBuildState.building
         assert not event_object.old_state
         assert event_object.task_id == 80860791
+        assert event_object.owner == "packit"
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "23806a208e32cc937f3a6eb151c62cbbc10d8f96"
         assert event_object.branch_name == "epel8"
@@ -1284,6 +1285,7 @@ class TestEvents:
         assert event_object.state == KojiBuildState.complete
         assert event_object.old_state == KojiBuildState.building
         assert event_object.task_id == 80860894
+        assert event_object.owner == "packit"
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "e029dd5250dde9a37a2cdddb6d822d973b09e5da"
         assert event_object.branch_name == "rawhide"
@@ -1326,6 +1328,7 @@ class TestEvents:
         assert event_object.state == KojiBuildState.complete
         assert event_object.old_state == KojiBuildState.building
         assert event_object.task_id == 80860789
+        assert event_object.owner == "packit"
         assert event_object.package_name == "python-ogr"
         assert event_object.commit_sha == "51b57ec04f5e6e9066ac859a1408cfbf1ead307e"
         assert event_object.branch_name == "f36"
@@ -1370,6 +1373,7 @@ class TestEvents:
         assert event_object.old_state == KojiBuildState.building
         assert event_object.task_id == 80860791
         assert event_object.package_name == "python-ogr"
+        assert event_object.owner == "packit"
         assert event_object.commit_sha == "23806a208e32cc937f3a6eb151c62cbbc10d8f96"
         assert event_object.branch_name == "epel8"
         assert event_object.git_ref == "epel8"


### PR DESCRIPTION
Fixes #2312


RELEASE NOTES BEGIN

You can now configure a list of Fedora accounts of users whose successful Koji builds will trigger automatic Bodhi updates (by default only `packit`).

RELEASE NOTES END
