### PR TITLE
Hide manual test statuses only when build handler is required

### DIFF
--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -260,13 +260,14 @@ class TestingFarmHandler(
                     "The latest build has not finished yet, "
                     "waiting until it finishes before running tests for it."
                 )
-                self.testing_farm_job_helper.report_status_to_tests_for_test_target(
-                    state=BaseCommitStatus.pending,
-                    description="The latest build has not finished yet, "
-                    "waiting until it finishes before running tests for it.",
-                    target=test_run.target,
-                    url=get_copr_build_info_url(copr_build.id),
-                )
+                if not self.job_config.manual_trigger:
+                    self.testing_farm_job_helper.report_status_to_tests_for_test_target(
+                        state=BaseCommitStatus.pending,
+                        description="The latest build has not finished yet, "
+                        "waiting until it finishes before running tests for it.",
+                        target=test_run.target,
+                        url=get_copr_build_info_url(copr_build.id),
+                    )
                 continue
 
             # Only retry what's needed


### PR DESCRIPTION
We should not check the labels and identifiers, this should be handled by pre-checks and results in no reporting for TF notifications.

Fixes #2386

TODO:
- [ ] testcase

RELEASE NOTES BEGIN

We have fixed reporting of tests with `manual_trigger: True`.

RELEASE NOTES END
