### PR TITLE
Fix database_maintenance

### DIFF
--- a/packit_service/worker/database.py
+++ b/packit_service/worker/database.py
@@ -48,12 +48,13 @@ def discard_old_package_configs():
         PACKAGE_CONFIGS_OUTDATED_AFTER_DAYS,
     )
     ago = timedelta(days=int(outdated_after_days))
-    for event in ProjectEventModel.get_older_than_with_packages_config(ago):
-        logger.debug(
-            f"ProjectEventModel {event.id} has all runs older than '{ago}'. "
-            "Discarding package config.",
-        )
-        event.set_packages_config(None)
+    events = ProjectEventModel.get_and_reset_older_than_with_packages_config(ago)
+    event_ids = "".join([" " + str(event.id) for event in events])
+
+    logger.debug(
+        f"ProjectEventModels with ids [{event_ids}] have all runs older than '{ago}'. "
+        "Discarded package configs.",
+    )
 
 
 def gzip_file(file: Path) -> Path:

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -22,11 +22,11 @@ def test_cleanup_old_srpm_build_logs():
 
 
 def test_discard_old_package_configs():
-    event_model = flexmock(id=1)
-    flexmock(event_model).should_receive("set_packages_config").with_args(None).once()
+    event_model1 = flexmock(id=1)
+    event_model2 = flexmock(id=2)
     flexmock(ProjectEventModel).should_receive(
-        "get_older_than_with_packages_config",
-    ).and_return([event_model]).once()
+        "get_and_reset_older_than_with_packages_config",
+    ).and_return([event_model1, event_model2]).once()
     database.discard_old_package_configs()
 
 

--- a/tests_openshift/database/test_models.py
+++ b/tests_openshift/database/test_models.py
@@ -1106,7 +1106,7 @@ def test_get_all_downstream_projects(clean_before_and_after, propose_model_submi
     assert projects.pop().project_url == SampleValues.downstream_project_url
 
 
-def test_project_event_get_older_than_with_packages_config(
+def test_project_event_get_and_reset_older_than_with_packages_config(
     clean_before_and_after,
     branch_project_event_model,
 ):
@@ -1117,7 +1117,7 @@ def test_project_event_get_older_than_with_packages_config(
     assert (
         len(
             list(
-                ProjectEventModel.get_older_than_with_packages_config(
+                ProjectEventModel.get_and_reset_older_than_with_packages_config(
                     timedelta(days=1),
                 ),
             ),
@@ -1131,7 +1131,7 @@ def test_project_event_get_older_than_with_packages_config(
     assert (
         len(
             list(
-                ProjectEventModel.get_older_than_with_packages_config(
+                ProjectEventModel.get_and_reset_older_than_with_packages_config(
                     timedelta(days=1),
                 ),
             ),


### PR DESCRIPTION
Should fix #2427

- Opened just one db session to speed up the operation that was taking too long
- Used `sql.null` instead of python `None` -> python `None` was not making the field null but was inserting a `Null` string into the field. 
