### PR TITLE
Temporarily re-add httpd dependencies

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -14,6 +14,10 @@
           - python3-click
           - git # setuptools-scm
           - dnf-utils
+          # httpd & deps
+          - python3-mod_wsgi
+          - mod_http2
+          - mod_ssl
           - python3-fastapi
           - python3-gunicorn
           - python3-uvicorn


### PR DESCRIPTION
The FastAPI code is not yet merged, so the deployment is failing without these.

