### PR TITLE
Declare babysit tasks celery queue in a different way

### DIFF
--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -7,6 +7,12 @@ import packit_service.constants
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std-setting-task_default_queue
 task_default_queue = packit_service.constants.CELERY_TASK_DEFAULT_QUEUE
 
+
+task_routes = [
+    ("task.babysit_vm_image_build", {"queue": "short-running"}),
+    ("task.babysit_copr_build", {"queue": "short-running"}),
+]
+
 # https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html
 beat_schedule = {
     "update-pending-copr-builds": {

--- a/packit_service/worker/handlers/vm_image.py
+++ b/packit_service/worker/handlers/vm_image.py
@@ -105,7 +105,6 @@ class VMImageBuildHandler(
             "task.babysit_vm_image_build",
             args=(image_id,),
             countdown=10,  # do the first check in 10s
-            queue="long-running",
         )
 
         self.report_status(VMImageBuildStatus.pending, "")

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -766,7 +766,6 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             "task.babysit_copr_build",
             args=(build_id,),
             countdown=120,  # do the first check in 120s
-            queue="long-running",
         )
 
     def _visualize_chroots_diff(


### PR DESCRIPTION
send_task  should have the same options as apply_async,
nevertheless passing queue as an option is not working.
Probably because the referenced queues have to be defined in task_queues.
Instead of defining task_queues let define explicitly the routes.