### PR TITLE
Implicitly include self in dependents of a koji_build job

### DIFF
--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -418,9 +418,15 @@ class KojiBuildTagHandler(
                 if (
                     job.type == JobType.koji_build
                     and job.sidetag_group == sidetag_group
-                    and job.dependents
                 ):
-                    packages_to_trigger.update(job.dependents)
+                    if job.dependents:
+                        packages_to_trigger.update(job.dependents)
+                    elif (
+                        job.downstream_package_name
+                        == self.package_config.downstream_package_name
+                    ):
+                        # implicitly include self in dependents
+                        packages_to_trigger.add(job.downstream_package_name)
         logger.debug(f"Packages to trigger: {packages_to_trigger}")
 
         for package_name in packages_to_trigger:

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -586,7 +586,11 @@ def babysit_vm_image_build(self, build_id: int):
 
 @celery_app.task(name=TaskName.koji_build_tag, base=TaskWithRetry)
 def run_koji_build_tag_handler(event: dict, package_config: dict, job_config: dict):
-    handler = KojiBuildTagHandler(package_config=None, job_config=None, event=event)
+    handler = KojiBuildTagHandler(
+        package_config=load_package_config(package_config),
+        job_config=load_job_config(job_config),
+        event=event,
+    )
     return get_handlers_task_results(handler.run_job(), event)
 
 


### PR DESCRIPTION
While it is possible to omit declaring self as a dependency in `bodhi_update` job, it is still necessary to explicitly declare self as a dependent for the `bodhi_update` job to be triggered:

```yaml
downstream_package_name: foo

jobs:
- job: koji_build
  trigger: commit
  sidetag_group: test
  dependents:
    - foo

- job: bodhi_update
  trigger: koji_build
  sidetag_group: test
  # dependencies:
  #   - foo
```

Fix that.