### PR TITLE
perf(tf): index by the test run group ID

### DIFF
--- a/alembic/versions/e3cfec8ce0f7_index_tft_test_run_group_id.py
+++ b/alembic/versions/e3cfec8ce0f7_index_tft_test_run_group_id.py
@@ -1,0 +1,35 @@
+"""Index tft_test_run_group_id
+
+Based on the Sentry's backend insights, it appears that in the last 90d
+we have spent 16.82min running the query that filters out rows based on
+the «test run group id», therefore index that column to improve the speed
+of the queries done.
+
+Revision ID: e3cfec8ce0f7
+Revises: d625d6c1122f
+Create Date: 2025-01-17 16:06:29.833622
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e3cfec8ce0f7"
+down_revision = "d625d6c1122f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        op.f("ix_tft_test_run_targets_tft_test_run_group_id"),
+        "tft_test_run_targets",
+        ["tft_test_run_group_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_tft_test_run_targets_tft_test_run_group_id"), table_name="tft_test_run_targets"
+    )

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -3325,7 +3325,7 @@ class TFTTestRunTargetModel(GroupAndTargetModelConnector, Base):
     # so it will run when the model is initiated, not when the table is made
     submitted_time = Column(DateTime, default=datetime.utcnow)
     data = Column(JSON)
-    tft_test_run_group_id = Column(Integer, ForeignKey("tft_test_run_groups.id"))
+    tft_test_run_group_id = Column(Integer, ForeignKey("tft_test_run_groups.id"), index=True)
 
     copr_builds = relationship(
         "CoprBuildTargetModel",


### PR DESCRIPTION
Based on the Sentry's backend insights, it appears that in the last 90d we have spent 16.82min running the query that filters out rows based on the «test run group id», therefore index that column to improve the speed of the queries done.

#### TODO

The alembic migration generated also:
```py
def upgrade():
    op.alter_column('project_events', 'type',
               existing_type=postgresql.ENUM('pull_request', 'branch_push', 'release', 'issue', 'koji_build_tag', 'anitya_version', 'anitya_multiple_versions', name='projecteventtype'),
               type_=sa.Enum('pull_request', 'branch_push', 'release', 'issue', 'koji_build_tag', 'anitya_version', 'anitya_multiple_versions', name='projecteventmodeltype'),
               existing_nullable=True)


def downgrade():
    op.alter_column('project_events', 'type',
               existing_type=sa.Enum('pull_request', 'branch_push', 'release', 'issue', 'koji_build_tag', 'anitya_version', 'anitya_multiple_versions', name='projecteventmodeltype'),
               type_=postgresql.ENUM('pull_request', 'branch_push', 'release', 'issue', 'koji_build_tag', 'anitya_version', 'anitya_multiple_versions', name='projecteventtype'),
               existing_nullable=True)
```

which is definitely not my change and is basically just a rename of the enumeration

- [ ] check what is it about