### PR TITLE
Do not filter out branches to fast forward

### DIFF
--- a/packit_service/worker/helpers/sync_release/sync_release.py
+++ b/packit_service/worker/helpers/sync_release/sync_release.py
@@ -82,13 +82,12 @@ class SyncReleaseHelper(BaseJobHelper):
 
         source_branch: source branch
         """
-        branches = aliases.get_fast_forward_merge_branches_for(
+        return aliases.get_fast_forward_merge_branches_for(
             self.job.dist_git_branches,
             source_branch,
             default=self.default_dg_branch,
             default_dg_branch=self.default_dg_branch,
         )
-        return self._filter_override_branches(branches)
 
     @property
     def job(self) -> Optional[JobConfig]:

--- a/tests/unit/test_propose_downstream.py
+++ b/tests/unit/test_propose_downstream.py
@@ -129,7 +129,6 @@ from packit_service.worker.helpers.sync_release.propose_downstream import (
                     trigger=JobConfigTriggerType.release,
                     packages={
                         "package": CommonPackageConfig(
-                            # no sense but possible!
                             dist_git_branches={
                                 "f41": {"fast_forward_merge_into": ["f40", "f39"]},
                                 "f38": {"fast_forward_merge_into": ["f37"]},
@@ -139,9 +138,9 @@ from packit_service.worker.helpers.sync_release.propose_downstream import (
                 ),
             ],
             JobConfigTriggerType.release,
-            {"f41", "f40"},
             {"f41"},
-            {"f41": {"f40"}},
+            {"f41"},
+            {"f41": {"f40", "f39"}},
         ),
     ],
 )


### PR DESCRIPTION
Should fix #2551

When retriggering propose-downstream for a branch
we want to fast forward the merge without filters.