### PR TITLE
Don't try to add reactions for commit comments

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -41,12 +41,12 @@ from packit_service.worker.events.comment import (
     AbstractCommentEvent,
     AbstractIssueCommentEvent,
     AbstractPRCommentEvent,
+    CommitCommentEvent,
 )
 from packit_service.worker.events.event import (
     AbstractForgeIndependentEvent,
     AbstractResultEvent,
 )
-from packit_service.worker.events.gitlab import CommitCommentGitlabEvent
 from packit_service.worker.events.koji import KojiBuildTagEvent
 from packit_service.worker.handlers import (
     CoprBuildHandler,
@@ -799,7 +799,7 @@ class SteveJobs:
 
             if handlers_triggered_by_job and not isinstance(
                 self.event,
-                (PullRequestCommentPagureEvent, CommitCommentGitlabEvent),
+                (PullRequestCommentPagureEvent, CommitCommentEvent),
             ):
                 self.event.comment_object.add_reaction(COMMENT_REACTION)
 

--- a/tests/integration/test_commit_comment.py
+++ b/tests/integration/test_commit_comment.py
@@ -13,7 +13,6 @@ from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject, LocalProjectBuilder
 
 from packit_service.constants import (
-    COMMENT_REACTION,
     TASK_ACCEPTED,
 )
 from packit_service.models import (
@@ -137,9 +136,6 @@ def test_commit_comment_build_and_test_handler(
     ).and_return(False).once()
     flexmock(celery_group).should_receive("apply_async").twice()
     flexmock(Pushgateway).should_receive("push").times(4).and_return()
-    comment = flexmock()
-    flexmock(GithubProject).should_receive("get_commit_comment").and_return(comment)
-    flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
 
     processing_results = SteveJobs().process_message(commit_build_comment_event)
     assert len(processing_results) == 2


### PR DESCRIPTION
Even though this works with normal account, in service we are getting exceptions like: `Max retries exceeded with url: /repos/packit/ogr/comments/148259166/reactions (Caused by ResponseError('too many 403 error responses'))"))`
