### PR TITLE
Handle monorepo-style packages when processing `KojiBuildTagEvent`

### DIFF
--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -185,6 +185,7 @@ def pc_koji_build_tag_specfile():
                     "specfile": CommonPackageConfig(
                         _targets=["fedora-all"],
                         specfile_path="python-specfile.spec",
+                        downstream_package_name="python-specfile",
                     )
                 },
             ),
@@ -192,6 +193,7 @@ def pc_koji_build_tag_specfile():
         packages={
             "specfile": CommonPackageConfig(
                 specfile_path="python-specfile.spec",
+                downstream_package_name="python-specfile",
             ),
         },
     )
@@ -210,6 +212,7 @@ def pc_koji_build_tag_packit():
                     "packit": CommonPackageConfig(
                         _targets=["fedora-all"],
                         specfile_path="packit.spec",
+                        downstream_package_name="packit",
                     )
                 },
             ),
@@ -222,6 +225,7 @@ def pc_koji_build_tag_packit():
                     "packit": CommonPackageConfig(
                         _targets=["fedora-all"],
                         specfile_path="packit.spec",
+                        downstream_package_name="packit",
                     )
                 },
             ),
@@ -229,6 +233,7 @@ def pc_koji_build_tag_packit():
         packages={
             "packit": CommonPackageConfig(
                 specfile_path="packit.spec",
+                downstream_package_name="packit",
             ),
         },
     )

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -921,7 +921,7 @@ def test_get_handlers_for_event(event_cls, db_project_object, jobs, result):
     # (And real event classes have a lot of __init__ arguments.)
     class Event(event_cls):
         def __init__(self):
-            pass
+            self.package_name = "test"
 
         @property
         def db_project_object(self):


### PR DESCRIPTION
Should fix some instances of https://red-hat-it.sentry.io/issues/5655380088.

Related to https://github.com/packit/packit-service/issues/2379.