### PR TITLE
fix(sync-release): upload to lookaside cache only for Fedora

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -252,6 +252,8 @@ class AbstractSyncReleaseHandler(
                 ),
                 sync_acls=True,
                 pr_description_footer=DistgitAnnouncement.get_announcement(),
+                # [TODO] Remove for CentOS support once it gets refined
+                add_new_sources=self.package_config.pkg_tool in (None, "fedpkg"),
             )
         except PackitDownloadFailedException as ex:
             # the archive has not been uploaded to PyPI yet

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -175,6 +175,7 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         release_monitoring_project_id=4181,
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
+        add_new_sources=True,
     ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2784,6 +2784,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
         release_monitoring_project_id=None,
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
+        add_new_sources=True,
     ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -211,6 +211,7 @@ def test_dist_git_push_release_handle(github_release_webhook, propose_downstream
         release_monitoring_project_id=None,
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
+        add_new_sources=True,
     ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -350,6 +351,7 @@ def test_dist_git_push_release_handle_multiple_branches(
             release_monitoring_project_id=None,
             sync_acls=True,
             pr_description_footer=DistgitAnnouncement.get_announcement(),
+            add_new_sources=True,
         ).and_return(pr).once()
 
         flexmock(ProposeDownstreamJobHelper).should_receive(
@@ -496,6 +498,7 @@ def test_dist_git_push_release_handle_one_failed(
                 release_monitoring_project_id=None,
                 sync_acls=True,
                 pr_description_footer=DistgitAnnouncement.get_announcement(),
+                add_new_sources=True,
             ).and_return(pr).once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
@@ -518,6 +521,7 @@ def test_dist_git_push_release_handle_one_failed(
                 release_monitoring_project_id=None,
                 sync_acls=True,
                 pr_description_footer=DistgitAnnouncement.get_announcement(),
+                add_new_sources=True,
             ).and_raise(Exception, f"Failed {model.branch}").once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
@@ -759,6 +763,7 @@ def test_retry_propose_downstream_task(
         release_monitoring_project_id=None,
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
+        add_new_sources=True,
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()
@@ -870,6 +875,7 @@ def test_dont_retry_propose_downstream_task(
         release_monitoring_project_id=None,
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
+        add_new_sources=True,
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -189,6 +189,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
         release_monitoring_project_id=None,
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
+        add_new_sources=True,
     ).and_return(pr).times(1 if success else 0)
     flexmock(shutil).should_receive("rmtree").with_args("")
 


### PR DESCRIPTION
When uploading the sources to lookaside cache, we cannot upload them to the CentOS as the cache is writeable only on the VPN / internal network.

However we still want to be able to submit updates via an MR, even if maintainer has to submit the archives to the lookaside cache by themselves.

Once the workflow with regards to the lookaside cache has been improved, drop this requirement from our side.

<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

<!-- release notes footer -->

(no release notes… disabling something that didn't even work in the first place…)
