### PR TITLE
Store package config in DB project event

### DIFF
--- a/packit_service/service/db_project_events.py
+++ b/packit_service/service/db_project_events.py
@@ -7,6 +7,7 @@ This file contains helper classes for events.
 from typing import Optional, Dict
 
 from ogr.abstract import GitProject
+from packit.config import PackageConfig
 from packit_service.models import (
     GitBranchModel,
     IssueModel,
@@ -14,6 +15,7 @@ from packit_service.models import (
     PullRequestModel,
     ProjectEventModel,
 )
+from packit_service.utils import dump_package_config
 
 
 class AddReleaseEventToDb:
@@ -21,6 +23,7 @@ class AddReleaseEventToDb:
     repo_namespace: str
     repo_name: str
     project_url: str
+    packages_config: PackageConfig
     _release: ProjectReleaseModel = None
     _event: ProjectEventModel = None
 
@@ -32,6 +35,7 @@ class AddReleaseEventToDb:
                 repo_name=self.repo_name,
                 project_url=self.project_url,
                 commit_hash=self.commit_sha,
+                packages_config=dump_package_config(self.packages_config),
             )
         return self._release, self._event
 
@@ -52,7 +56,9 @@ class AddReleaseEventToDb:
         (_, event) = self._add_release_and_event()
         return event
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()  # type: ignore
         result.pop("_release", None)
         result.pop("_event", None)
@@ -65,6 +71,7 @@ class AddBranchPushEventToDb:
     repo_name: str
     project_url: str
     commit_sha: str
+    packages_config: PackageConfig
     _branch: GitBranchModel = None
     _event: ProjectEventModel = None
 
@@ -76,6 +83,7 @@ class AddBranchPushEventToDb:
                 repo_name=self.repo_name,
                 project_url=self.project_url,
                 commit_sha=self.commit_sha,
+                packages_config=dump_package_config(self.packages_config),
             )
         return self._branch, self._event
 
@@ -89,7 +97,9 @@ class AddBranchPushEventToDb:
         (_, event) = self._add_branch_and_event()
         return event
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()  # type: ignore
         result.pop("_branch", None)
         result.pop("_event", None)
@@ -112,6 +122,7 @@ class AddPullRequestEventToDb:
                 repo_name=self.project.repo,
                 project_url=self.project_url,
                 commit_sha=self.commit_sha,
+                packages_config=dump_package_config(self.packages_config),
             )
         return self._pull_request, self._event
 
@@ -125,7 +136,9 @@ class AddPullRequestEventToDb:
         (_, event) = self._add_pull_request_and_event()
         return event
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()  # type: ignore
         result.pop("_pull_request", None)
         result.pop("_event", None)
@@ -138,6 +151,7 @@ class AddIssueEventToDb:
     repo_name: str
     project_url: str
     commit_sha: str
+    packages_config: PackageConfig
     _issue: IssueModel = None
     _event: ProjectEventModel = None
 
@@ -148,6 +162,7 @@ class AddIssueEventToDb:
                 namespace=self.repo_namespace,
                 repo_name=self.repo_name,
                 project_url=self.project_url,
+                packages_config=dump_package_config(self.packages_config),
             )
         return self._issue, self._event
 
@@ -161,7 +176,9 @@ class AddIssueEventToDb:
         (_, event) = self._add_issue_and_event()
         return event
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()  # type: ignore
         result.pop("_issue", None)
         result.pop("_event", None)

--- a/packit_service/worker/events/comment.py
+++ b/packit_service/worker/events/comment.py
@@ -38,7 +38,9 @@ class AbstractCommentEvent(AbstractForgeIndependentEvent):
     def comment_object(self) -> Optional[Comment]:
         raise NotImplementedError("Use subclass instead.")
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result.pop("_comment_object")
         return result
@@ -108,7 +110,9 @@ class AbstractPRCommentEvent(AddPullRequestEventToDb, AbstractCommentEvent):
             )
         return self._tests_targets_override
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["commit_sha"] = self.commit_sha
         result.pop("_build_targets_override")
@@ -175,7 +179,9 @@ class AbstractIssueCommentEvent(AddIssueEventToDb, AbstractCommentEvent):
             self._comment_object = self.issue_object.get_comment(self.comment_id)
         return self._comment_object
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["tag_name"] = self.tag_name
         result["commit_sha"] = self.commit_sha

--- a/packit_service/worker/events/copr.py
+++ b/packit_service/worker/events/copr.py
@@ -6,6 +6,7 @@ from typing import Optional, Dict, Union
 
 from ogr.abstract import GitProject
 from ogr.services.pagure import PagureProject
+from packit.config import PackageConfig
 
 from packit_service.constants import COPR_SRPM_CHROOT
 from packit_service.models import (
@@ -15,6 +16,7 @@ from packit_service.models import (
     SRPMBuildModel,
     ProjectEventModel,
 )
+from packit_service.utils import load_package_config
 from packit_service.worker.events.event import AbstractResultEvent
 from packit_service.worker.events.enums import FedmsgTopic
 
@@ -72,6 +74,11 @@ class AbstractCoprBuildEvent(AbstractResultEvent):
 
     def get_db_project_event(self) -> Optional[ProjectEventModel]:
         return self.build.get_project_event_model()
+
+    def get_packages_config(self) -> Optional[PackageConfig]:
+        if self.build.packages_config:
+            return load_package_config(self.build.packages_config)
+        return super().get_packages_config()
 
     def get_base_project(self) -> Optional[GitProject]:
         if self.pr_id is not None:
@@ -140,7 +147,9 @@ class AbstractCoprBuildEvent(AbstractResultEvent):
     def get_non_serializable_attributes(self):
         return super().get_non_serializable_attributes() + ["build"]
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["topic"] = result["topic"].value
         return result

--- a/packit_service/worker/events/github.py
+++ b/packit_service/worker/events/github.py
@@ -62,7 +62,9 @@ class ReleaseEvent(AddReleaseEventToDb, AbstractGithubEvent):
             self._commit_sha = self.project.get_sha_from_tag(tag_name=self.tag_name)
         return self._commit_sha
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["commit_sha"] = self.commit_sha
         return result
@@ -111,7 +113,9 @@ class PullRequestGithubEvent(AddPullRequestEventToDb, AbstractGithubEvent):
         self.identifier = str(pr_id)
         self.git_ref = None  # pr_id will be used for checkout
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["action"] = result["action"].value
         return result
@@ -155,7 +159,9 @@ class PullRequestCommentGithubEvent(AbstractPRCommentEvent, AbstractGithubEvent)
         self.identifier = str(pr_id)
         self.git_ref = None  # pr_id will be used for checkout
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["action"] = result["action"].value
         return result
@@ -200,7 +206,9 @@ class IssueCommentEvent(AbstractIssueCommentEvent, AbstractGithubEvent):
         self.target_repo = target_repo
         self.identifier = str(issue_id)
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["action"] = result["action"].value
         return result
@@ -390,7 +398,9 @@ class InstallationEvent(Event):
             sender_login=event.get("sender_login"),
         )
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["status"] = result["status"].value
         return result

--- a/packit_service/worker/events/gitlab.py
+++ b/packit_service/worker/events/gitlab.py
@@ -86,7 +86,9 @@ class MergeRequestGitlabEvent(AddPullRequestEventToDb, AbstractGitlabEvent):
         self.description = description
         self.url = url
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["action"] = result["action"].value
         return result
@@ -132,7 +134,9 @@ class MergeRequestCommentGitlabEvent(AbstractPRCommentEvent, AbstractGitlabEvent
         self.actor = actor
         self.identifier = str(object_iid)
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["action"] = result["action"].value
         return result
@@ -173,7 +177,9 @@ class IssueCommentGitlabEvent(AbstractIssueCommentEvent, AbstractGitlabEvent):
         self.action = action
         self.actor = actor
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["action"] = result["action"].value
         return result
@@ -224,7 +230,9 @@ class ReleaseGitlabEvent(AddReleaseEventToDb, AbstractGitlabEvent):
     def commit_sha(self):
         return self._commit_sha
 
-    def get_dict(self, default_dict: Optional[dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["commit_sha"] = self.commit_sha
         return result

--- a/packit_service/worker/events/new_hotness.py
+++ b/packit_service/worker/events/new_hotness.py
@@ -140,7 +140,9 @@ class AnityaUpdateEvent(Event):
 
         return self.packages_config.upstream_tag_template.format(version=self.version)
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         d = self.__dict__
         d["project_url"] = self.project_url
         d["tag_name"] = self.tag_name

--- a/packit_service/worker/events/pagure.py
+++ b/packit_service/worker/events/pagure.py
@@ -107,7 +107,9 @@ class PullRequestCommentPagureEvent(AbstractPRCommentEvent, AbstractPagureEvent)
 
         self._repo_url: Optional[RepoUrl] = None
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         d = self.__dict__
         d["repo_name"] = self.repo_name
         d["repo_namespace"] = self.repo_namespace
@@ -215,7 +217,9 @@ class PullRequestPagureEvent(AddPullRequestEventToDb, AbstractPagureEvent):
         self.git_ref = None  # pr_id will be used for checkout
         self.project_url = project_url
 
-    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+    def get_dict(
+        self, default_dict: Optional[Dict] = None, store_event: bool = False
+    ) -> dict:
         result = super().get_dict()
         result["action"] = result["action"].value
         return result

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -360,7 +360,7 @@ class JobHandler(Handler):
                     else None
                 ),
                 "job_config": dump_job_config(job),
-                "event": event.get_dict(),
+                "event": event.get_dict(store_event=True),
             },
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,7 @@ def srpm_build_model(
         type=pr_model.project_event_model_type,
         event_id=pr_model.id,
         commit_sha="0011223344",
+        packages_config=dict,
     ).and_return(project_event_model)
 
     def mock_set_status(status):
@@ -230,6 +231,7 @@ def copr_build_model(
         type=trigger_object_model.project_event_model_type,
         event_id=trigger_object_model.id,
         commit_sha="0011223344",
+        packages_config=dict,
     ).and_return(project_event_model)
 
     def mock_set_status(status):
@@ -309,6 +311,7 @@ def koji_build_pr():
         type=pr_model.project_event_model_type,
         event_id=pr_model.id,
         commit_sha="0011223344",
+        packages_config="dict",
     ).and_return(project_event_model)
 
     run_model = flexmock(
@@ -361,7 +364,10 @@ def add_pull_request_event_with_pr_id_9():
         db_project_object
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.pull_request, event_id=9, commit_sha="12345"
+        type=ProjectEventModelType.pull_request,
+        event_id=9,
+        commit_sha="12345",
+        packages_config=dict,
     ).and_return(db_project_event)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=9,
@@ -389,7 +395,10 @@ def add_pull_request_event_with_sha_0011223344():
         db_project_object
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.pull_request, event_id=9, commit_sha="0011223344"
+        type=ProjectEventModelType.pull_request,
+        event_id=9,
+        commit_sha="0011223344",
+        packages_config=dict,
     ).and_return(db_project_event)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=9,

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -71,7 +71,10 @@ def test_sync_from_downstream():
     ).and_return(["buildah.spec", ".packit.yaml"])
 
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.branch_push, event_id=9, commit_sha="abcd"
+        type=ProjectEventModelType.branch_push,
+        event_id=9,
+        commit_sha="abcd",
+        packages_config=dict,
     ).and_return(flexmock())
     flexmock(GitBranchModel).should_receive("get_or_create").with_args(
         branch_name="main",
@@ -149,7 +152,10 @@ def test_do_not_sync_from_downstream_on_a_different_branch():
     ).and_return(["buildah.spec", ".packit.yaml"])
 
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.branch_push, event_id=9, commit_sha="abcd"
+        type=ProjectEventModelType.branch_push,
+        event_id=9,
+        commit_sha="abcd",
+        packages_config=dict,
     ).and_return(flexmock())
     flexmock(GitBranchModel).should_receive("get_or_create").with_args(
         branch_name="main",
@@ -225,7 +231,10 @@ def test_downstream_koji_build():
         .mock()
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.branch_push, event_id=9, commit_sha="abcd"
+        type=ProjectEventModelType.branch_push,
+        event_id=9,
+        commit_sha="abcd",
+        packages_config=dict,
     ).and_return(flexmock())
     flexmock(GitBranchModel).should_receive("get_or_create").with_args(
         branch_name="main",
@@ -320,7 +329,10 @@ def test_downstream_koji_build_failure_no_issue():
         .mock()
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.branch_push, event_id=9, commit_sha="abcd"
+        type=ProjectEventModelType.branch_push,
+        event_id=9,
+        commit_sha="abcd",
+        packages_config=dict,
     ).and_return(flexmock())
     flexmock(GitBranchModel).should_receive("get_or_create").with_args(
         branch_name="main",
@@ -419,7 +431,10 @@ def test_downstream_koji_build_failure_issue_created():
         .mock()
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.branch_push, event_id=9, commit_sha="abcd"
+        type=ProjectEventModelType.branch_push,
+        event_id=9,
+        commit_sha="abcd",
+        packages_config=dict,
     ).and_return(flexmock())
     flexmock(GitBranchModel).should_receive("get_or_create").with_args(
         branch_name="main",
@@ -524,7 +539,10 @@ def test_downstream_koji_build_failure_issue_comment():
         .mock()
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.branch_push, event_id=9, commit_sha="abcd"
+        type=ProjectEventModelType.branch_push,
+        event_id=9,
+        commit_sha="abcd",
+        packages_config=dict,
     ).and_return(flexmock())
     flexmock(GitBranchModel).should_receive("get_or_create").with_args(
         branch_name="main",
@@ -720,7 +738,10 @@ def test_downstream_koji_build_where_multiple_branches_defined(jobs_config):
         .mock()
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.branch_push, event_id=9, commit_sha="abcd"
+        type=ProjectEventModelType.branch_push,
+        event_id=9,
+        commit_sha="abcd",
+        packages_config=dict,
     ).and_return(flexmock())
     flexmock(GitBranchModel).should_receive("get_or_create").with_args(
         branch_name="main",
@@ -832,7 +853,10 @@ def test_do_not_run_downstream_koji_build_for_a_different_branch(jobs_config):
     ).and_return(["buildah.spec", ".packit.yaml"])
 
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.branch_push, event_id=9, commit_sha="abcd"
+        type=ProjectEventModelType.branch_push,
+        event_id=9,
+        commit_sha="abcd",
+        packages_config=dict,
     ).and_return(flexmock())
     flexmock(GitBranchModel).should_receive("get_or_create").with_args(
         branch_name="main",

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -14,7 +14,7 @@ from packit.config import (
     JobType,
     PackageConfig,
 )
-from packit_service.config import ServiceConfig
+from packit_service.config import ServiceConfig, PackageConfigGetter
 from packit_service.constants import KOJI_PRODUCTION_BUILDS_ISSUE
 from packit_service.models import (
     GitBranchModel,
@@ -79,6 +79,7 @@ def test_handler_cleanup(tmp_path, trick_p_s_with_k8s):
 
 
 def test_precheck(github_pr_event):
+    flexmock(PackageConfigGetter).should_receive("get_package_config_from_repo")
     db_project_object = flexmock(
         id=342,
         job_config_trigger_type=JobConfigTriggerType.pull_request,
@@ -94,6 +95,7 @@ def test_precheck(github_pr_event):
         type=ProjectEventModelType.pull_request,
         event_id=342,
         commit_sha="528b803be6f93e19ca4130bf4976f2800a3004c4",
+        packages_config=None,
     ).and_return(db_project_event)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=342,
@@ -131,6 +133,7 @@ def test_precheck(github_pr_event):
 
 
 def test_precheck_gitlab(gitlab_mr_event):
+    flexmock(PackageConfigGetter).should_receive("get_package_config_from_repo")
     db_project_object = flexmock(
         id=1,
         job_config_trigger_type=JobConfigTriggerType.pull_request,
@@ -146,6 +149,7 @@ def test_precheck_gitlab(gitlab_mr_event):
         type=ProjectEventModelType.pull_request,
         event_id=1,
         commit_sha="1f6a716aa7a618a9ffe56970d77177d99d100022",
+        packages_config=None,
     ).and_return(db_project_event)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=1,
@@ -188,6 +192,7 @@ def test_precheck_gitlab(gitlab_mr_event):
 
 
 def test_precheck_push(github_push_event):
+    flexmock(PackageConfigGetter).should_receive("get_package_config_from_repo")
     db_project_object = flexmock(
         id=1,
         job_config_trigger_type=JobConfigTriggerType.commit,
@@ -204,6 +209,7 @@ def test_precheck_push(github_push_event):
         type=ProjectEventModelType.branch_push,
         event_id=1,
         commit_sha="04885ff850b0fa0e206cd09db73565703d48f99b",
+        packages_config=None,
     ).and_return(db_project_event)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         db_project_object
@@ -243,6 +249,7 @@ def test_precheck_push(github_push_event):
 
 
 def test_precheck_push_to_a_different_branch(github_push_event):
+    flexmock(PackageConfigGetter).should_receive("get_package_config_from_repo")
     db_project_object = flexmock(
         id=1,
         job_config_trigger_type=JobConfigTriggerType.commit,
@@ -259,6 +266,7 @@ def test_precheck_push_to_a_different_branch(github_push_event):
         type=ProjectEventModelType.branch_push,
         event_id=1,
         commit_sha="04885ff850b0fa0e206cd09db73565703d48f99b",
+        packages_config=None,
     ).and_return(db_project_event)
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         db_project_object
@@ -292,6 +300,7 @@ def test_precheck_push_to_a_different_branch(github_push_event):
 
 
 def test_precheck_push_actor_check(github_push_event):
+    flexmock(PackageConfigGetter).should_receive("get_package_config_from_repo")
     flexmock(GitBranchModel).should_receive("get_or_create").and_return(
         flexmock(id=1, job_config_trigger_type=JobConfigTriggerType.commit)
     )
@@ -317,6 +326,7 @@ def test_precheck_push_actor_check(github_push_event):
 
 
 def test_precheck_koji_build_non_scratch(github_pr_event):
+    flexmock(PackageConfigGetter).should_receive("get_package_config_from_repo")
     db_project_object = flexmock(
         id=342,
         job_config_trigger_type=JobConfigTriggerType.pull_request,
@@ -342,6 +352,7 @@ def test_precheck_koji_build_non_scratch(github_pr_event):
         type=ProjectEventModelType.pull_request,
         event_id=342,
         commit_sha="528b803be6f93e19ca4130bf4976f2800a3004c4",
+        packages_config=None,
     ).and_return(db_project_event)
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=BaseCommitStatus.neutral,

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -219,7 +219,10 @@ def test_issue_comment_propose_downstream_handler(
         .mock()
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.issue, event_id=123, commit_sha=None
+        type=ProjectEventModelType.issue,
+        event_id=123,
+        commit_sha=None,
+        packages_config=dict,
     ).and_return(db_project_event)
     flexmock(IssueModel).should_receive("get_or_create").and_return(db_project_object)
 

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -57,7 +57,10 @@ def sync_release_model():
     )
     run_model = flexmock(PipelineModel)
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.release, event_id=12, commit_sha=None
+        type=ProjectEventModelType.release,
+        event_id=12,
+        commit_sha=None,
+        packages_config=dict,
     ).and_return(project_event)
     flexmock(ProjectReleaseModel).should_receive("get_or_create").with_args(
         tag_name="7.0.3",

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -182,7 +182,10 @@ def mock_pr_comment_functionality(request):
         .mock()
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.pull_request, event_id=9, commit_sha="12345"
+        type=ProjectEventModelType.pull_request,
+        event_id=9,
+        commit_sha="12345",
+        packages_config=dict,
     ).and_return(db_project_event)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=9,
@@ -442,7 +445,10 @@ def test_pr_comment_production_build_handler(pr_production_build_comment_event):
     flexmock(Allowlist, check_and_report=True)
 
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.pull_request, event_id=9, commit_sha="12345"
+        type=ProjectEventModelType.pull_request,
+        event_id=9,
+        commit_sha="12345",
+        packages_config=dict,
     ).and_return(project_event)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=9,
@@ -1846,7 +1852,10 @@ def test_retest_failed(
         .mock()
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.pull_request, event_id=9, commit_sha="12345"
+        type=ProjectEventModelType.pull_request,
+        event_id=9,
+        commit_sha="12345",
+        packages_config=dict,
     ).and_return(db_project_event)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=9,
@@ -2489,6 +2498,7 @@ def test_koji_build_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added):
         type=ProjectEventModelType.pull_request,
         event_id=12,
         commit_sha="beaf90bcecc51968a46663f8d6f092bfdc92e682",
+        packages_config=dict,
     ).and_return(db_project_event)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=pagure_pr_comment_added["pullrequest"]["id"],
@@ -2583,6 +2593,7 @@ def test_bodhi_update_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added)
         type=ProjectEventModelType.pull_request,
         event_id=12,
         commit_sha="beaf90bcecc51968a46663f8d6f092bfdc92e682",
+        packages_config=dict,
     ).and_return(project_event)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=36,
@@ -2819,6 +2830,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
         type=ProjectEventModelType.pull_request,
         event_id=12,
         commit_sha="beaf90bcecc51968a46663f8d6f092bfdc92e682",
+        packages_config=dict,
     ).and_return(db_project_event)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=pagure_pr_comment_added["pullrequest"]["id"],

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -67,7 +67,10 @@ def propose_downstream_model():
     )
     run_model = flexmock(PipelineModel)
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.release, event_id=12, commit_sha="123456"
+        type=ProjectEventModelType.release,
+        event_id=12,
+        commit_sha="123456",
+        packages_config=dict,
     ).and_return(db_project_event)
     flexmock(ProjectReleaseModel).should_receive("get_or_create").with_args(
         tag_name="0.3.0",

--- a/tests/integration/test_vm_image_build.py
+++ b/tests/integration/test_vm_image_build.py
@@ -3,18 +3,12 @@
 
 import json
 
-from flexmock import flexmock
-
 from celery import Celery
 from celery.canvas import Signature
+from flexmock import flexmock
 
 from ogr.services.github import GithubProject
-
-from packit_service.worker.jobs import SteveJobs
-from packit_service.worker.monitoring import Pushgateway
-from packit_service.worker.tasks import (
-    run_vm_image_build,
-)
+from packit.copr_helper import CoprHelper
 from packit_service.models import (
     PullRequestModel,
     JobConfigTriggerType,
@@ -25,9 +19,13 @@ from packit_service.models import (
     ProjectEventModel,
 )
 from packit_service.worker.allowlist import Allowlist
-from tests.spellbook import first_dict_value, get_parameters_from_results
 from packit_service.worker.handlers.vm_image import VMImageBuildHandler
-from packit.copr_helper import CoprHelper
+from packit_service.worker.jobs import SteveJobs
+from packit_service.worker.monitoring import Pushgateway
+from packit_service.worker.tasks import (
+    run_vm_image_build,
+)
+from tests.spellbook import first_dict_value, get_parameters_from_results
 
 
 def test_vm_image_build(github_vm_image_build_comment):
@@ -76,7 +74,10 @@ def test_vm_image_build(github_vm_image_build_comment):
     ).and_return(["packit.spec", ".packit.yaml"])
 
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.pull_request, event_id=1, commit_sha="123456"
+        type=ProjectEventModelType.pull_request,
+        event_id=1,
+        commit_sha="123456",
+        packages_config=dict,
     ).and_return(flexmock())
     flexmock(PullRequestModel).should_receive("get_or_create").and_return(
         flexmock(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -83,7 +83,10 @@ def add_pull_request_event_with_empty_sha():
     )
 
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.pull_request, event_id=123, commit_sha=""
+        type=ProjectEventModelType.pull_request,
+        event_id=123,
+        commit_sha="",
+        packages_config=dict,
     ).and_return(db_project_event)
     yield db_project_object, db_project_event
 

--- a/tests/unit/test_mixin.py
+++ b/tests/unit/test_mixin.py
@@ -1,14 +1,16 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-import pytest
-
-from flexmock import flexmock
 from typing import Optional
 
-from packit.vm_image_build import ImageBuilder
+import pytest
+from flexmock import flexmock
+
 from ogr.abstract import GitProject
+from packit.vm_image_build import ImageBuilder
 from packit_service.config import ServiceConfig
+from packit_service.worker.events import EventData
+from packit_service.worker.events.comment import AbstractIssueCommentEvent
 from packit_service.worker.handlers.mixin import (
     GetVMImageBuilderMixin,
     GetCoprBuildJobHelperMixin,
@@ -19,9 +21,6 @@ from packit_service.worker.mixin import (
     ConfigFromDistGitUrlMixin,
     ConfigFromEventMixin,
 )
-
-from packit_service.worker.events import EventData
-from packit_service.worker.events.comment import AbstractIssueCommentEvent
 
 
 def test_GetVMImageBuilderMixin():
@@ -150,6 +149,7 @@ def test_ConfigFromDistGitUrlMixin():
                 comment="probably an issue opened by the propose downstream",
                 comment_id=1,
             )
+            flexmock(AbstractIssueCommentEvent).should_receive("get_packages_config")
             event.dist_git_project_url = "url to distgit"
             self.data = EventData.from_event_dict(
                 flexmock(event, tag_name="a tag", commit_sha="aebdf").get_dict()

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -121,7 +121,10 @@ def test_process_message(event, private, enabled_private_namespaces, success):
         .mock()
     )
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.release, event_id=12, commit_sha="12345"
+        type=ProjectEventModelType.release,
+        event_id=12,
+        commit_sha="12345",
+        packages_config=dict,
     ).and_return(db_project_event)
     flexmock(ProjectReleaseModel).should_receive("get_or_create").with_args(
         tag_name="1.2.3",

--- a/tests_openshift/database/test_models.py
+++ b/tests_openshift/database/test_models.py
@@ -419,7 +419,10 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
         project_url="https://github.com/the-namespace/the-repo-name",
     )
     project_event = ProjectEventModel.get_or_create(
-        type=ProjectEventModelType.pull_request, event_id=pr1.id, commit_sha="abcdef"
+        type=ProjectEventModelType.pull_request,
+        event_id=pr1.id,
+        commit_sha="abcdef",
+        packages_config=dict,
     )
     # SRPMBuildModel is (sadly) not shared between Koji and Copr builds.
     srpm_build_for_copr, run_model_for_copr = SRPMBuildModel.create_with_new_run(


### PR DESCRIPTION
So that it doesn't have to be obtained via Github API multiple times during the pipeline (e.g. Copr build start, end, Testing farm results)

Fixes #1940


TODO:

- [ ] think about cleanup in DB (periodic/pipeline end)
- [ ] make sure that now that `Event.get_dict()` calls `get_packages_config()`, it doesn't cause obtaining package config in case it is not really needed (e.g. maybe in Event.__str__)
- [ ] test

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
