### PR TITLE
Pass target repo URL according to use_target_repo_for_fmf_url

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -215,7 +215,11 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
     def fmf_url(self) -> str:
         return (
             self.job_config.fmf_url
-            or (self.pull_request_object and self.pull_request_object.source_project.get_web_url())
+            or (
+                self.pull_request_object
+                and not self.job_config.use_target_repo_for_fmf_url
+                and self.pull_request_object.source_project.get_web_url()
+            )
             or self.project.get_web_url()
         )
 


### PR DESCRIPTION
Fixes #2748
Requires https://github.com/packit/packit/pull/2552

TODO:
- [x] tests

RELEASE NOTES BEGIN

It is now possible to set `use_target_repo_for_fmf_url` configuration flag to bypass the default passing of fork URLs for test requests.

RELEASE NOTES END
