### PR TITLE
Avoid creating divergent git branches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,11 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.16.0
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -36,7 +36,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         args:
@@ -44,7 +44,7 @@ repos:
           - --per-file-ignores=files/packit.wsgi:F401,E402
           - --extend-ignore=E701 # conflicting with black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.1
+    rev: v1.11.2
     hooks:
       - id: mypy
         args: [
@@ -113,7 +113,7 @@ repos:
         # 'git diff --staged', i.e. always passes in pre-push/manual stage.
         stages: [commit]
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.6
+    rev: 0.29.2
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -261,6 +261,9 @@ class AbstractSyncReleaseHandler(
                 pr_description_footer=DistgitAnnouncement.get_announcement(),
                 # [TODO] Remove for CentOS support once it gets refined
                 add_new_sources=self.package_config.pkg_tool in (None, "fedpkg"),
+                fast_forward_merge_branches=self.helper.get_fast_forward_merge_branches_for(
+                    branch
+                ),
             )
             if not self.packit_api.non_git_upstream:
                 kwargs["tag"] = self.tag

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -583,3 +583,21 @@ def pagure_pr_comment_added():
 def new_hotness_update():
     with open(DATA_DIR / "fedmsg" / "new_hotness_update.json") as outfile:
         return json.load(outfile)
+
+
+@pytest.fixture()
+def mock_get_fast_forward_aliases():
+    import packit
+
+    mock_aliases_module = flexmock(packit.config.aliases)
+    mock_aliases_module.should_receive("get_aliases").and_return(
+        {
+            "fedora-all": ["fedora-39", "fedora-40", "fedora-rawhide"],
+            "fedora-stable": ["fedora-39", "fedora-40"],
+            "fedora-development": ["fedora-rawhide"],
+            "fedora-latest": ["fedora-40"],
+            "fedora-latest-stable": ["fedora-40"],
+            "fedora-branched": ["fedora-39", "fedora-40"],
+            "epel-all": ["epel-8", "epel-9"],
+        }
+    )

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -222,6 +222,7 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
+        fast_forward_merge_branches=set(),
     ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -394,6 +395,7 @@ def test_new_hotness_update_non_git(new_hotness_update, sync_release_model_non_g
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
+        fast_forward_merge_branches=set(),
     ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2705,6 +2705,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
+        fast_forward_merge_branches=set(),
     ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -2872,6 +2873,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment_non_git(
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
+        fast_forward_merge_branches=set(),
     ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -221,6 +221,7 @@ def test_dist_git_push_release_handle(
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
+        fast_forward_merge_branches=set(),
     ).and_return(pr).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -363,6 +364,7 @@ def test_dist_git_push_release_handle_multiple_branches(
             sync_acls=True,
             pr_description_footer=DistgitAnnouncement.get_announcement(),
             add_new_sources=True,
+            fast_forward_merge_branches=set(),
         ).and_return(pr).once()
 
         flexmock(ProposeDownstreamJobHelper).should_receive(
@@ -513,6 +515,7 @@ def test_dist_git_push_release_handle_one_failed(
                 sync_acls=True,
                 pr_description_footer=DistgitAnnouncement.get_announcement(),
                 add_new_sources=True,
+                fast_forward_merge_branches=set(),
             ).and_return(pr).once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
@@ -536,6 +539,7 @@ def test_dist_git_push_release_handle_one_failed(
                 sync_acls=True,
                 pr_description_footer=DistgitAnnouncement.get_announcement(),
                 add_new_sources=True,
+                fast_forward_merge_branches=set(),
             ).and_raise(Exception, f"Failed {model.branch}").once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch"
@@ -780,6 +784,7 @@ def test_retry_propose_downstream_task(
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
+        fast_forward_merge_branches=set(),
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()
@@ -893,6 +898,7 @@ def test_dont_retry_propose_downstream_task(
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
+        fast_forward_merge_branches=set(),
     ).and_raise(
         PackitDownloadFailedException, "Failed to download source from example.com"
     ).once()

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -191,6 +191,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
         sync_acls=True,
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
+        fast_forward_merge_branches=set(),
     ).and_return(pr).times(1 if success else 0)
     flexmock(shutil).should_receive("rmtree").with_args("")
 


### PR DESCRIPTION
Should fix packit/packit#1724

Merge after packit/packit#2363

RELEASE NOTES BEGIN
When synching a new release Packit is now able to fast forward a specified merge to a configured list of branches.
Use the `dist_git_branches` new syntax as in this example: 
```
{
  "rawhide": {
    "fast_forward_merge_into": ["f40"]
   },
  "fedora-stable": {}
}
```
RELEASE NOTES END