### PR TITLE
chore: Enable HTTP/2 protocol for packit-service

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -16,6 +16,7 @@
           - git # setuptools-scm
           # httpd & deps
           - python3-mod_wsgi
+          - mod_http2
           - mod_ssl
           - python3-alembic
           - python3-sqlalchemy

--- a/files/run_httpd.sh
+++ b/files/run_httpd.sh
@@ -29,6 +29,7 @@ HTTPS_PORT=$(sed -nr 's/^server_name: ([^:]+)(:([0-9]+))?$/\3/p' "$PACKIT_SERVIC
 exec mod_wsgi-express-3 start-server \
     --access-log \
     --log-to-terminal \
+    --http2 \
     --https-port "${HTTPS_PORT:-8443}" \
     --ssl-certificate-file /secrets/fullchain.pem \
     --ssl-certificate-key-file /secrets/privkey.pem \


### PR DESCRIPTION
With this change we should now have mod_http2 installed and enabled.

As I haven't figured out how to run packit-service for development purposes this is just a guess on what needs to be done.

RELEASE NOTES BEGIN
Enable HTTP/2 for Packit service
RELEASE NOTES END
