### PR TITLE
fix: do not log failed submodule reset as an error

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -338,7 +338,7 @@ class AbstractSyncReleaseHandler(
                     try:
                         submodule.update(init=True, recursive=True, force=True)
                     except Exception as ex:  # noqa: PERF203
-                        logger.error(f"Failed to reset submodule {submodule.name}: {ex}")
+                        logger.warning(f"Failed to reset submodule {submodule.name}: {ex}")
 
         return downstream_pr, additional_prs
 


### PR DESCRIPTION
Do not log failure when resetting the git submodule during sync-release as an error.

Since it gets logged as an error, Sentry takes it as is, and also for each unique submodule, tracks as a separate error.

This should not be an issue, as we have already discussed with @nforro, therefore it should be enough to be logged as warning instead.

Related to packit/agile#804