### PR TITLE
Add downstream package name to Sentry tags

### DIFF
--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -204,6 +204,8 @@ class Handler(PackitAPIProtocol, Config):
                     "namespace": self.project.namespace,
                 }
             )
+        if "package_name" in self.data.event_dict:
+            tags.update({"package_name": self.data.event_dict["package_name"]})
         return tags
 
     def run_n_clean(self) -> TaskResults:


### PR DESCRIPTION
With the rise of pull-from-upstream usage it can be useful to have related Sentry events tagged with downstream package name (which can often be different from the upstream repository name).