### PR TITLE
Revert "Install mod_wsgi from updates-testing in service"

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -37,21 +37,6 @@
           - python-setuptools_scm
         state: present
         install_weak_deps: False
-    - name: Install mod_wsgi from updates-testing
-      # mod_wsgi < 5.0.2 has issues with Python 3.13:
-      #
-      # [wsgi:error] [pid 13:tid 78] Exception ignored in: <_io.TextIOWrapper name='<wsgi.errors>' encoding='utf-8'>
-      # [wsgi:error] [pid 13:tid 78] RuntimeError: log object has expired
-      #
-      # install it from updates-testing (this can be removed when
-      # https://bodhi.fedoraproject.org/updates/FEDORA-2024-235cc1f0b3 reaches stable)
-      ansible.builtin.dnf:
-        enablerepo:
-          - updates-testing
-        name:
-          - python3-mod_wsgi
-        state: latest
-        install_weak_deps: False
     - import_tasks: tasks/setup-copr-repos.yaml
     - name: Install ogr, specfile and packit from copr
       ansible.builtin.dnf:


### PR DESCRIPTION
Fixed version [5.0.2](https://koji.fedoraproject.org/koji/buildinfo?buildID=2596740) is in the repos now.

This reverts commit beda4770360d4b69f2990f5a335454fbf9f01fea.