### PR TITLE
Report proper status in case RPM build failure is a result of SRPM build failure

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -87,6 +87,7 @@ TASK_ACCEPTED = "The task was accepted."
 
 COPR_SRPM_CHROOT = "srpm-builds"
 COPR_SUCC_STATE = "succeeded"
+COPR_FAIL_STATE = "failed"
 COPR_API_SUCC_STATE = 1
 COPR_API_FAIL_STATE = 2
 

--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -321,18 +321,20 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
         if self.copr_event.status != COPR_API_SUCC_STATE:
             failed_msg = "RPMs failed to be built."
             packit_dashboard_url = get_copr_build_info_url(self.build.id)
-            self.copr_build_helper.report_status_to_all_for_chroot(
-                state=BaseCommitStatus.failure,
-                description=failed_msg,
-                url=packit_dashboard_url,
-                chroot=self.copr_event.chroot,
-            )
-            self.measure_time_after_reporting()
-            self.copr_build_helper.notify_about_failure_if_configured(
-                packit_dashboard_url=packit_dashboard_url,
-                external_dashboard_url=self.build.web_url,
-                logs_url=self.build.build_logs_url,
-            )
+            # if SRPM build failed it has been reported already so skip reporting
+            if self.build.get_srpm_build().status != BuildStatus.failure:
+                self.copr_build_helper.report_status_to_all_for_chroot(
+                    state=BaseCommitStatus.failure,
+                    description=failed_msg,
+                    url=packit_dashboard_url,
+                    chroot=self.copr_event.chroot,
+                )
+                self.measure_time_after_reporting()
+                self.copr_build_helper.notify_about_failure_if_configured(
+                    packit_dashboard_url=packit_dashboard_url,
+                    external_dashboard_url=self.build.web_url,
+                    logs_url=self.build.build_logs_url,
+                )
             self.build.set_status(BuildStatus.failure)
             return TaskResults(success=False, details={"msg": failed_msg})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,9 @@ def copr_build_model(
     )
 
     runs = []
-    srpm_build = flexmock(logs="asdsdf", url=None, runs=runs)
+    srpm_build = flexmock(
+        logs="asdsdf", url=None, runs=runs, status=BuildStatus.success
+    )
     copr_group = flexmock(runs=runs)
     copr_build = flexmock(
         id=1,


### PR DESCRIPTION
Related to https://github.com/packit/packit-service/issues/2195.

This fixes two cases:

- babysit task updates build statuses in the DB but also overwrites status checks with a wrong message and link
- `CoprBuildEndEvent` for SRPM is never received and SRPM build status in the DB stays in `pending` forever

RELEASE NOTES BEGIN

We have fixed an issue when `copr_build` job status checks were sometimes wrongly updated with a misleading message after a SRPM build failure.

RELEASE NOTES END
