### PR TITLE
Set higher time limit for DB maintenance task

### DIFF
--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -42,7 +42,7 @@ beat_schedule = {
     "database-maintenance": {
         "task": "packit_service.worker.tasks.database_maintenance",
         "schedule": crontab(minute=0, hour=1),  # nightly at 1AM
-        "options": {"queue": "long-running"},
+        "options": {"queue": "long-running", "time_limit": 1800},
     },
     "check-onboarded-projects": {
         "task": "packit_service.worker.tasks.run_check_onboarded_projects",


### PR DESCRIPTION
Discarding the old package configurations may take longer time, let's try to set the limit higher that the default.
