### PR TITLE
Regenerate the Anitya related models migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ compose-for-db-up:
 # run alembic revision through another service pod
 # run processes as *local host user* inside the pod
 # preserve *local host user* files' uid inside the pod
-# See CONTRIBUTING.md#database
+# See docs/database/README.md
 migrate-db: compose-for-db-up
 	sleep 10 # service pod have to be up and running "alembic upgrade head"
 	podman run --rm -ti --user $(MY_ID) --uidmap=$(MY_ID):0:1 --uidmap=0:1:999 \

--- a/alembic/versions/fd785af95c19_add_anitya_related_models.py
+++ b/alembic/versions/fd785af95c19_add_anitya_related_models.py
@@ -1,8 +1,8 @@
 """Add Anitya related models
 
-Revision ID: b43ff6137622
-Revises: 64a51b961c28
-Create Date: 2024-08-01 10:37:55.286362
+Revision ID: fd785af95c19
+Revises: 2fdbdcd581f5
+Create Date: 2024-08-13 13:02:24.370985
 
 """
 
@@ -11,8 +11,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = "b43ff6137622"
-down_revision = "64a51b961c28"
+revision = "fd785af95c19"
+down_revision = "2fdbdcd581f5"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
While the PR was open, there was a new alembic migration causing now a conflict.
