### PR TITLE
Reset repo submodules before the next sync_release run

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -330,6 +330,9 @@ class AbstractSyncReleaseHandler(
                     index=True,
                     working_tree=True,
                 )
+                # reset also submodules
+                for submodule in self.packit_api.up.local_project.git_repo.submodules:
+                    submodule.update(init=True, recursive=True, force=True)
 
         return downstream_pr
 

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -193,6 +193,13 @@ def test_issue_comment_propose_downstream_handler(
             .once()
             .mock(),
             git=flexmock(clear_cache=lambda: None),
+            submodules=[
+                flexmock()
+                .should_receive("update")
+                .with_args(init=True, recursive=True, force=True)
+                .once()
+                .mock()
+            ],
         ),
     )
 

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -179,6 +179,13 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
             .once()
             .mock(),
             git=flexmock(clear_cache=lambda: None),
+            submodules=[
+                flexmock()
+                .should_receive("update")
+                .with_args(init=True, recursive=True, force=True)
+                .once()
+                .mock()
+            ],
         ),
     )
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2638,6 +2638,13 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
             .once()
             .mock(),
             git=flexmock(clear_cache=lambda: None),
+            submodules=[
+                flexmock()
+                .should_receive("update")
+                .with_args(init=True, recursive=True, force=True)
+                .once()
+                .mock()
+            ],
         ),
     )
 

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -193,6 +193,13 @@ def test_dist_git_push_release_handle(
             .once()
             .mock(),
             git=flexmock(clear_cache=lambda: None),
+            submodules=[
+                flexmock()
+                .should_receive("update")
+                .with_args(init=True, recursive=True, force=True)
+                .once()
+                .mock()
+            ],
         ),
     )
 
@@ -316,6 +323,13 @@ def test_dist_git_push_release_handle_multiple_branches(
             .times(len(fedora_branches))
             .mock(),
             git=flexmock(clear_cache=lambda: None),
+            submodules=[
+                flexmock()
+                .should_receive("update")
+                .with_args(init=True, recursive=True, force=True)
+                .times(len(fedora_branches))
+                .mock()
+            ],
         ),
     )
 
@@ -460,6 +474,13 @@ def test_dist_git_push_release_handle_one_failed(
             .times(len(fedora_branches))
             .mock(),
             git=flexmock(clear_cache=lambda: None),
+            submodules=[
+                flexmock()
+                .should_receive("update")
+                .with_args(init=True, recursive=True, force=True)
+                .times(len(fedora_branches))
+                .mock()
+            ],
         ),
     )
     flexmock(Allowlist, check_and_report=True)
@@ -653,6 +674,13 @@ def test_dist_git_push_release_handle_all_failed(
             .times(len(fedora_branches))
             .mock(),
             git=flexmock(clear_cache=lambda: None),
+            submodules=[
+                flexmock()
+                .should_receive("update")
+                .with_args(init=True, recursive=True, force=True)
+                .times(len(fedora_branches))
+                .mock()
+            ],
         ),
     )
 
@@ -760,6 +788,13 @@ def test_retry_propose_downstream_task(
             .once()
             .mock(),
             git=flexmock(clear_cache=lambda: None),
+            submodules=[
+                flexmock()
+                .should_receive("update")
+                .with_args(init=True, recursive=True, force=True)
+                .once()
+                .mock()
+            ],
         ),
     )
 
@@ -924,6 +959,13 @@ def test_dont_retry_propose_downstream_task(
             .once()
             .mock(),
             git=flexmock(clear_cache=lambda: None),
+            submodules=[
+                flexmock()
+                .should_receive("update")
+                .with_args(init=True, recursive=True, force=True)
+                .once()
+                .mock()
+            ],
         ),
     )
     flexmock(Context, retries=6)

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -98,6 +98,13 @@ def test_process_message(event, private, enabled_private_namespaces, success):
             .times(1 if success else 0)
             .mock(),
             git=flexmock(clear_cache=lambda: None),
+            submodules=[
+                flexmock()
+                .should_receive("update")
+                .with_args(init=True, recursive=True, force=True)
+                .times(1 if success else 0)
+                .mock()
+            ],
         ),
     )
 


### PR DESCRIPTION
Fixes https://github.com/packit/packit-service/issues/2765.

RELEASE NOTES BEGIN

We have fixed an issue that could cause subsequent runs of `propose_downstream`/`pull_from_upstream` to fail if upstream git repo contains submodules that are manipulated with in actions.

RELEASE NOTES END