### PR TITLE
Don't include OSH link in check title

### DIFF
--- a/packit_service/worker/handlers/open_scan_hub.py
+++ b/packit_service/worker/handlers/open_scan_hub.py
@@ -165,8 +165,7 @@ class OpenScanHubTaskFinishedHandler(
                 external_links = {"Added issues": self.get_issues_added_url()}
             elif number_of_new_findings > 0:
                 description = (
-                    f"{base_description} [{number_of_new_findings}"
-                    f" new findings]({self.get_issues_added_url()}) identified."
+                    f"{base_description} {number_of_new_findings} new findings identified."
                 )
                 external_links = {"Added issues": self.get_issues_added_url()}
             else:

--- a/tests/unit/test_open_scan_hub.py
+++ b/tests/unit/test_open_scan_hub.py
@@ -254,11 +254,7 @@ def test_handle_scan_task_finished(
     if processing_results:
         if scan_status == OpenScanHubTaskFinishedEvent.Status.success:
             state = BaseCommitStatus.success
-            description = (
-                "Scan in OpenScanHub is finished. "
-                "[2 new findings](https://openscanhub."
-                "fedoraproject.org/task/15649/log/added.html) identified."
-            )
+            description = "Scan in OpenScanHub is finished. " "2 new findings identified."
             flexmock(scan_mock).should_receive("set_status").with_args(
                 "succeeded",
             ).once()


### PR DESCRIPTION
In check title, markdown is not supported (and the URL is still present in the URL table).

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
