### PR TITLE
Do not ignore dist-git PRs with ID 0

### DIFF
--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -250,7 +250,7 @@ class GetPagurePullRequestMixin(GetPagurePullRequest):
     @property
     def pull_request(self):
         if not self._pull_request:
-            if self.data.pr_id:
+            if self.data.pr_id is not None:
                 logger.debug(
                     f"Getting pull request #{self.data.pr_id}"
                     f"for repo {self.project.namespace}/{self.project.repo}"


### PR DESCRIPTION
While it seems dist-git PR IDs for a project always start with 1 the condition is technically wrong and in case there was a PR with ID 0 it would be silently ignored.

Related to #2359.