### PR TITLE
fix(tf): add enum value for requested cancel

### DIFF
--- a/alembic/versions/4387d6ab90e9_fix_tf_fix_typo_in_canceled_request.py
+++ b/alembic/versions/4387d6ab90e9_fix_tf_fix_typo_in_canceled_request.py
@@ -1,0 +1,24 @@
+"""fix(tf): fix typo in canceled-request
+
+Revision ID: 4387d6ab90e9
+Revises: 9f84a235ccbf
+Create Date: 2024-11-12 11:46:17.354580
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4387d6ab90e9"
+down_revision = "9f84a235ccbf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE testingfarmresult ADD VALUE 'cancel_requested'")
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
As @lbarcziova noticed there are some visible spikes of usage in the postgres pod and also a flood of Sentry issues related to the non-existing ‹cancel_requested› TF result in the DB. As it turns out, we receive ‹cancel-requested› from the Testing Farm, but at the same time SQLAlchemy has its own intelligence to use the enum »NAME« instead of the »VALUE« even though it is perfectly usable.

SQLAlchemy docs: https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum Excerpt in question:

    Above, the string names of each element, e.g. “one”, “two”, “three”,
    are persisted to the database.

Additionally, for the integrity of the database, the only allowed action on the enums is »adding« the values, so… We can have 2 different cancel states even though only one will be used. This could be potentially cleaned up afterwards after this issue is resolved and it has been verified it's possible to reset the entries (there is no guarantee of the same integer ID being assigned to the same constant…)

    Although enum types are primarily intended for static sets of values,
    there is support for adding new values to an existing enum type, and
    for renaming values (see ALTER TYPE). Existing values cannot be
    removed from an enum type, nor can the sort ordering of such values
    be changed, short of dropping and re-creating the enum type.

Fixes #2631
