### PR TITLE
Make `KojiBuildTagEvent` be handled only by `KojiBuildTagHandler`

### DIFF
--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -44,7 +44,7 @@ from packit_service.worker.events import (
     IssueCommentEvent,
     IssueCommentGitlabEvent,
 )
-from packit_service.worker.events.koji import KojiBuildEvent, KojiBuildTagEvent
+from packit_service.worker.events.koji import KojiBuildEvent
 from packit_service.worker.handlers.abstract import (
     TaskName,
     configured_as,
@@ -409,7 +409,6 @@ class CreateBodhiUpdateHandler(
 
 
 @configured_as(job_type=JobType.bodhi_update)
-@reacts_to(event=KojiBuildTagEvent)
 class BodhiUpdateFromSidetagHandler(
     BodhiUpdateHandler,
     RetriableJobHandler,

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -894,7 +894,6 @@ class AbstractDownstreamKojiBuildHandler(
 @run_for_comment(command="koji-build")
 @reacts_to(event=PushPagureEvent)
 @reacts_to(event=PullRequestCommentPagureEvent)
-@reacts_to(event=KojiBuildTagEvent)
 class DownstreamKojiBuildHandler(
     AbstractDownstreamKojiBuildHandler,
     ConfigFromEventMixin,

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -942,7 +942,8 @@ class DownstreamKojiBuildHandler(
         elif self.data.event_type == KojiBuildTagEvent.__name__:
             trigger_type_description += (
                 f"Fedora Koji build was triggered "
-                f"by tagging of build {self.data.build_id} to {self.data.koji_tag_name}."
+                f"by tagging of build {self.data.event_dict['build_id']} "
+                f"into {self.data.event_dict['tag_name']}."
             )
         return trigger_type_description
 


### PR DESCRIPTION
Neither `DownstreamKojiBuildHandler` nor `BodhiUpdateFromSidetagHandler` should react to the event directly.

Should fix [this](https://red-hat-it.sentry.io/issues/5656608375/?project=1767823) and [this](https://red-hat-it.sentry.io/issues/5656623299/?project=1767823) Sentry issue.

Related to https://github.com/packit/packit-service/issues/2379.