### PR TITLE
Don't create issues for propose-downstream when disabled in config

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -539,6 +539,10 @@ class ProposeDownstreamHandler(AbstractSyncReleaseHandler):
         return (IsUpstreamTagMatchingConfig,)
 
     def _report_errors_for_each_branch(self, message: str) -> None:
+        if not self.job_config.notifications.failure_issue.create:
+            logger.debug("Reporting via issues disabled in config, skipping.")
+            return
+
         msg_retrigger = MSG_RETRIGGER.format(
             job="update",
             command="propose-downstream",


### PR DESCRIPTION
Fixes #2416

TODO:

- [ ] Update or write new documentation in `packit/packit.dev`.

RELEASE NOTES BEGIN

It is now possible to disable reporting issues about failure of `propose_downstream` by setting `notifications.failure_issue.create` in configuration to `false`.

RELEASE NOTES END
