### PR TITLE
Fix getting builds suitable for update

### DIFF
--- a/packit_service/worker/helpers/sidetag.py
+++ b/packit_service/worker/helpers/sidetag.py
@@ -45,9 +45,9 @@ class Sidetag:
         for package in dependencies:
             latest_build = max(b for b in builds if b.name == package)
             latest_stable_nvr = self.koji_helper.get_latest_stable_nvr(
-                package, self.dist_git_branch, include_candidate=True
+                package, self.dist_git_branch
             )
-            # exclude NVRs that are already in stable or candidate tags - if a build
+            # exclude NVRs that are already in stable tags - if a build
             # has been manually tagged into the sidetag to satisfy dependencies,
             # we don't want it in the update
             if not latest_stable_nvr or latest_build > NEVR.from_string(

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -955,12 +955,10 @@ def test_bodhi_update_from_sidetag(
     flexmock(KojiHelper).should_receive("get_latest_stable_nvr").with_args(
         "python-specfile",
         "f40",
-        include_candidate=True,
     ).and_return("python-specfile-0.30.0-1.fc40")
     flexmock(KojiHelper).should_receive("get_latest_stable_nvr").with_args(
         "packit",
         "f40",
-        include_candidate=True,
     ).and_return("packit-0.98.0-1.fc40")
 
     flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(


### PR DESCRIPTION
As Bodhi updates created from sidetags are now being repeatedly updated with new builds until they reach stable, it is necessary to supply a full list of builds, including those that are already part of the update.