### PR TITLE
Feat/configurable check name

### DIFF
--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -412,9 +412,16 @@ class BaseBuildJobHelper(BaseJobHelper):
         chroot: str = None,
         project_event_identifier: Optional[str] = None,
         identifier: Optional[str] = None,
+        package: Optional[str] = None,
+        template: Optional[str] = None,
     ):
         return cls.get_check_cls(
-            cls.status_name_build, chroot, project_event_identifier, identifier
+            cls.status_name_build,
+            chroot,
+            project_event_identifier,
+            identifier,
+            package=package,
+            template=template,
         )
 
     @classmethod
@@ -423,9 +430,16 @@ class BaseBuildJobHelper(BaseJobHelper):
         chroot: str = None,
         project_event_identifier: Optional[str] = None,
         identifier: Optional[str] = None,
+        package: Optional[str] = None,
+        template: Optional[str] = None,
     ):
         return cls.get_check_cls(
-            cls.status_name_test, chroot, project_event_identifier, identifier
+            cls.status_name_test,
+            chroot,
+            project_event_identifier,
+            identifier,
+            package=package,
+            template=template,
         )
 
     @property
@@ -447,6 +461,8 @@ class BaseBuildJobHelper(BaseJobHelper):
             chroot,
             self.project_event_identifier_for_status,
             self.job_build_or_job_config.identifier,
+            package=None,  # [TODO]
+            template=self.job_build_or_job_config.status_name_template,
         )
 
     def test_check_names_for_test_job(self, test_job_config: JobConfig) -> List[str]:
@@ -460,6 +476,8 @@ class BaseBuildJobHelper(BaseJobHelper):
                 target,
                 self.project_event_identifier_for_status,
                 test_job_config.identifier,
+                package=None,  # [TODO]
+                template=test_job_config.status_name_template,
             )
             for target in self.tests_targets_for_test_job(test_job_config)
         ]

--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -385,14 +385,24 @@ class BaseBuildJobHelper(BaseJobHelper):
         chroot: str = None,
         project_event_identifier: Optional[str] = None,
         identifier: Optional[str] = None,
+        package: Optional[str] = None,
+        template: Optional[str] = None,
     ):
+        if project_event_identifier:
+            project_event_identifier = project_event_identifier.replace(":", "-")
+
+        if template is not None:
+            return template.format(
+                job_name=job_name,
+                chroot=chroot,
+                event=project_event_identifier,
+                identifier=identifier,
+                package=package,
+            )
+
         chroot_str = f":{chroot}" if chroot else ""
         # replace ':' in the project event identifier
-        trigger_str = (
-            f":{project_event_identifier.replace(':', '-')}"
-            if project_event_identifier
-            else ""
-        )
+        trigger_str = f":{project_event_identifier}" if project_event_identifier else ""
         optional_suffix = f":{identifier}" if identifier else ""
         return f"{job_name}{trigger_str}{chroot_str}{optional_suffix}"
 

--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -391,14 +391,21 @@ class BaseBuildJobHelper(BaseJobHelper):
         if project_event_identifier:
             project_event_identifier = project_event_identifier.replace(":", "-")
 
-        if template is not None:
-            return template.format(
-                job_name=job_name,
-                chroot=chroot,
-                event=project_event_identifier,
-                identifier=identifier,
-                package=package,
+        try:
+            if template is not None:
+                return template.format(
+                    job_name=job_name,
+                    chroot=chroot,
+                    event=project_event_identifier,
+                    identifier=identifier,
+                    package=package,
+                )
+        except Exception as e:
+            logger.warning(
+                "Failed to use the template for status check, falling back to default: %s",
+                e,
             )
+            pass
 
         chroot_str = f":{chroot}" if chroot else ""
         # replace ':' in the project event identifier

--- a/packit_service/worker/helpers/build/build_helper.py
+++ b/packit_service/worker/helpers/build/build_helper.py
@@ -461,7 +461,7 @@ class BaseBuildJobHelper(BaseJobHelper):
             chroot,
             self.project_event_identifier_for_status,
             self.job_build_or_job_config.identifier,
-            package=None,  # [TODO]
+            package=self.get_package_name(),
             template=self.job_build_or_job_config.status_name_template,
         )
 
@@ -476,7 +476,7 @@ class BaseBuildJobHelper(BaseJobHelper):
                 target,
                 self.project_event_identifier_for_status,
                 test_job_config.identifier,
-                package=None,  # [TODO]
+                package=self.get_package_name(),
                 template=test_job_config.status_name_template,
             )
             for target in self.tests_targets_for_test_job(test_job_config)

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1286,7 +1286,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             chroot,
             self.project_event_identifier_for_status,
             self.job_config.identifier,
-            package=None,  # [TODO]
+            package=self.get_package_name(),
             template=self.job_config.status_name_template,
         )
 

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1283,7 +1283,11 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
     def get_test_check(self, chroot: str = None) -> str:
         return self.get_test_check_cls(
-            chroot, self.project_event_identifier_for_status, self.job_config.identifier
+            chroot,
+            self.project_event_identifier_for_status,
+            self.job_config.identifier,
+            package=None,  # [TODO]
+            template=self.job_config.status_name_template,
         )
 
     @property

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -620,7 +620,12 @@ def test_check_and_report(
         )
     ]
     flexmock(PullRequestGithubEvent).should_receive("get_packages_config").and_return(
-        flexmock(jobs=job_configs, get_package_config_for=lambda job_config: flexmock())
+        flexmock(
+            jobs=job_configs,
+            get_package_config_for=lambda job_config: flexmock(
+                packages={"package": {}}
+            ),
+        )
     )
     _, _ = add_pull_request_event_with_empty_sha
 
@@ -805,7 +810,12 @@ def test_check_and_report_actor_pull_request(
         )
     ]
     flexmock(PullRequestGithubEvent).should_receive("get_packages_config").and_return(
-        flexmock(jobs=job_configs, get_package_config_for=lambda job_config: flexmock())
+        flexmock(
+            jobs=job_configs,
+            get_package_config_for=lambda job_config: flexmock(
+                packages={"package": {}}
+            ),
+        )
     )
     _, _ = add_pull_request_event_with_empty_sha
 

--- a/tests/unit/test_status_names.py
+++ b/tests/unit/test_status_names.py
@@ -1,0 +1,154 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+# import re
+from dataclasses import dataclass
+from typing import Optional
+import logging
+
+# from flexmock import flexmock
+import pytest
+
+from packit_service.worker.helpers.build.build_helper import BaseBuildJobHelper
+from packit_service.worker.helpers.build.copr_build import CoprBuildJobHelper
+from packit_service.worker.helpers.testing_farm import TestingFarmJobHelper
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StatusNameTestcase:
+    job_name: Optional[str] = None
+    chroot: Optional[str] = None
+    event: Optional[str] = None
+    identifier: Optional[str] = None
+    package: Optional[str] = None
+    template: Optional[str] = None
+    expected: str = None
+
+
+@pytest.mark.parametrize(
+    "testcase",
+    [
+        pytest.param(
+            StatusNameTestcase(
+                job_name="copr",
+                chroot="centos-10",
+                event="pr-42",
+                identifier=None,
+                package="packit",
+                template=None,
+                expected="copr:pr-42:centos-10",
+            ),
+            id="default template",
+        ),
+        pytest.param(
+            StatusNameTestcase(
+                job_name="copr",
+                chroot="centos-10",
+                event="pr-42",
+                identifier=None,
+                package="packit",
+                template="packit:{job_name}:{event}:{chroot}",
+                expected="packit:copr:pr-42:centos-10",
+            ),
+            id="custom template",
+        ),
+        pytest.param(
+            StatusNameTestcase(
+                job_name="copr",
+                chroot="fedora-40",
+                event="stable",
+                identifier="custom-build",
+                package="special-package",
+                template="packit:rpm-build:{package}:{identifier}:{chroot}",
+                expected="packit:rpm-build:special-package:custom-build:fedora-40",
+            ),
+            id="custom template #2",
+        ),
+    ],
+)
+def test_get_check_cls(testcase):
+    assert (
+        BaseBuildJobHelper.get_check_cls(
+            job_name=testcase.job_name,
+            chroot=testcase.chroot,
+            project_event_identifier=testcase.event,
+            identifier=testcase.identifier,
+            package=testcase.package,
+            template=testcase.template,
+        )
+        == testcase.expected
+    )
+
+
+@pytest.mark.parametrize(
+    "testcase",
+    [
+        pytest.param(
+            StatusNameTestcase(
+                chroot="centos-10",
+                event="stable",
+                identifier="release-build",
+                expected="rpm-build:stable:centos-10:release-build",
+            ),
+            id="default template",
+        ),
+        pytest.param(
+            StatusNameTestcase(
+                chroot="fedora-40-x86_64",
+                event="pr-42069",
+                identifier="release-build",
+                template="copr-build:pr:{chroot}:{identifier}",
+                expected="copr-build:pr:fedora-40-x86_64:release-build",
+            ),
+            id="custom template",
+        ),
+    ],
+)
+def test_get_copr_build_check_cls(testcase):
+    assert (
+        CoprBuildJobHelper.get_build_check_cls(
+            chroot=testcase.chroot,
+            project_event_identifier=testcase.event,
+            identifier=testcase.identifier,
+            template=testcase.template,
+        )
+        == testcase.expected
+    )
+
+
+@pytest.mark.parametrize(
+    "testcase",
+    [
+        pytest.param(
+            StatusNameTestcase(
+                chroot="centos-10",
+                event="stable",
+                identifier="release-test",
+                expected="testing-farm:stable:centos-10:release-test",
+            ),
+            id="default template",
+        ),
+        pytest.param(
+            StatusNameTestcase(
+                chroot="fedora-40-x86_64",
+                event="pr-42069",
+                identifier="revdep-on-release-build",
+                template="tests:pr:{chroot}:{identifier}",
+                expected="tests:pr:fedora-40-x86_64:revdep-on-release-build",
+            ),
+            id="custom template",
+        ),
+    ],
+)
+def test_get_copr_test_check_cls(testcase):
+    assert (
+        TestingFarmJobHelper.get_test_check_cls(
+            chroot=testcase.chroot,
+            project_event_identifier=testcase.event,
+            identifier=testcase.identifier,
+            template=testcase.template,
+        )
+        == testcase.expected
+    )

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -102,6 +102,9 @@ def test_testing_farm_response(
                 },
             ),
         ],
+        packages={
+            "package": {},
+        },
     )
     flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
- [ ] [FIXME]: retriggering via GitHub re-run BROKEN

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

<!-- release notes footer -->

RELEASE NOTES BEGIN

We have introduced a new `status_name_template` option that allows you to configure status name for a Packit job. For further details have a look at our [docs](https://packit.dev/docs/configuration#status_name_template). This feature is still experimental and it is not possible to retry those jobs via GitHub Checks' re-run at the moment.

RELEASE NOTES END
