### PR TITLE
Allow running Koji scratch builds from the original repo, not only forks

### DIFF
--- a/packit_service/events/pagure/pr.py
+++ b/packit_service/events/pagure/pr.py
@@ -36,6 +36,7 @@ class Comment(AbstractPRCommentEvent, PagureEvent):
         base_ref: Optional[str],
         target_repo: str,
         project_url: str,
+        source_project_url: str,
         user_login: str,
         comment: str,
         comment_id: int,
@@ -56,6 +57,7 @@ class Comment(AbstractPRCommentEvent, PagureEvent):
         self.base_repo_owner = base_repo_owner
         self.base_ref = base_ref
         self.target_repo = target_repo
+        self.source_project_url = source_project_url
         self.user_login = user_login
         self.identifier = str(pr_id)
         self.git_ref = None  # pr_id will be used for checkout
@@ -157,6 +159,7 @@ class Action(AddPullRequestEventToDb, PagureEvent):
         base_ref: Optional[str],
         target_repo: str,
         project_url: str,
+        source_project_url: str,
         commit_sha: str,
         user_login: str,
         target_branch: str,
@@ -173,6 +176,7 @@ class Action(AddPullRequestEventToDb, PagureEvent):
         self.identifier = str(pr_id)
         self.git_ref = None  # pr_id will be used for checkout
         self.project_url = project_url
+        self.source_project_url = source_project_url
         self.target_branch = target_branch
 
     @classmethod

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1645,6 +1645,7 @@ class Parser:
         base_repo_owner = repo_from["user"]["name"] if repo_from else pagure_login
         target_repo = repo_from["name"] if repo_from else base_repo_name
         https_url = event["pullrequest"]["project"]["full_url"]
+        source_project_url = repo_from["full_url"] if repo_from else https_url
         commit_sha = event["pullrequest"]["commit_stop"]
 
         if "added" in event["topic"]:
@@ -1664,6 +1665,7 @@ class Parser:
             base_ref=None,
             target_repo=target_repo,
             project_url=https_url,
+            source_project_url=source_project_url,
             commit_sha=commit_sha,
             user_login=pagure_login,
             comment=comment,
@@ -1697,6 +1699,7 @@ class Parser:
         base_repo_owner = repo_from["user"]["name"] if repo_from else pagure_login
         target_repo = repo_from["name"] if repo_from else base_repo_name
         https_url = event["pullrequest"]["project"]["full_url"]
+        source_project_url = repo_from["full_url"] if repo_from else https_url
         commit_sha = event["pullrequest"]["commit_stop"]
         target_branch = event["pullrequest"]["branch"]
 
@@ -1709,6 +1712,7 @@ class Parser:
             base_ref=None,
             target_repo=target_repo,
             project_url=https_url,
+            source_project_url=source_project_url,
             commit_sha=commit_sha,
             user_login=pagure_login,
             target_branch=target_branch,

--- a/tests/data/fedmsg/pagure_pr_new_no_fork.json
+++ b/tests/data/fedmsg/pagure_pr_new_no_fork.json
@@ -1,0 +1,105 @@
+{
+  "agent": "ngompa",
+  "pullrequest": {
+    "assignee": null,
+    "branch": "rawhide",
+    "branch_from": "update-variants-list-20250222",
+    "cached_merge_status": "unknown",
+    "closed_at": null,
+    "closed_by": null,
+    "comments": [],
+    "commit_start": "1cc05ef282f08e199b69d4411b70544ab11d21c0",
+    "commit_stop": "914e61919e3a3a82c0ef7b6bd3a73f74e2de36e7",
+    "date_created": "1740205464",
+    "full_url": "https://pagure.io/fedora-kiwi-descriptions/pull-request/150",
+    "id": 150,
+    "initial_comment": "This pull request updates `VARIANTS.md` with all the images being built in Fedora. There's still more supported in the descriptions to document.",
+    "last_updated": "1740205464",
+    "project": {
+      "access_groups": {
+        "admin": ["releng"],
+        "collaborator": [],
+        "commit": [],
+        "ticket": []
+      },
+      "access_users": {
+        "admin": ["adamwill", "davdunc"],
+        "collaborator": [],
+        "commit": [],
+        "owner": ["ngompa"],
+        "ticket": ["zuul"]
+      },
+      "close_status": [],
+      "custom_keys": [],
+      "date_created": "1631117496",
+      "date_modified": "1732738404",
+      "description": "Fedora image build descriptions for the KIWI image build tool",
+      "full_url": "https://pagure.io/fedora-kiwi-descriptions",
+      "fullname": "fedora-kiwi-descriptions",
+      "id": 10614,
+      "milestones": {},
+      "name": "fedora-kiwi-descriptions",
+      "namespace": null,
+      "parent": null,
+      "priorities": {},
+      "tags": [],
+      "url_path": "fedora-kiwi-descriptions",
+      "user": {
+        "full_url": "https://pagure.io/user/ngompa",
+        "fullname": "Neal Gompa",
+        "name": "ngompa",
+        "url_path": "user/ngompa"
+      }
+    },
+    "remote_git": null,
+    "repo_from": {
+      "access_groups": {
+        "admin": ["releng"],
+        "collaborator": [],
+        "commit": [],
+        "ticket": []
+      },
+      "access_users": {
+        "admin": ["adamwill", "davdunc"],
+        "collaborator": [],
+        "commit": [],
+        "owner": ["ngompa"],
+        "ticket": ["zuul"]
+      },
+      "close_status": [],
+      "custom_keys": [],
+      "date_created": "1631117496",
+      "date_modified": "1732738404",
+      "description": "Fedora image build descriptions for the KIWI image build tool",
+      "full_url": "https://pagure.io/fedora-kiwi-descriptions",
+      "fullname": "fedora-kiwi-descriptions",
+      "id": 10614,
+      "milestones": {},
+      "name": "fedora-kiwi-descriptions",
+      "namespace": null,
+      "parent": null,
+      "priorities": {},
+      "tags": [],
+      "url_path": "fedora-kiwi-descriptions",
+      "user": {
+        "full_url": "https://pagure.io/user/ngompa",
+        "fullname": "Neal Gompa",
+        "name": "ngompa",
+        "url_path": "user/ngompa"
+      }
+    },
+    "status": "Open",
+    "tags": [],
+    "threshold_reached": null,
+    "title": "Update VARIANTS in use",
+    "uid": "5b607fba790e4531add705eb21a59647",
+    "updated_on": "1740205464",
+    "user": {
+      "full_url": "https://pagure.io/user/ngompa",
+      "fullname": "Neal Gompa",
+      "name": "ngompa",
+      "url_path": "user/ngompa"
+    }
+  },
+  "topic": "org.fedoraproject.prod.pagure.pull-request.new"
+}

--- a/tests/unit/test_bodhi_update_error_msgs.py
+++ b/tests/unit/test_bodhi_update_error_msgs.py
@@ -75,6 +75,7 @@ def package_config__job_config__pull_request_event(package_config__job_config):
         base_repo_owner="a_owner",
         target_repo="a_target",
         project_url="projec_url",
+        source_project_url="source_project_url",
         user_login="usr_login",
         comment="/packit creat-update",
         comment_id=321,


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
- [x] How do we formulate the changes related to the PoC of Fedora dist-git CI in the release notes?

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #2711

<!-- release notes footer -->

RELEASE NOTES BEGIN
(Fedora dist-git CI beta) You can now trigger scratch Koji builds from the dist-git PRs even when the PR is created from the branch on the same repository.
RELEASE NOTES END
