### PR TITLE
Skip running Koji builds if they are triggered already

### DIFF
--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -286,6 +286,9 @@ def test_downstream_koji_build(sidetag_group):
         from_upstream=False,
         koji_target=koji_target if sidetag_group else None,
     ).and_return("")
+    flexmock(DownstreamKojiBuildHandler).should_receive(
+        "is_already_triggered"
+    ).and_return(False)
     processing_results = SteveJobs().process_message(distgit_commit_event())
     event_dict, job, job_config, package_config = get_parameters_from_results(
         processing_results
@@ -373,6 +376,9 @@ def test_downstream_koji_build_failure_no_issue():
         from_upstream=False,
         koji_target=None,
     ).and_raise(PackitException, "Some error")
+    flexmock(DownstreamKojiBuildHandler).should_receive(
+        "is_already_triggered"
+    ).and_return(False)
 
     pagure_project_mock.should_receive("get_issue_list").times(0)
     pagure_project_mock.should_receive("create_issue").times(0)
@@ -463,6 +469,9 @@ def test_downstream_koji_build_failure_issue_created():
         from_upstream=False,
         koji_target=None,
     ).and_raise(PackitException, "Some error")
+    flexmock(DownstreamKojiBuildHandler).should_receive(
+        "is_already_triggered"
+    ).and_return(False)
 
     issue_project_mock = flexmock(GithubProject)
     issue_project_mock.should_receive("get_issue_list").and_return([]).once()
@@ -561,6 +570,9 @@ def test_downstream_koji_build_failure_issue_comment():
         from_upstream=False,
         koji_target=None,
     ).and_raise(PackitException, "Some error")
+    flexmock(DownstreamKojiBuildHandler).should_receive(
+        "is_already_triggered"
+    ).and_return(False)
 
     issue_project_mock = flexmock(GithubProject)
     issue_project_mock.should_receive("get_issue_list").and_return(
@@ -747,6 +759,9 @@ def test_downstream_koji_build_where_multiple_branches_defined(jobs_config):
         from_upstream=False,
         koji_target=None,
     ).once().and_return("")
+    flexmock(DownstreamKojiBuildHandler).should_receive(
+        "is_already_triggered"
+    ).and_return(False)
 
     processing_results = SteveJobs().process_message(distgit_commit_event())
     assert len(processing_results) == 1

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -542,6 +542,9 @@ def test_issue_comment_retrigger_koji_build_handler(
     flexmock(RetriggerDownstreamKojiBuildHandler).should_receive(
         "local_project"
     ).and_return(flexmock())
+    flexmock(RetriggerDownstreamKojiBuildHandler).should_receive(
+        "is_already_triggered"
+    ).and_return(False)
 
     results = run_retrigger_downstream_koji_build(
         package_config=package_config,
@@ -605,6 +608,9 @@ def test_issue_comment_retrigger_koji_build_error_msg(
         message=msg,
         comment_to_existing=msg,
     ).once()
+    flexmock(RetriggerDownstreamKojiBuildHandler).should_receive(
+        "is_already_triggered"
+    ).and_return(False)
 
     run_retrigger_downstream_koji_build(
         package_config=package_config,

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2434,6 +2434,9 @@ def test_koji_build_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added):
     )
 
     flexmock(DownstreamKojiBuildHandler).should_receive("pre_check").and_return(True)
+    flexmock(DownstreamKojiBuildHandler).should_receive(
+        "is_already_triggered"
+    ).and_return(False)
     flexmock(LocalProjectBuilder, _refresh_the_state=lambda *args: flexmock())
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(celery_group).should_receive("apply_async").once()


### PR DESCRIPTION
Fixes #2503
Requires packit/packit#2435

<!-- TODO list -->

TODO:

- [x] test it

RELEASE NOTES BEGIN

Before triggering the non-scratch Koji builds, we now check whether there is not already a build in progress or completed for the same NVR.

RELEASE NOTES END
