### PR TITLE
Switch to HTML table for downstream error reporting

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -40,8 +40,11 @@ TESTING_FARM_ARTIFACTS_KEY = "artifacts"
 MSG_DOWNSTREAM_JOB_ERROR_HEADER = (
     "Packit failed on creating {object} in dist-git "
     "({dist_git_url}):\n\n"
-    "| dist-git branch | error |\n"
-    "| --------------- | ----- |\n"
+    "<table>"
+    "<tr>"
+    "<th>dist-git branch</th>"
+    "<th>error</th>"
+    "</tr>"
 )
 
 MSG_GET_IN_TOUCH = (

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -255,7 +255,13 @@ class BodhiUpdateHandler(
             object="Bodhi update", dist_git_url=self.packit_api.dg.local_project.git_url
         )
         for branch, ex in errors.items():
-            body += f"| `{branch}` | ```{ex}``` |\n"
+            body += (
+                "<tr>"
+                f"<td><code>{branch}</code></td>"
+                f"<td><pre>{ex}</pre></td>"
+                "</tr>\n"
+            )
+        body += "</table>\n"
 
         msg_retrigger = MSG_RETRIGGER.format(
             job="update",

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -498,7 +498,14 @@ class AbstractSyncReleaseHandler(
             branch_errors = ""
             for model in sorted(models_with_errors, key=lambda model: model.branch):
                 dashboard_url = self.get_dashboard_url(model.id)
-                branch_errors += f"| `{model.branch}` | See {dashboard_url} |\n"
+                branch_errors += (
+                    "<tr>"
+                    f"<td><code>{model.branch}</code></td>"
+                    f'<td>See <a href="{dashboard_url}">{dashboard_url}</a></td>'
+                    "</tr>\n"
+                )
+            branch_errors += "</table>\n"
+
             body_msg = MSG_DOWNSTREAM_JOB_ERROR_HEADER.format(
                 object="pull-requests",
                 dist_git_url=self.packit_api.dg.local_project.git_url,
@@ -873,7 +880,13 @@ class AbstractDownstreamKojiBuildHandler(
             object="Koji build", dist_git_url=self.packit_api.dg.local_project.git_url
         )
         for branch, ex in errors.items():
-            body += f"| `{branch}` | ```{ex}``` |\n"
+            body += (
+                "<tr>"
+                f"<td><code>{branch}</code></td>"
+                f"<td><pre>{ex}</pre></td>"
+                "</tr>\n"
+            )
+        body += "</table>\n"
 
         msg_retrigger = MSG_RETRIGGER.format(
             job="build",

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -590,8 +590,9 @@ def test_issue_comment_retrigger_koji_build_error_msg(
     ).and_return(packit_api)
     msg = (
         "Packit failed on creating Koji build in dist-git (an url):"
-        "\n\n| dist-git branch | error |\n| --------------- | ----- |\n"
-        "| `f37` | ```error abc``` |\n\n"
+        "\n\n<table><tr>"
+        "<th>dist-git branch</th><th>error</th></tr>"
+        "<tr><td><code>f37</code></td><td><pre>error abc</pre></td></tr>\n</table>\n\n"
         "Fedora Koji build was re-triggered by comment in issue 1.\n\n"
         "You can retrigger the build by adding a comment "
         "(`/packit koji-build`) into this issue.\n\n"

--- a/tests/integration/test_koji_build.py
+++ b/tests/integration/test_koji_build.py
@@ -195,9 +195,14 @@ def test_koji_build_error_msg(distgit_push_packit):
         packit_api
     )
     msg = (
-        "Packit failed on creating Koji build in dist-git (an url):"
-        "\n\n| dist-git branch | error |\n| --------------- | ----- |"
-        "\n| `f36` | ```error abc``` |\n\n"
+        "Packit failed on creating Koji build in dist-git (an url):\n\n"
+        "<table>"
+        "<tr>"
+        "<th>dist-git branch</th>"
+        "<th>error</th>"
+        "</tr>"
+        "<tr><td><code>f36</code></td><td><pre>error abc</pre></td></tr>\n"
+        "</table>\n\n"
         "Fedora Koji build was triggered by push "
         "with sha ad0c308af91da45cf40b253cd82f07f63ea9cbbf."
         "\n\nYou can retrigger the build by adding a comment "

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -606,8 +606,12 @@ def test_dist_git_push_release_handle_all_failed(
     for model in sorted(
         propose_downstream_target_models, key=lambda model: model.branch
     ):
+        dashboard_url = get_propose_downstream_info_url(model.id)
         table_content += (
-            f"| `{model.branch}` | See {get_propose_downstream_info_url(model.id)} |\n"
+            "<tr>"
+            f"<td><code>{model.branch}</code></td>"
+            f'<td>See <a href="{dashboard_url}">{dashboard_url}</a></td>'
+            "</tr>\n"
         )
     project = (
         flexmock(
@@ -626,9 +630,12 @@ def test_dist_git_push_release_handle_all_failed(
             title="[packit] Propose downstream failed for release 0.3.0",
             body="Packit failed on creating pull-requests in dist-git "
             "(https://src.fedoraproject.org/rpms/hello-world.git):\n\n"
-            "| dist-git branch | error |\n"
-            "| --------------- | ----- |\n"
-            f"{table_content}\n\n"
+            "<table>"
+            "<tr>"
+            "<th>dist-git branch</th>"
+            "<th>error</th>"
+            "</tr>"
+            f"{table_content}</table>\n\n\n"
             "You can retrigger the update by adding a comment (`/packit propose-downstream`)"
             " into this issue.\n",
         )

--- a/tests/unit/test_bodhi_update_error_msgs.py
+++ b/tests/unit/test_bodhi_update_error_msgs.py
@@ -90,9 +90,10 @@ def test_pull_request_retrigger_bodhi_update_with_koji_data(
     msg = (
         "Packit failed on creating Bodhi update "
         "in dist-git (an url):\n\n"
-        "| dist-git branch | error |\n"
-        "| --------------- | ----- |\n"
-        "| `f36` | ```error abc``` |\n\n"
+        "<table>"
+        "<tr><th>dist-git branch</th><th>error</th></tr>"
+        "<tr><td><code>f36</code></td><td><pre>error abc</pre></td></tr>\n"
+        "</table>\n\n"
         "Fedora Bodhi update was re-triggered by comment in dist-git PR with id 123.\n\n"
         "You can retrigger the update by adding a comment (`/packit create-update`) "
         "into this issue.\n\n---\n\n"


### PR DESCRIPTION
Fixes #1865

<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
- [x] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

The downstream error reporting, had been switched to html.   

RELEASE NOTES END
