### PR TITLE
Don't stop babysitting TF runs if there is issue with getting info from API

### DIFF
--- a/packit_service/worker/helpers/build/babysit.py
+++ b/packit_service/worker/helpers/build/babysit.py
@@ -82,9 +82,9 @@ def check_pending_testing_farm_runs() -> None:
         if not response.ok:
             logger.info(
                 f"Failed to obtain state of TF pipeline {run.pipeline_id}. "
-                f"Status code {response.status_code}. Reason: {response.reason}."
+                f"Status code {response.status_code}. Reason: {response.reason}. "
+                "Let's try again later."
             )
-            run.set_status(TestingFarmResult.error)
             continue
 
         details = response.json()


### PR DESCRIPTION


This may be likely an API outage and we should continue babysitting the run (we have the timeouts, so in case this is some other issue, we will eventually stop).

See discussion with @thrix in https://redhat-internal.slack.com/archives/C04MU29TES1/p1720786823958689.


RELEASE NOTES BEGIN

We have improved the babysitting of Testing Farm runs to better handle API outages.

RELEASE NOTES END
