### PR TITLE
fix(db): fix alembic migration after rebase

### DIFF
--- a/alembic/versions/48b09a73cf77_add_canceled_state_to_buildstatus.py
+++ b/alembic/versions/48b09a73cf77_add_canceled_state_to_buildstatus.py
@@ -1,7 +1,7 @@
 """Add canceled state to BuildStatus
 
 Revision ID: 48b09a73cf77
-Revises: eadd57289c17
+Revises: 16219ebce6cb
 Create Date: 2025-04-23 13:44:56.196348
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "48b09a73cf77"
-down_revision = "eadd57289c17"
+down_revision = "16219ebce6cb"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Correct the ‹down_revision› as I have not noticed that a migration has occurred in the meantime, causing migration to fail after the deployment.