### PR TITLE
Try to minimize concurrency problems

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -43,7 +43,6 @@ from sqlalchemy import (
     null,
 )
 from sqlalchemy.dialects.postgresql import array as psql_array
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import (
     Session as SQLASession,

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -23,6 +23,7 @@ from urllib.parse import urlparse
 
 from cachetools import TTLCache, cached
 from cachetools.func import ttl_cache
+from packit.config import JobConfigTriggerType
 from sqlalchemy import (
     JSON,
     Boolean,
@@ -42,11 +43,11 @@ from sqlalchemy import (
     null,
 )
 from sqlalchemy.dialects.postgresql import array as psql_array
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import (
     Session as SQLASession,
 )
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import (
     relationship,
     scoped_session,
@@ -55,7 +56,6 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql.functions import count
 from sqlalchemy.types import ARRAY
 
-from packit.config import JobConfigTriggerType
 from packit_service.constants import ALLOWLIST_CONSTANTS
 
 logger = logging.getLogger(__name__)

--- a/packit_service/worker/events/open_scan_hub.py
+++ b/packit_service/worker/events/open_scan_hub.py
@@ -38,13 +38,20 @@ class OpenScanHubTaskAbstractEvent(AbstractResultEvent):
                 " It should have been created when receiving the CoprBuildEndEvent"
                 " and should have been associated with the copr build.",
             )
-        else:
-            self.build = self.scan.copr_build_target
-            project_event = self.build.get_project_event_model()
-            # commit_sha is needed by the StatusReporter
-            # and have to be serialized to be later found in the
-            # event metadata
-            self.commit_sha = project_event.commit_sha if not self.commit_sha else self.commit_sha
+            return
+        self.build = self.scan.copr_build_target
+        if not self.build:
+            logger.warning(
+                f"Scan with id {task_id} not associated with a build."
+                " It should have been associated when receiving the CoprBuildEndEvent."
+            )
+            return
+
+        project_event = self.build.get_project_event_model()
+        # commit_sha is needed by the StatusReporter
+        # and have to be serialized to be later found in the
+        # event metadata
+        self.commit_sha = project_event.commit_sha if not self.commit_sha else self.commit_sha
 
     def get_db_project_object(self) -> Optional[AbstractProjectObjectDbType]:
         return self.build.get_project_event_object()

--- a/packit_service/worker/helpers/open_scan_hub.py
+++ b/packit_service/worker/helpers/open_scan_hub.py
@@ -9,7 +9,6 @@ from os import getenv
 from os.path import basename
 from pathlib import Path
 from typing import Optional
-from sqlalchemy.exc import IntegrityError
 
 from packit.config import (
     JobConfig,
@@ -17,6 +16,7 @@ from packit.config import (
     JobType,
 )
 from packit.exceptions import PackitException
+from sqlalchemy.exc import IntegrityError
 
 from packit_service.constants import (
     OPEN_SCAN_HUB_FEATURE_DESCRIPTION,

--- a/tests/unit/test_open_scan_hub.py
+++ b/tests/unit/test_open_scan_hub.py
@@ -158,7 +158,11 @@ def test_handle_scan(build_models):
                 type=ProjectEventModelType.pull_request,
                 get_project_event_object=lambda: flexmock(),
             ),
-        ),
+        )
+        .should_receive("add_scan_transaction")
+        .once()
+        .and_return(flexmock())
+        .mock(),
         copr_build_helper=CoprBuildJobHelper(
             service_config=flexmock(),
             package_config=package_config,


### PR DESCRIPTION
Related to #2604

We have concurrency issues. 
This change does not solve them but could minimize them.

Here an example log of the concurrency issue before my change:


**worker1**
```
11/5/24 11:47:31.688 AM	2024-11-05T11:47:31.688406049+00:00 stderr F [2024-11-05 11:47:31,688: DEBUG/MainProcess] task.run_copr_build_end_handler[8d4413e0-ba73-4f78-a14f-487b824a1b0f] Searching for base build for 7c08e96170470eb6e3cb99fbf8b705862a1e0a58 commit in @teemtee/tmt Copr project in our DB.
[...]
11/5/24 11:47:32.592 AM	2024-11-05T11:47:32.592982751+00:00 stderr F [2024-11-05 11:47:32,592: DEBUG/MainProcess] task.run_copr_build_end_handler[8d4413e0-ba73-4f78-a14f-487b824a1b0f] Command: osh-cli version-diff-build --srpm=/tmp/tmp27a0u3z_/tmt-1.39.dev888-1.20241105114529529022.pr3342.18.g3fc4607c.src.rpm --base-srpm=/tmp/tmp27a0u3z_/tmt-1.39.dev17+g7c08e961-main.src.rpm --config=fedora-rawhide-x86_64 --nowait --json --comment=Submitted via Packit Service for https://dashboard.packit.dev/results/copr-builds/1994869
11/5/24 11:47:39.070 AM	2024-11-05T11:47:39.070934307+00:00 stderr F [2024-11-05 11:47:39,070: INFO/MainProcess] task.run_copr_build_end_handler[8d4413e0-ba73-4f78-a14f-487b824a1b0f] Scan submitted successfully.
```

**worker2**
```
11/5/24 11:47:30.159 AM	2024-11-05T11:47:30.159087194+00:00 stderr F [2024-11-05 11:47:30,158: DEBUG/ForkPoolWorker-1] task.babysit_copr_build[fd022210-82ed-43ff-9494-18705b393847] Searching for base build for 7c08e96170470eb6e3cb99fbf8b705862a1e0a58 commit in @teemtee/tmt Copr project in our DB.
[...]
11/5/24 11:47:30.795 AM	2024-11-05T11:47:30.795838802+00:00 stderr F [2024-11-05 11:47:30,795: DEBUG/ForkPoolWorker-1] task.babysit_copr_build[fd022210-82ed-43ff-9494-18705b393847] Command: osh-cli version-diff-build --srpm=/tmp/tmpg70py27t/tmt-1.39.dev888-1.20241105114529529022.pr3342.18.g3fc4607c.src.rpm --base-srpm=/tmp/tmpg70py27t/tmt-1.39.dev17+g7c08e961-main.src.rpm --config=fedora-rawhide-x86_64 --nowait --json --comment=Submitted via Packit Service for https://dashboard.packit.dev/results/copr-builds/1994869
11/5/24 11:47:32.774 AM	2024-11-05T11:47:32.774600167+00:00 stderr F [2024-11-05 11:47:32,774: INFO/ForkPoolWorker-1] task.babysit_copr_build[fd022210-82ed-43ff-9494-18705b393847] Scan submitted successfully.
```