### PR TITLE
fix: correct the type after introducing TF Client

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1233,7 +1233,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             return
 
         for (test_run,) in running_tests:
-            self.cancel_testing_farm_request(test_run.pipeline_id)
+            self.tft_client.cancel(test_run.pipeline_id)
             test_run.set_status(TestingFarmResult.cancel_requested)
 
 

--- a/packit_service/worker/helpers/testing_farm_client.py
+++ b/packit_service/worker/helpers/testing_farm_client.py
@@ -82,7 +82,7 @@ class TestingFarmClient:
             raise PackitException(f"Cannot connect to url: `{url}`") from err
         return response
 
-    def cancel_testing_farm_request(self, request_id: str) -> bool:
+    def cancel(self, request_id: str) -> bool:
         """
         Cancel TF request with the given ID.
 


### PR DESCRIPTION
Another thing missed from the factoring out of the Testing Farm client. It is now a separate property and not under the helper.

Additionally also shorten the name of the method used for canceling the requests. No need to be so explicit, as long as it's TF client, it's apparent we are canceling TF requests.

Fixes #2793