### PR TITLE
Fix dist-git PR git URL passed to TF

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1477,7 +1477,9 @@ class DownstreamTestingFarmJobHelper:
         return {
             "test": {
                 "tmt": {
-                    "url": self.project.get_pr(self.metadata.pr_id).source_project.get_web_url(),
+                    "url": self.project.get_pr(self.metadata.pr_id)
+                    .source_project.get_git_urls()
+                    .get("git"),
                     "ref": self.metadata.commit_sha,
                 },
             },

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -2598,7 +2598,9 @@ def test_koji_build_end_downstream(
                 get_file_content=lambda path, ref: flexmock(),
                 get_pr=lambda _: flexmock(
                     source_project=flexmock(
-                        get_web_url=lambda: "https://src.fedoraproject.org/fork/packit/rpms/packit"
+                        get_git_urls=lambda: {
+                            "git": "https://src.fedoraproject.org/fork/packit/rpms/packit.git"
+                        }
                     )
                 ),
             )
@@ -2660,7 +2662,7 @@ def test_koji_build_end_downstream(
     payload_custom = {
         "test": {
             "tmt": {
-                "url": "https://src.fedoraproject.org/fork/packit/rpms/packit",
+                "url": "https://src.fedoraproject.org/fork/packit/rpms/packit.git",
                 "ref": "0011223344",
             },
         },


### PR DESCRIPTION
In Pagure a project web URL and git URL are different and web URL can not be used for cloning.

Related to https://github.com/packit/packit-service/issues/2713.