### PR TITLE
Increase celery hard time limit for get_usage_statistics

### DIFF
--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -53,6 +53,7 @@ beat_schedule = {
         "task": "packit_service.worker.tasks.get_usage_statistics",
         "schedule": 3600.0,
         "options": {"queue": "long-running"},
+        "time_limit": 1800,
     },
 }
 


### PR DESCRIPTION
Since last deployment the get_usage_statistics task is failing because of exception:

Hard time limit (900s) exceeded for packit_service.worker.tasks.get_usage_statistics


