### PR TITLE
Implement Fedora CI retriggering

### DIFF
--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -303,6 +303,7 @@ class KojiTaskReportDownstreamHandler(AbstractKojiTaskReportHandler):
             self._helper = FedoraCIHelper(
                 project=self.project,
                 metadata=self.data,
+                target_branch=self.data.event_dict.get("target"),
             )
         return self._helper
 

--- a/packit_service/worker/helpers/fedora_ci.py
+++ b/packit_service/worker/helpers/fedora_ci.py
@@ -19,18 +19,13 @@ class FedoraCIHelper:
         self,
         project: GitProject,
         metadata: EventData,
+        target_branch: str,
     ):
         self.project = project
         self.metadata = metadata
+        self.target_branch = target_branch
 
         self._status_reporter = None
-
-    @property
-    def target_branch(self) -> str:
-        return (
-            self.metadata.event_dict.get("target_branch")  # for pagure.pr.Action
-            or self.metadata.event_dict.get("target")  # for koji.result.Task
-        )
 
     @property
     def status_reporter(self) -> StatusReporter:


### PR DESCRIPTION
Fixes https://github.com/packit/packit-service/issues/2738.

---

Notes:
I think it makes sense to allow only packagers to retrigger CI.
Feel free to suggest better command names than `/packit ci`.

---

RELEASE NOTES BEGIN

It is now possible to retrigger dist-git CI scratch builds with `/packit ci`.

RELEASE NOTES END
