### PR TITLE
Fix tuple not callable error

### DIFF
--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1741,10 +1741,10 @@ class Parser:
                 parse_anitya_version_update_event.__func__  # type: ignore
             ),
             "openscanhub.task.started": (
-                parse_openscanhub_task_started_event.__func__,  # type: ignore
+                parse_openscanhub_task_started_event.__func__  # type: ignore
             ),
             "openscanhub.task.finished": (
-                parse_openscanhub_task_finished_event.__func__,  # type: ignore
+                parse_openscanhub_task_finished_event.__func__  # type: ignore
             ),
         },
         "testing-farm": {


### PR DESCRIPTION
Raised when parsing new Open Scan Hub events.

I don't know why I didn't catch it locally 🤔