### PR TITLE
Unify resolve bug for pull_from_upstream retriggering

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -680,7 +680,7 @@ class PullFromUpstreamHandler(AbstractSyncReleaseHandler):
         """
         If we are reacting to New Hotness, return the corresponding bugzilla ID only.
         In case of comment, take the argument from comment. The format in the comment
-        should be /packit pull-from-upstream --resolved-bugs rhbz#123,rhbz#124
+        should be /packit pull-from-upstream --resolve-bug rhbz#123,rhbz#124
         """
         if self.data.event_type in (NewHotnessUpdateEvent.__name__,):
             bug_id = self.data.event_dict.get("bug_id")
@@ -691,7 +691,7 @@ class PullFromUpstreamHandler(AbstractSyncReleaseHandler):
             comment, self.service_config.comment_command_prefix
         )
         args = commands[1:] if len(commands) > 1 else ""
-        bugs_keyword = "--resolved-bugs"
+        bugs_keyword = "--resolve-bug"
         if bugs_keyword not in args:
             return []
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2600,7 +2600,7 @@ def test_bodhi_update_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added)
 def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added):
     pagure_pr_comment_added["pullrequest"]["comments"][0][
         "comment"
-    ] = "/packit pull-from-upstream --with-pr-config --resolved-bugs rhbz#123,rhbz#124"
+    ] = "/packit pull-from-upstream --with-pr-config --resolve-bug rhbz#123,rhbz#124"
     sync_release_pr_model = flexmock(sync_release_targets=[flexmock(), flexmock()])
     model = flexmock(status="queued", id=1234, branch="main")
     flexmock(SyncReleaseTargetModel).should_receive("create").with_args(
@@ -2797,7 +2797,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment_non_git(
 ):
     pagure_pr_comment_added["pullrequest"]["comments"][0][
         "comment"
-    ] = "/packit pull-from-upstream --with-pr-config --resolved-bugs rhbz#123,rhbz#124"
+    ] = "/packit pull-from-upstream --with-pr-config --resolve-bug rhbz#123,rhbz#124"
     sync_release_pr_model = flexmock(sync_release_targets=[flexmock(), flexmock()])
     model = flexmock(status="queued", id=1234, branch="main")
     flexmock(SyncReleaseTargetModel).should_receive("create").with_args(


### PR DESCRIPTION
Related to packit/packit#2428

<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

We have unified the interface for propagating resolved Bugzillas to use `--resolve-bug` everywhere. When retriggering `pull-from-upstream` via issue/PR comment, please use the new `--resolve-bug` option.

RELEASE NOTES END
