### PR TITLE
Adjust validate-config occurences to the rename

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -366,7 +366,7 @@ class PackageConfigGetter:
                 f"[the documentation]({DOCS_HOW_TO_CONFIGURE_URL}) "
                 "or [contact the Packit team]"
                 f"({CONTACTS_URL}). You can also use "
-                f"our CLI command [`validate-config`]({DOCS_VALIDATE_CONFIG}) or our "
+                f"our CLI command [`config validate`]({DOCS_VALIDATE_CONFIG}) or our "
                 f"[pre-commit hooks]({DOCS_VALIDATE_HOOKS}) for validation of the configuration."
             )
 

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -14,7 +14,7 @@ DOCS_HOW_TO_CONFIGURE_URL = f"{DOCS_URL}/guide/#3-configuration"
 DOCS_APPROVAL_URL = f"{DOCS_URL}/guide/#2-approval"
 DOCS_VM_IMAGE_BUILD = f"{DOCS_URL}/cli/build/in-image-builder/"
 DOCS_TESTING_FARM = f"{DOCS_URL}/configuration/upstream/tests"
-DOCS_VALIDATE_CONFIG = f"{DOCS_URL}/cli/validate-config"
+DOCS_VALIDATE_CONFIG = f"{DOCS_URL}/cli/config/validate"
 DOCS_VALIDATE_HOOKS = "https://packit.dev/posts/pre-commit-hooks#validate-config"
 
 KOJI_PRODUCTION_BUILDS_ISSUE = "https://pagure.io/releng/issue/9801"

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -1670,7 +1670,7 @@ def test_trigger_packit_command_without_config(
         f"[the documentation]({DOCS_HOW_TO_CONFIGURE_URL}) "
         "or [contact the Packit team]"
         f"({CONTACTS_URL}). You can also use "
-        f"our CLI command [`validate-config`]({DOCS_VALIDATE_CONFIG}) or our "
+        f"our CLI command [`config validate`]({DOCS_VALIDATE_CONFIG}) or our "
         f"[pre-commit hooks]({DOCS_VALIDATE_HOOKS}) for validation of the configuration."
     )
     flexmock(pr).should_receive("comment").with_args(err_msg)


### PR DESCRIPTION
The command was renamed from `validate-config` to `config validate` in packit/packit#2559

