### PR TITLE
Remove sidetag immediately after successful Bodhi update creation

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -3592,10 +3592,14 @@ class SidetagModel(Base):
         with sa_session_transaction() as session:
             return session.query(SidetagModel).filter_by(koji_name=koji_name).first()
 
-    def set_koji_name(self, koji_name: str):
+    def set_koji_name(self, koji_name: str) -> None:
         with sa_session_transaction(commit=True) as session:
             self.koji_name = koji_name
             session.add(self)
+
+    def delete(self) -> None:
+        with sa_session_transaction(commit=True) as session:
+            session.delete(self)
 
 
 @cached(cache=TTLCache(maxsize=2048, ttl=(60 * 60 * 24)))

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -881,7 +881,10 @@ def test_bodhi_update_from_sidetag(koji_build_tagged, missing_dependency):
 
     sidetag_group = flexmock(name=sidetag_group_name)
     sidetag = flexmock(
-        sidetag_group=sidetag_group, target=dg_branch, koji_name=sidetag_name
+        sidetag_group=sidetag_group,
+        target=dg_branch,
+        koji_name=sidetag_name,
+        delete=lambda: None,
     )
     sidetag_group.should_receive("get_sidetag_by_target").with_args(
         dg_branch
@@ -918,6 +921,9 @@ def test_bodhi_update_from_sidetag(koji_build_tagged, missing_dependency):
     flexmock(KojiHelper).should_receive("get_latest_nvr_in_tag").with_args(
         package="packit", tag=str
     ).and_return("packit-0.98.0-1.fc40")
+    flexmock(KojiHelper).should_receive("remove_sidetag").with_args(sidetag_name).times(
+        0 if missing_dependency else 1
+    )
 
     flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
         task_id=task_id
@@ -997,6 +1003,8 @@ def test_bodhi_update_from_sidetag(koji_build_tagged, missing_dependency):
     ).and_return(flexmock())
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
+
+    flexmock(PackitAPI).should_receive("init_kerberos_ticket").and_return()
 
     def _create_update(dist_git_branch, update_type, koji_builds, sidetag):
         assert dist_git_branch == dg_branch


### PR DESCRIPTION
Bodhi removes the sidetag an update has been created from automatically when the update hits stable, but it doesn't allow creating new updates from the same sidetag. In order to allow creating e.g. hotfix updates, remove the sidetag immediately after successful update creation so a new one can be created for any new builds and a new update.

Related to https://github.com/packit/packit-service/issues/2379.