### PR TITLE
Set UID when setting Pagure PR flag

### DIFF
--- a/packit_service/worker/reporting/reporters/pagure.py
+++ b/packit_service/worker/reporting/reporters/pagure.py
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
-
+import hashlib
 import logging
 from typing import Optional
 
@@ -47,8 +47,16 @@ class StatusReporterPagure(StatusReporter):
             url = CONTACTS_URL
 
         if self.pull_request_object:
+            # generate a custom uid from the check_name,
+            # so that we can update flags we set previously,
+            # instead of creating new ones (Pagure specific behaviour)
+            uid = hashlib.sha256(check_name.encode()).hexdigest()
             self.pull_request_object.set_flag(
-                username=check_name, comment=description, url=url, status=state_to_set
+                username=check_name,
+                comment=description,
+                url=url,
+                status=state_to_set,
+                uid=uid,
             )
 
         else:


### PR DESCRIPTION
Generate it from the check_name. This prevents creating multiple separate flags (for each state). This was already introduced in 0d4bc3653d61e7d10310823995aa97a8071f93fe .

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
