### PR TITLE
fix(jobs): force ‹__str__› when logging jobs

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -939,7 +939,11 @@ class SteveJobs:
                 f"{self.event.event_type()}",
             )
 
-        logger.debug(f"Jobs matching {handler_kls}: {matching_jobs}")
+        logger.debug(
+            "Jobs matching %s: %s",
+            handler_kls.__qualname__,
+            [str(j) for j in matching_jobs],
+        )
 
         return matching_jobs
 


### PR DESCRIPTION
Apparently, even if there is a ‹__str__› implementation, logging still uses ‹__repr__› which prints everything in a sort-of JSON format.

Therefore map each of the jobs to their respective string representation during the logging to force the usage of the ‹__str__› instead of the ‹__repr__›.

Related to packit/packit#2306