### PR TITLE
Store results only of usage data tasks

### DIFF
--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -9,6 +9,10 @@ task_default_queue = packit_service.constants.CELERY_TASK_DEFAULT_QUEUE
 # https://docs.celeryq.dev/en/latest/userguide/configuration.html#conf-redis-result-backend
 result_backend = "redis"
 
+# do not store task results by default
+# https://docs.celeryq.dev/en/latest/userguide/configuration.html#task-ignore-result
+task_ignore_result = True
+
 imports = ("packit_service.worker.tasks", "packit_service.service.tasks")
 
 task_routes = {

--- a/packit_service/service/tasks.py
+++ b/packit_service/service/tasks.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 CHART_DATA_TYPE = list[dict[str, Union[str, int]]]
 
 
-@celery_app.task
+@celery_app.task(ignore_result=False)
 def get_usage_interval_data(
     days: int, hours: int, count: int
 ) -> dict[str, Union[str, CHART_DATA_TYPE, dict[str, CHART_DATA_TYPE]]]:
@@ -164,7 +164,7 @@ def calculate_onboarded_projects():
     return {"onboarded": onboarded, "almost_onboarded": almost_onboarded}
 
 
-@celery_app.task
+@celery_app.task(ignore_result=False)
 def get_past_usage_data(datetime_from=None, datetime_to=None, top=5):
     # Even though frontend expects only the first N (=5) to be present
     # in the project lists, we need to get all to calculate the number


### PR DESCRIPTION
Storing results of all tasks is unnecessary and requires all result data to be serializable. Ignore results of all tasks by default (they will still be visible in the logs) and only store them for usage data tasks.