### PR TITLE
Process Fedora CI commands correctly

### DIFF
--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -51,6 +51,7 @@ SUPPORTED_EVENTS_FOR_HANDLER_FEDORA_CI: dict[type["JobHandler"], set[type["Event
     set
 )
 MAP_COMMENT_TO_HANDLER: dict[str, set[type["JobHandler"]]] = defaultdict(set)
+MAP_COMMENT_TO_HANDLER_FEDORA_CI: dict[str, set[type["JobHandler"]]] = defaultdict(set)
 MAP_CHECK_PREFIX_TO_HANDLER: dict[str, set[type["JobHandler"]]] = defaultdict(set)
 
 
@@ -157,6 +158,33 @@ def run_for_comment(command: str):
 
     def _add_to_mapping(kls: type["JobHandler"]):
         MAP_COMMENT_TO_HANDLER[command].add(kls)
+        return kls
+
+    return _add_to_mapping
+
+
+def run_for_comment_as_fedora_ci(command: str):
+    """
+    [class decorator]
+    Specify a command for which we want to run a handler as a Fedora CI.
+    e.g. for `/packit-ci command` we need to add `command`
+
+    Multiple decorators are allowed.
+
+    Don't forget to specify valid comment events
+    using @reacts_to_as_fedora_ci decorator.
+
+    Example:
+    ```
+    @run_for_comment(command="scratch-build")
+    @reacts_to_as_fedora_ci(event=pagure.pr.Action)
+    @reacts_to_as_fedora_ci(event=pagure.pr.Comment)
+    class DownstreamKojiScratchBuildHandler(
+    ```
+    """
+
+    def _add_to_mapping(kls: type["JobHandler"]):
+        MAP_COMMENT_TO_HANDLER_FEDORA_CI[command].add(kls)
         return kls
 
     return _add_to_mapping

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -94,6 +94,7 @@ from packit_service.worker.handlers.abstract import (
     reacts_to_as_fedora_ci,
     run_for_check_rerun,
     run_for_comment,
+    run_for_comment_as_fedora_ci,
 )
 from packit_service.worker.handlers.mixin import GetProjectToSyncMixin
 from packit_service.worker.helpers.fedora_ci import FedoraCIHelper
@@ -761,7 +762,7 @@ class PullFromUpstreamHandler(AbstractSyncReleaseHandler):
             return super().run()
 
 
-@run_for_comment(command="scratch-build")
+@run_for_comment_as_fedora_ci(command="scratch-build")
 @reacts_to_as_fedora_ci(event=pagure.pr.Action)
 @reacts_to_as_fedora_ci(event=pagure.pr.Comment)
 class DownstreamKojiScratchBuildHandler(

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2460,7 +2460,7 @@ def test_koji_build_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added):
 def test_downstream_koji_scratch_build_retrigger_via_dist_git_pr_comment(
     pagure_pr_comment_added, target_branch, uid, check_name
 ):
-    pagure_pr_comment_added["pullrequest"]["comments"][0]["comment"] = "/packit scratch-build"
+    pagure_pr_comment_added["pullrequest"]["comments"][0]["comment"] = "/packit-ci scratch-build"
     pagure_pr_comment_added["pullrequest"]["branch"] = target_branch
     pr_object = (
         flexmock(target_branch=target_branch)
@@ -2516,9 +2516,6 @@ def test_downstream_koji_scratch_build_retrigger_via_dist_git_pr_comment(
         .and_return(dg_project)
         .mock()
     )
-    flexmock(pagure.pr.Comment).should_receive(
-        "get_base_project",
-    ).once().and_return(dg_project)
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(service_config)
     flexmock(PackitAPIWithDownstreamMixin).should_receive("is_packager").and_return(
         True,


### PR DESCRIPTION
Fedora CI commands are now handled separately from Packit Service commands and use hardcoded `/packit-ci` and `/packit-ci-stg` prefixes.