### PR TITLE
fix(usage): raise time limit and lower frequency

### DIFF
--- a/packit_service/celery_config.py
+++ b/packit_service/celery_config.py
@@ -51,8 +51,8 @@ beat_schedule = {
     },
     "get_usage_statistics": {
         "task": "packit_service.worker.tasks.get_usage_statistics",
-        "schedule": 3600.0,
-        "options": {"queue": "long-running", "time_limit": 1800},
+        "schedule": 10800.0,
+        "options": {"queue": "long-running", "time_limit": 3600},
     },
 }
 


### PR DESCRIPTION
As discussed with @majamassarini in the DMs, there are numerous occurencies of the hourly usage statistics caching not meeting the Celery deadline. Therefore adjusting both timeout and frequency.

• Timeout: 1800s → 3600s
           30min → 60min

  To make sure it doesn't spam Sentry with unnecessary exceptions.

• Frequency: 3600s → 10800s
               1hr →    3hr

  To avoid parallel runs of the same task and also to avoid congestion
  with other tasks (e.g., regular jobs).