### PR TITLE
Use error_message key for Koji and Bodhi updates

### DIFF
--- a/packit_service/service/api/bodhi_updates.py
+++ b/packit_service/service/api/bodhi_updates.py
@@ -82,7 +82,7 @@ class BodhiUpdateItem(Resource):
             "submitted_time": optional_timestamp(update.submitted_time),
             "update_creation_time": optional_timestamp(update.update_creation_time),
             "run_ids": sorted(run.id for run in update.group_of_targets.runs),
-            "error": update.data.get("error") if update.data else None,
+            "error_message": update.data.get("error") if update.data else None,
         }
 
         update_dict.update(get_project_info_from_build(update))

--- a/packit_service/service/api/koji_builds.py
+++ b/packit_service/service/api/koji_builds.py
@@ -98,7 +98,7 @@ class KojiBuildItem(Resource):
             "srpm_build_id": srpm_build.id if srpm_build else None,
             "run_ids": sorted(run.id for run in build.group_of_targets.runs),
             "build_submission_stdout": build.build_submission_stdout,
-            "error": build.data.get("error") if build.data else None,
+            "error_message": build.data.get("error") if build.data else None,
         }
 
         build_dict.update(get_project_info_from_build(build))


### PR DESCRIPTION
To be explicit this is something we populate from the data and not an error with getting the info from API.

