### PR TITLE
Avoid race condition when creating sidetag in Koji

### DIFF
--- a/packit_service/worker/helpers/sidetag.py
+++ b/packit_service/worker/helpers/sidetag.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-from typing import Optional, Set
+from typing import Any, Optional, Set
 
 from packit.exceptions import PackitException
 from packit.utils.koji_helper import KojiHelper
@@ -70,7 +70,7 @@ class Sidetag:
 
 
 class SidetagHelperMeta(type):
-    def __init__(cls, *args, **kwargs):
+    def __init__(cls, *args: Any, **kwargs: Any) -> None:
         cls._koji_helper: Optional[KojiHelper] = None
 
     @property

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -264,13 +264,9 @@ def test_downstream_koji_build(sidetag_group):
         koji_target = "f40-build-side-12345"
         sidetag = flexmock(koji_name=None)
 
-        def set_koji_name(name):
-            sidetag.koji_name = name
-
-        sidetag.should_receive("set_koji_name").with_args(koji_target).replace_with(
-            set_koji_name
+        flexmock(SidetagModel).should_receive("get_or_create_for_updating").and_return(
+            sidetag
         )
-        flexmock(SidetagModel).should_receive("get_or_create").and_return(sidetag)
         flexmock(SidetagGroupModel).should_receive("get_or_create").and_return(
             flexmock()
         )

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -3050,10 +3050,10 @@ def test_koji_build_tag_via_dist_git_pr_comment(pagure_pr_comment_added, all_bra
     flexmock(SidetagGroupModel).should_receive("get_or_create").with_args(
         "test"
     ).and_return(sidetag_group)
-    flexmock(SidetagModel).should_receive("get_or_create").with_args(
+    flexmock(SidetagModel).should_receive("get_or_create_for_updating").with_args(
         sidetag_group, "f39"
     ).and_return(flexmock(koji_name="f39-build-side-12345", target="f39"))
-    flexmock(SidetagModel).should_receive("get_or_create").with_args(
+    flexmock(SidetagModel).should_receive("get_or_create_for_updating").with_args(
         sidetag_group, "f40"
     ).and_return(flexmock(koji_name="f40-build-side-12345", target="f40"))
     flexmock(KojiHelper).should_receive("get_tag_info").with_args(


### PR DESCRIPTION
There is a big time window between reading Koji name of a sidetag from the DB and updating it with a new value returned after a new sidetag in Koji is created, making race conditions possible.

Prevent this by doing everything in a single DB transaction.

Fixes #2545.