### PR TITLE
Consider identifiers for OpenScanHub

### DIFF
--- a/packit_service/worker/checker/open_scan_hub.py
+++ b/packit_service/worker/checker/open_scan_hub.py
@@ -25,3 +25,15 @@ class RawhideX86Target(
             )
             return False
         return True
+
+
+class IsEventForJob(Checker):
+    def pre_check(self) -> bool:
+        if self.data.identifier != self.job_config.identifier:
+            logger.debug(
+                f"Skipping reporting, identifiers don't match "
+                f"(identifier of the OpenScanHub job to report: {self.data.identifier}, "
+                f"identifier from build job config: {self.job_config.identifier}).",
+            )
+            return False
+        return True

--- a/packit_service/worker/events/open_scan_hub.py
+++ b/packit_service/worker/events/open_scan_hub.py
@@ -10,6 +10,7 @@ from ogr.abstract import GitProject
 from packit_service.config import ServiceConfig
 from packit_service.models import (
     AbstractProjectObjectDbType,
+    CoprBuildTargetModel,
     OSHScanModel,
     ProjectEventModel,
 )
@@ -23,6 +24,7 @@ class OpenScanHubTaskAbstractEvent(AbstractResultEvent):
         self,
         task_id: int,
         commit_sha: Optional[str] = None,
+        identifier: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -31,7 +33,7 @@ class OpenScanHubTaskAbstractEvent(AbstractResultEvent):
         self.commit_sha = commit_sha
 
         self.scan = OSHScanModel.get_by_task_id(task_id)
-        self.build = None
+        self.build: Optional[CoprBuildTargetModel] = None
         if not self.scan:
             logger.warning(
                 f"Scan with id {task_id} not found in the database."
@@ -52,6 +54,7 @@ class OpenScanHubTaskAbstractEvent(AbstractResultEvent):
         # and have to be serialized to be later found in the
         # event metadata
         self.commit_sha = project_event.commit_sha if not self.commit_sha else self.commit_sha
+        self.identifier = identifier or self.build.identifier
 
     def get_db_project_object(self) -> Optional[AbstractProjectObjectDbType]:
         return self.build.get_project_event_object()

--- a/packit_service/worker/handlers/open_scan_hub.py
+++ b/packit_service/worker/handlers/open_scan_hub.py
@@ -12,7 +12,7 @@ from packit.config import (
 from packit_service.models import OSHScanStatus
 from packit_service.service.urls import get_openscanhub_info_url
 from packit_service.worker.checker.abstract import Checker
-from packit_service.worker.checker.open_scan_hub import RawhideX86Target
+from packit_service.worker.checker.open_scan_hub import IsEventForJob, RawhideX86Target
 from packit_service.worker.events import (
     OpenScanHubTaskFinishedEvent,
     OpenScanHubTaskStartedEvent,
@@ -52,7 +52,7 @@ class OpenScanHubAbstractHandler(
 
     @staticmethod
     def get_checkers() -> tuple[type[Checker], ...]:
-        return (RawhideX86Target,)
+        return (RawhideX86Target, IsEventForJob)
 
     def get_helper(self) -> OpenScanHubHelper:
         build_helper = CoprBuildJobHelper(

--- a/packit_service/worker/helpers/open_scan_hub.py
+++ b/packit_service/worker/helpers/open_scan_hub.py
@@ -151,11 +151,14 @@ class OpenScanHubHelper:
         url: str,
         links_to_external_services: Optional[dict[str, str]] = None,
     ):
+        check_name = "osh-diff-scan:fedora-rawhide-x86_64"
+        if identifier := self.copr_build_helper.job_config.identifier:
+            check_name += f":{identifier}"
         self.copr_build_helper._report(
             state=state,
             description=description,
             url=url,
-            check_names=["osh-diff-scan:fedora-rawhide-x86_64"],
+            check_names=[check_name],
             markdown_content=OPEN_SCAN_HUB_FEATURE_DESCRIPTION,
             links_to_external_services=links_to_external_services,
         )

--- a/tests/unit/events/test_open_scan_hub.py
+++ b/tests/unit/events/test_open_scan_hub.py
@@ -41,6 +41,7 @@ def scan_config_and_db(add_pull_request_event_with_sha_123456):
     db_build = (
         flexmock(
             build_id="55",
+            identifier=None,
             status="success",
             build_submitted_time=datetime.datetime.utcnow(),
             target="the-target",

--- a/tests/unit/test_open_scan_hub.py
+++ b/tests/unit/test_open_scan_hub.py
@@ -61,6 +61,7 @@ def prepare_openscanhub_db_and_handler(
     db_build = (
         flexmock(
             build_id="55",
+            identifier=None,
             status="success",
             build_submitted_time=datetime.datetime.utcnow(),
             target="the-target",
@@ -98,12 +99,17 @@ def prepare_openscanhub_db_and_handler(
 @pytest.mark.parametrize(
     "build_models",
     [
-        [("abcdef", [flexmock(get_srpm_build=lambda: flexmock(url="base-srpm-url"))])],
+        [
+            (
+                "abcdef",
+                [flexmock(identifier=None, get_srpm_build=lambda: flexmock(url="base-srpm-url"))],
+            )
+        ],
         [
             ("abcdef", []),
             (
                 "fedcba",
-                [flexmock(get_srpm_build=lambda: flexmock(url="base-srpm-url"))],
+                [flexmock(identifier=None, get_srpm_build=lambda: flexmock(url="base-srpm-url"))],
             ),
         ],
     ],
@@ -137,6 +143,7 @@ def test_handle_scan(build_models):
                 branch="main",
                 project="commit-project",
                 owner="user-123",
+                identifier=None,
             ),
         ],
     )
@@ -170,7 +177,7 @@ def test_handle_scan(build_models):
             project=project,
             metadata=flexmock(pr_id=12),
             db_project_event=flexmock(get_project_event_object=lambda: None),
-            job_config=flexmock(),
+            job_config=flexmock(identifier=None),
         ),
     ).handle_scan()
 


### PR DESCRIPTION
Fixes #2653


RELEASE NOTES BEGIN

We have fixed the reporting of OpenScanHub jobs when identifiers for Copr build jobs are configured.

RELEASE NOTES END
