### PR TITLE
Improve error logging for Sentry errors reduction

### DIFF
--- a/packit_service/worker/allowlist.py
+++ b/packit_service/worker/allowlist.py
@@ -518,7 +518,7 @@ class Allowlist:
                 return callback(event, project, job_configs)
 
         msg = f"Failed to validate account: Unrecognized event type {type(event)!r}."
-        logger.error(msg)
+        logger.debug(msg)
         raise PackitException(msg)
 
     def get_approval_issue(self, namespace) -> Optional[str]:

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -337,11 +337,6 @@ class JobHandler(Handler):
         job_results[result_key] = self.run_n_clean()
         logger.debug("Job finished!")
 
-        for result in job_results.values():
-            if not (result and result["success"]):
-                if msg := result["details"].get("msg"):
-                    logger.error(msg)
-
         # push the metrics from job
         self.pushgateway.push()
 

--- a/packit_service/worker/helpers/build/babysit.py
+++ b/packit_service/worker/helpers/build/babysit.py
@@ -481,7 +481,7 @@ def update_vm_image_build(build_id: int, build: "VMImageBuildTargetModel"):
         status = body["image_status"]["status"]
     except HTTPError as ex:
         message = f"No response for VM Image Build {build_id}: {ex}"
-        logger.error(message)
+        logger.debug(message)
         status = VMImageBuildStatus.error
     except Exception as ex:
         message = (
@@ -503,7 +503,7 @@ def update_vm_image_build(build_id: int, build: "VMImageBuildTargetModel"):
     if status == VMImageBuildStatus.failure:
         error = body["image_status"]["error"]
         message = f"VM image build {build.build_id} failed: {error}"
-        logger.error(message)
+        logger.debug(message)
 
     if status == VMImageBuildStatus.success:
         message = get_message_for_successful_build(body["image_status"])
@@ -524,7 +524,7 @@ def update_vm_image_build(build_id: int, build: "VMImageBuildTargetModel"):
     packages_config = event.get_packages_config()
     if not packages_config:
         build.set_status(status)
-        logger.error(
+        logger.debug(
             f"No package config found for {build.build_id}. "
             "No feedback can be given to the user."
         )
@@ -555,7 +555,7 @@ def update_vm_image_build(build_id: int, build: "VMImageBuildTargetModel"):
         return True
 
     build.set_status(status)
-    logger.error(
+    logger.debug(
         f"Something went wrong retrieving job configs for {build.build_id}. "
         "No feedback can be given to the user."
     )

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -730,7 +730,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
                 f"The compose {compose} (from target {distro}) does not match any compose"
                 f" in the list of available composes:\n{composes}. "
             )
-            logger.error(msg)
+            logger.debug(msg)
             msg += (
                 "Please, check the targets defined in your test job configuration. If you think"
                 f" your configuration is correct, get in touch with [us]({CONTACTS_URL})."
@@ -762,7 +762,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
                 f"The architecture {arch} is not in the list of "
                 f"available architectures:\n{supported_architectures}. "
             )
-            logger.error(msg)
+            logger.debug(msg)
             msg += (
                 "Please, check the targets defined in your test job configuration. If you think"
                 f" your configuration is correct, get in touch with [us]({CONTACTS_URL})."
@@ -841,7 +841,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             # Leaving here just to be sure that we will discover this situation if it occurs.
             # Currently not possible to trigger this situation.
             msg = f"Target '{test_run.target}' not defined for tests but triggered."
-            logger.error(msg)
+            logger.debug(msg)
             send_to_sentry(PackitConfigException(msg))
             return TaskResults(
                 success=False,


### PR DESCRIPTION
See commit messages.

I wanted to remove the TaskResults completely, but in the end I think it can be useful for testing.

Related to #2526 


RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
