### PR TITLE
Trim the UID for setting Pagure PR flag

### DIFF
--- a/packit_service/worker/reporting/reporters/pagure.py
+++ b/packit_service/worker/reporting/reporters/pagure.py
@@ -50,7 +50,8 @@ class StatusReporterPagure(StatusReporter):
             # generate a custom uid from the check_name,
             # so that we can update flags we set previously,
             # instead of creating new ones (Pagure specific behaviour)
-            uid = hashlib.sha256(check_name.encode()).hexdigest()
+            # the max length of uid is 32 chars
+            uid = hashlib.sha256(check_name.encode()).hexdigest()[:32]
             self.pull_request_object.set_flag(
                 username=check_name,
                 comment=description,


### PR DESCRIPTION
The limit for the length is 32 characters
(https://pagure.io/api/0/#pull_requests-tab).


RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
