### PR TITLE
Generate uid for pagure set_flag using target_branch

### DIFF
--- a/packit_service/worker/helpers/fedora_ci.py
+++ b/packit_service/worker/helpers/fedora_ci.py
@@ -26,6 +26,10 @@ class FedoraCIHelper:
         self._status_reporter = None
 
     @property
+    def target_branch(self) -> str:
+        return self.metadata.event_dict.get("target_branch")
+
+    @property
     def status_reporter(self) -> StatusReporter:
         if not self._status_reporter:
             self._status_reporter = StatusReporter.get_instance(
@@ -42,4 +46,5 @@ class FedoraCIHelper:
             description=description,
             url=url,
             check_name=self.status_name,
+            target_branch=self.target_branch,
         )

--- a/packit_service/worker/reporting/reporters/base.py
+++ b/packit_service/worker/reporting/reporters/base.py
@@ -102,6 +102,7 @@ class StatusReporter:
         url: str = "",
         links_to_external_services: Optional[dict[str, str]] = None,
         markdown_content: Optional[str] = None,
+        target_branch: Optional[str] = None,
     ):
         raise NotImplementedError()
 

--- a/packit_service/worker/reporting/reporters/github.py
+++ b/packit_service/worker/reporting/reporters/github.py
@@ -98,6 +98,7 @@ class StatusReporterGithubChecks(StatusReporterGithubStatuses):
         url: str = "",
         links_to_external_services: Optional[dict[str, str]] = None,
         markdown_content: Optional[str] = None,
+        target_branch: Optional[str] = None,
     ):
         markdown_content = markdown_content or ""
         state_to_set = self.get_check_run(state)

--- a/packit_service/worker/reporting/reporters/gitlab.py
+++ b/packit_service/worker/reporting/reporters/gitlab.py
@@ -31,6 +31,7 @@ class StatusReporterGitlab(StatusReporter):
         url: str = "",
         links_to_external_services: Optional[dict[str, str]] = None,
         markdown_content: Optional[str] = None,
+        target_branch: Optional[str] = None,
     ):
         state_to_set = self.get_commit_status(state)
         logger.debug(

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -2608,6 +2608,7 @@ def test_koji_build_end_downstream(
         description="RPM build succeeded.",
         url=url,
         check_name="Packit - scratch build",
+        target_branch=None,
     ).once()
     flexmock(Signature).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").times(2).and_return()


### PR DESCRIPTION
Fixes #2736

Not yet tested on a real packit-service instance (I will test it on stg instace later)

RELEASE NOTES BEGIN

We have fixed a bug for Fedora CI, scratch Koji builds statuses in Pagure are no more overwritten when the same commit is shared between different target branches. 

RELEASE NOTES END
