### PR TITLE
Improvements for showing onboarded projects

### DIFF
--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -51,7 +51,7 @@ beat_schedule = {
     },
     "get_usage_statistics": {
         "task": "packit_service.worker.tasks.get_usage_statistics",
-        "schedule": crontab(minute=1, hour=0),  # nightly at 0AM
+        "schedule": 3600.0,
         "options": {"queue": "long-running"},
     },
 }

--- a/packit_service/service/api/usage.py
+++ b/packit_service/service/api/usage.py
@@ -368,7 +368,7 @@ def _get_celery_result(id: str) -> Response:
 
     Wait here until the UX can deal with polling for the result.
     """
-    TIMEOUT = 5  # seconds
+    TIMEOUT = 15  # seconds
     STEP = 0.1  # second
     elapsed = 0.0
     while not (celery_app.AsyncResult(id).ready() or elapsed > TIMEOUT):


### PR DESCRIPTION
- Increase the timeout when collecting usage statistics
- Cache the result of get_onboarded_projects
- Collect statistics every hour -> should help with caching data in all the pods where long tasks are run and also should help with the pods restarts. But cpu usage should stay low since the caching.