### PR TITLE
Link dashboard when reporting Koji and Bodhi errors

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -46,6 +46,10 @@ MSG_DOWNSTREAM_JOB_ERROR_HEADER = (
     "</tr>"
 )
 
+MSG_DOWNSTREAM_JOB_ERROR_ROW = (
+    '<tr><td><code>{branch}</code></td><td>See <a href="{url}">{url}</a></td></tr>\n'
+)
+
 MSG_GET_IN_TOUCH = f"\n\n---\n\n*Get in [touch with us]({CONTACTS_URL}) if you need some help.*"
 
 MSG_RETRIGGER = (

--- a/packit_service/service/urls.py
+++ b/packit_service/service/urls.py
@@ -50,3 +50,7 @@ def get_pull_from_upstream_info_url(id_: int) -> str:
 
 def get_openscanhub_info_url(id_: int) -> str:
     return _get_url_for_dashboard_results("openscanhub", id_)
+
+
+def get_bodhi_update_info_url(id_: int) -> str:
+    return _get_url_for_dashboard_results("bodhi", id_)

--- a/tests/integration/test_bodhi_update.py
+++ b/tests/integration/test_bodhi_update.py
@@ -324,6 +324,7 @@ def test_bodhi_update_for_unknown_koji_build_failed_issue_created(
     group_model = flexmock(
         grouped_targets=[
             flexmock(
+                id=12,
                 target="rawhide",
                 koji_nvrs="packit-0.43.0-1.fc36",
                 sidetag=None,
@@ -447,6 +448,7 @@ def test_bodhi_update_for_unknown_koji_build_failed_issue_comment(
     group_model = flexmock(
         grouped_targets=[
             flexmock(
+                id=12,
                 target="rawhide",
                 koji_nvrs="packit-0.43.0-1.fc36",
                 sidetag=None,

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -511,6 +511,7 @@ def test_downstream_koji_build_failure_issue_created():
     nvr = "package-1.2.3-1.fc40"
 
     koji_build = flexmock(
+        id=12,
         target="main",
         status="queued",
         sidetag=None,
@@ -620,6 +621,7 @@ def test_downstream_koji_build_failure_issue_comment():
     nvr = "package-1.2.3-1.fc40"
 
     koji_build = flexmock(
+        id=12,
         target="main",
         status="queued",
         sidetag=None,

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -362,6 +362,7 @@ def mock_repository_issue_retriggering():
     nvr_f37 = "package-1.2.3-1.fc37"
 
     koji_build_f37 = flexmock(
+        id=12,
         target="f37",
         status="queued",
         sidetag=None,
@@ -376,6 +377,7 @@ def mock_repository_issue_retriggering():
     nvr_f38 = "package-1.2.3-1.fc38"
 
     koji_build_f38 = flexmock(
+        id=13,
         target="f38",
         status="queued",
         sidetag=None,
@@ -622,7 +624,9 @@ def test_issue_comment_retrigger_koji_build_error_msg(
         "Packit failed on creating Koji build in dist-git (an url):"
         "\n\n<table><tr>"
         "<th>dist-git branch</th><th>error</th></tr>"
-        "<tr><td><code>f37</code></td><td><pre>error abc</pre></td></tr>\n</table>\n\n"
+        "<tr><td><code>f37</code></td>"
+        '<td>See <a href="https://localhost/jobs/koji/12">https://localhost/jobs/koji/12</a></td>'
+        "</tr>\n</table>\n\n"
         "Fedora Koji build was re-triggered by comment in issue 1.\n\n"
         "You can retrigger the build by adding a comment "
         "(`/packit koji-build`) into this issue.\n\n"

--- a/tests/integration/test_koji_build.py
+++ b/tests/integration/test_koji_build.py
@@ -165,6 +165,7 @@ def test_koji_build_error_msg(distgit_push_packit):
     nvr = "package-1.2.3-1.fc40"
 
     koji_build = flexmock(
+        id=12,
         target="f36",
         status="queued",
         sidetag=None,
@@ -211,7 +212,9 @@ def test_koji_build_error_msg(distgit_push_packit):
         "<th>dist-git branch</th>"
         "<th>error</th>"
         "</tr>"
-        "<tr><td><code>f36</code></td><td><pre>error abc</pre></td></tr>\n"
+        "<tr><td><code>f36</code></td>"
+        '<td>See <a href="https://localhost/jobs/koji/12">https://localhost/jobs/koji/12</a></td>'
+        "</tr>\n"
         "</table>\n\n"
         "Fedora Koji build was triggered by push "
         "with sha ad0c308af91da45cf40b253cd82f07f63ea9cbbf."

--- a/tests/unit/test_bodhi_update_error_msgs.py
+++ b/tests/unit/test_bodhi_update_error_msgs.py
@@ -93,7 +93,8 @@ def test_pull_request_retrigger_bodhi_update_with_koji_data(
         "in dist-git (an url):\n\n"
         "<table>"
         "<tr><th>dist-git branch</th><th>error</th></tr>"
-        "<tr><td><code>f36</code></td><td><pre>error abc</pre></td></tr>\n"
+        "<tr><td><code>f36</code></td>"
+        '<td>See <a href="/jobs/bodhi/12">/jobs/bodhi/12</a></td></tr>\n'
         "</table>\n\n"
         "Fedora Bodhi update was re-triggered by comment in dist-git PR with id 123.\n\n"
         "You can retrigger the update by adding a comment (`/packit create-update`) "
@@ -122,6 +123,7 @@ def test_pull_request_retrigger_bodhi_update_with_koji_data(
         flexmock(
             grouped_targets=[
                 flexmock(
+                    id=12,
                     target="f36",
                     koji_nvrs="a_package_1.f36",
                     sidetag=None,


### PR DESCRIPTION
Related to #2426

This makes it consistent with behaviour for release syncing.

RELEASE NOTES BEGIN

Packit now includes dashboard links when reporting errors for Koji builds and Bodhi updates.

RELEASE NOTES END
