### PR TITLE
Support tests for release events

### DIFF
--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -45,6 +45,8 @@ from packit_service.worker.events import (
     PushGitlabEvent,
     MergeRequestGitlabEvent,
     AbstractPRCommentEvent,
+    ReleaseEvent,
+    ReleaseGitlabEvent,
 )
 from packit_service.worker.handlers import JobHandler
 from packit_service.worker.handlers.abstract import (
@@ -73,6 +75,8 @@ logger = logging.getLogger(__name__)
 @run_for_comment(command="copr-build")
 @run_for_comment(command="retest-failed")
 @run_for_check_rerun(prefix="testing-farm")
+@reacts_to(ReleaseEvent)
+@reacts_to(ReleaseGitlabEvent)
 @reacts_to(PullRequestGithubEvent)
 @reacts_to(PushGitHubEvent)
 @reacts_to(PushGitlabEvent)

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -182,6 +182,32 @@ from packit_service.worker.result import TaskResults
             {CoprBuildHandler},
             id="config=build_for_release&release&ReleaseEvent",
         ),
+        pytest.param(
+            ReleaseEvent,
+            flexmock(job_config_trigger_type=JobConfigTriggerType.release),
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                ),
+            ],
+            {TestingFarmHandler},
+            id="config=test_for_release&release&ReleaseEvent",
+        ),
+        pytest.param(
+            ReleaseGitlabEvent,
+            flexmock(job_config_trigger_type=JobConfigTriggerType.release),
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.release,
+                    packages={"package": CommonPackageConfig()},
+                ),
+            ],
+            {TestingFarmHandler},
+            id="config=test_for_release&release&ReleaseGitlabEvent",
+        ),
         # Copr results for build:
         pytest.param(
             CoprBuildStartEvent,


### PR DESCRIPTION


RELEASE NOTES BEGIN

It is now possible to run tests for releases.

RELEASE NOTES END
