### PR TITLE
Run custom tests on dist-git pull requests

### DIFF
--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -471,5 +471,7 @@ class FedoraCIJobHandler(JobHandler):
     check_name: str = ""
 
     @classmethod
-    def get_check_names(cls, service_config: ServiceConfig, metadata: EventData) -> list[str]:
+    def get_check_names(
+        cls, service_config: ServiceConfig, project: GitProject, metadata: EventData
+    ) -> list[str]:
         return [cls.check_name] if cls.check_name else []

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from celery import Task
+from ogr.abstract import GitProject
 from packit.config import JobConfig, JobType, aliases
 from packit.config.package_config import PackageConfig
 
@@ -383,10 +384,14 @@ class DownstreamTestingFarmHandler(
         )
 
     @classmethod
-    def get_check_names(cls, service_config: ServiceConfig, metadata: EventData) -> list[str]:
+    def get_check_names(
+        cls, service_config: ServiceConfig, project: GitProject, metadata: EventData
+    ) -> list[str]:
         return [
             DownstreamTestingFarmJobHelper.get_check_name(t)
-            for t in DownstreamTestingFarmJobHelper.get_fedora_ci_tests(service_config, metadata)
+            for t in DownstreamTestingFarmJobHelper.get_fedora_ci_tests(
+                service_config, project, metadata
+            )
         ]
 
     def _get_or_create_group(
@@ -455,7 +460,7 @@ class DownstreamTestingFarmHandler(
         failed: dict[str, str] = {}
 
         fedora_ci_tests = self.downstream_testing_farm_job_helper.get_fedora_ci_tests(
-            self.service_config, self.data
+            self.service_config, self.project, self.data
         )
 
         group, test_runs = self._get_or_create_group(fedora_ci_tests)

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -417,7 +417,9 @@ class SteveJobs:
             target_branch=self.event.pull_request_object.target_branch,
         )
 
-        for check_name in handler_kls.get_check_names(self.service_config, metadata):
+        for check_name in handler_kls.get_check_names(
+            self.service_config, self.event.project, metadata
+        ):
             helper.report(
                 description=TASK_ACCEPTED,
                 state=BaseCommitStatus.pending,

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -3300,14 +3300,14 @@ def test_koji_build_tag_via_dist_git_pr_comment(pagure_pr_comment_added, all_bra
     [
         pytest.param(
             "rawhide",
-            "754c2fe7504b1ebb674fb2e8ad25e249",
-            "Packit - installability test - rawhide",
+            "380723461ab74e1cde4eb89b711c8f1d",
+            "Packit - installability test(s) - rawhide",
             id="rawhide target branch",
         ),
         pytest.param(
             "f42",
-            "2b8e260f509e000b733833e465ad13d7",
-            "Packit - installability test - f42",
+            "a478035df5f8599527e3e37bfc2ca25f",
+            "Packit - installability test(s) - f42",
             id="f42 target branch",
         ),
     ],
@@ -3345,6 +3345,9 @@ def test_downstream_testing_farm_retrigger_via_dist_git_pr_comment(
         .mock()
         .should_receive("get_files")
         .and_return([])
+        .mock()
+        .should_receive("get_file_content")
+        .and_raise(FileNotFoundError)
         .mock()
         .should_receive("get_web_url")
         .and_return("URL")

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -297,7 +297,7 @@ def test_downstream_testing_farm_response(
         state=status_status,
         description=status_message,
         url="https://dashboard.localhost/jobs/testing-farm/123",
-        check_name="Packit - installability test",
+        check_name="Packit - installability test(s)",
         target_branch="rawhide",
     ).once()
 


### PR DESCRIPTION
Fixes https://github.com/packit/packit-service/issues/2713.

---

A couple of notes:

- I've set initiator to `packit-fedora-ci` (thanks @mfocko for the suggestion), is that ok, should it be `packit` or `fedora-ci`?
- The check name is `custom test(s)`, the original Fedora CI calls it `dist-git test`, is that ok?

---

RELEASE NOTES BEGIN

Packit now runs custom TMT tests as part of CI on dist-git pull requests.

RELEASE NOTES END
