### PR TITLE
Push metrics once per process_message task

### DIFF
--- a/tests/integration/test_check_rerun.py
+++ b/tests/integration/test_check_rerun.py
@@ -286,7 +286,7 @@ def test_check_rerun_pr_testing_farm_handler(
         markdown_content=None,
     ).once()
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(4).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_testing_farm)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -344,7 +344,7 @@ def test_check_rerun_pr_koji_build_handler(
         markdown_content=None,
     ).once()
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(4).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_koji_build)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -403,7 +403,7 @@ def test_check_rerun_pr_koji_build_handler_old_job_name(
         markdown_content=None,
     ).once()
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(4).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_koji_build)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -487,7 +487,7 @@ def test_check_rerun_push_testing_farm_handler(
         markdown_content=None,
     ).once()
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(4).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_testing_farm)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -547,7 +547,7 @@ def test_check_rerun_push_koji_build_handler(
         markdown_content=None,
     ).once()
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(4).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_koji_build_push)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -606,7 +606,7 @@ def test_check_rerun_release_koji_build_handler(
         markdown_content=None,
     ).once()
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(4).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(check_rerun_event_koji_build)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -667,7 +667,7 @@ def test_check_rerun_release_propose_downstream_handler(
         update_feedback_time=object,
     ).once()
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+    flexmock(Pushgateway).should_receive("push").times(1).and_return()
 
     processing_results = SteveJobs().process_message(
         check_rerun_event_propose_downstream,

--- a/tests/integration/test_commit_comment.py
+++ b/tests/integration/test_commit_comment.py
@@ -131,7 +131,7 @@ def test_commit_comment_build_and_test_handler(
         "is_custom_copr_project_defined",
     ).and_return(False).once()
     flexmock(celery_group).should_receive("apply_async").twice()
-    flexmock(Pushgateway).should_receive("push").times(4).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(commit_build_comment_event)
     assert len(processing_results) == 2

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -260,7 +260,7 @@ def test_issue_comment_propose_downstream_handler(
     ).once()
 
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(ProposeDownstreamJobHelper).should_receive(
         "report_status_to_all",
     ).with_args(

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -292,7 +292,7 @@ def test_pr_comment_build_build_and_test_handler(
         "is_custom_copr_project_defined",
     ).and_return(False).once()
     flexmock(celery_group).should_receive("apply_async").twice()
-    flexmock(Pushgateway).should_receive("push").times(4).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     pr = flexmock(head_commit="12345")
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
@@ -367,7 +367,7 @@ def test_pr_comment_build_build_and_test_handler_manual_test_reporting(
         "is_custom_copr_project_defined",
     ).and_return(False).once()
     flexmock(celery_group).should_receive("apply_async").twice()
-    flexmock(Pushgateway).should_receive("push").times(4).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     pr = flexmock(head_commit="12345")
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
@@ -467,7 +467,7 @@ def test_pr_comment_production_build_handler(pr_production_build_comment_event):
         update_feedback_time=object,
     ).once()
     flexmock(celery_group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     pr = flexmock(head_commit="12345")
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
     comment = flexmock()
@@ -693,7 +693,7 @@ def test_pr_test_command_handler(
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=True, details={}),
     )
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -783,7 +783,7 @@ def test_pr_test_command_handler_identifiers(
     flexmock(TestingFarmJobHelper).should_receive("run_testing_farm").once().and_return(
         TaskResults(success=True, details={}),
     )
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -941,7 +941,7 @@ def test_pr_test_command_handler_retries(
         {"fedora-rawhide-x86_64"},
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
-    flexmock(Pushgateway).should_receive("push").times(4).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     payload = {
         "api_key": "secret-token",
@@ -1140,7 +1140,7 @@ def test_pr_test_command_handler_skip_build_option(
         {"fedora-rawhide-x86_64"},
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -1345,7 +1345,7 @@ def test_pr_test_command_handler_compose_not_present(
         {"fedora-rawhide-x86_64"},
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -1472,7 +1472,7 @@ def test_pr_test_command_handler_composes_not_available(
         {"fedora-rawhide-x86_64"},
     )
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -1680,7 +1680,6 @@ def test_trigger_packit_command_without_config(
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     pr = flexmock(head_commit="12345")
     flexmock(GithubProject).should_receive("get_pr").and_return(pr)
-    flexmock(Pushgateway).should_receive("push").times(1).and_return()
     err_msg = (
         "No config file for packit (e.g. `.packit.yaml`) found in namespace/repo on commit 12345"
         "\n\n"
@@ -1812,7 +1811,7 @@ def test_retest_failed(
         {("some_target", None)},
     )
 
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -1904,7 +1903,7 @@ def test_pr_test_command_handler_skip_build_option_no_fmf_metadata(
     ).and_return(group_model)
     flexmock(TFTTestRunTargetModel).should_receive("create").and_return(test_run)
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").never()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,
@@ -2105,7 +2104,7 @@ def test_pr_test_command_handler_multiple_builds(
     flexmock(TestingFarmJobHelper).should_receive("get_latest_copr_build").and_return(
         build,
     )
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(TestingFarmJobHelper).should_receive("report_status_to_tests").with_args(
         description=TASK_ACCEPTED,
         state=BaseCommitStatus.pending,

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -246,7 +246,7 @@ def test_dist_git_push_release_handle(
     ).once()
 
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(shutil).should_receive("rmtree").with_args("")
 
     url = get_propose_downstream_info_url(model.id)
@@ -398,7 +398,7 @@ def test_dist_git_push_release_handle_multiple_branches(
         ),
     )
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     from packit_service.worker.handlers.distgit import shutil
 
@@ -563,7 +563,7 @@ def test_dist_git_push_release_handle_one_failed(
     )
 
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     from packit_service.worker.handlers.distgit import shutil
 
@@ -703,7 +703,7 @@ def test_dist_git_push_release_handle_all_failed(
     )
     flexmock(shutil).should_receive("rmtree").with_args("")
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(github_release_webhook)
     event_dict, job, job_config, package_config = get_parameters_from_results(
@@ -806,7 +806,7 @@ def test_retry_propose_downstream_task(
 
     flexmock(shutil).should_receive("rmtree").with_args("")
     flexmock(Task).should_receive("retry").once().and_return()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     url = get_propose_downstream_info_url(model.id)
     flexmock(ProposeDownstreamJobHelper).should_receive(
@@ -929,7 +929,7 @@ def test_dont_retry_propose_downstream_task(
     flexmock(Context, retries=6)
     flexmock(shutil).should_receive("rmtree").with_args("")
     flexmock(Task).should_receive("retry").never()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     url = get_propose_downstream_info_url(model.id)
     flexmock(ProposeDownstreamJobHelper).should_receive(
@@ -1034,7 +1034,7 @@ def test_dist_git_push_release_failed_issue_creation_disabled(
 
     flexmock(shutil).should_receive("rmtree").with_args("")
     flexmock(group).should_receive("apply_async").once()
-    flexmock(Pushgateway).should_receive("push").times(3).and_return()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(github_release_webhook)
     event_dict, job, job_config, package_config = get_parameters_from_results(

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -27,7 +27,6 @@ def test_copr_metrics_ignored(handler, targets):
     counter.should_receive("inc").never()
 
     pushgateway = flexmock(copr_builds_queued=counter)
-    pushgateway.should_receive("push").once()
 
     jobs = SteveJobs(event)
     jobs.pushgateway = pushgateway
@@ -42,7 +41,6 @@ def test_copr_metrics_pushed():
     counter.should_receive("inc").with_args(7).once()
 
     pushgateway = flexmock(copr_builds_queued=counter)
-    pushgateway.should_receive("push").once()
 
     jobs = SteveJobs(event)
     jobs.pushgateway = pushgateway
@@ -68,7 +66,6 @@ def test_delayed():
         last_initial_status_time=last,
         no_status_after_25_s=counter,
     )
-    pushgateway.should_receive("push").once()
 
     jobs = SteveJobs(event)
     jobs.pushgateway = pushgateway

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -211,7 +211,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
     ).times(
         1 if success else 0,
     )
-    flexmock(Pushgateway).should_receive("push").times(3 if success else 1)
+    flexmock(Pushgateway).should_receive("push").times(2 if success else 1)
 
     url = get_propose_downstream_info_url(model.id)
 


### PR DESCRIPTION
Previously, metrics could be pushed multiple times within a single process_message task. This could potentially lead to increased CPU usage, redundant network requests, and  metric inconsistencies. Related to #2430 #2697
