### PR TITLE
chore(tests): unpin pytest

### DIFF
--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -8,7 +8,6 @@
     - name: Install test RPM dependencies
       ansible.builtin.dnf:
         name:
-          - python3-flexmock
           - tar
           - rsync
         state: present
@@ -16,7 +15,8 @@
       ansible.builtin.pip:
         name:
           - requre
-          - pytest==8.0.2
+          - flexmock
+          - pytest
           - pytest-cov
           - pytest-flask
           - deepdiff < 8.0.0 # version 8.0.0 requires numpy, avoid it


### PR DESCRIPTION
As the breaking change (deprecation) in pytest=8.1.1 has been already fixed in flexmock¹, unpin pytest and also install flexmock from the PyPI rather than RPM (to ensure the same behavior even if we switched back to the CentOS images).

Newer version of pytest introduces ‹PYTEST_VERSION› environment variable that can be used to detect whether the tests are being run or not, which is used in some safe-guards in the events-refactor².

¹ https://github.com/flexmock/flexmock/pull/153
² https://github.com/packit/packit-service/pull/2590