### PR TITLE
docs(ib): add note to the handler about Copr

### DIFF
--- a/packit_service/worker/handlers/vm_image.py
+++ b/packit_service/worker/handlers/vm_image.py
@@ -62,6 +62,9 @@ class VMImageBuildHandler(
     def get_checkers() -> Tuple[Type[Checker], ...]:
         return (
             HasAuthorWriteAccess,
+            # [NOTE] We require Copr repository being present for the VM image
+            # builds via Packit Service as there are no common use cases that
+            # would benefit from relaxing this condition.
             IsCoprBuildForChrootOk,
         )
 


### PR DESCRIPTION
As we discussed with @majamassarini, we cannot find any use cases for supporting the VM image builds via Packit Service without any Copr repository set. Therefore adding a note about the fact that it's not possible as opposed to CLI support of this through ‹packit build in-image-builder›.

Related to packit/packit#1966, packit/packit#2434
