### PR TITLE
Change the initiator for custom dist-git TMT tests

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1498,7 +1498,7 @@ class DownstreamTestingFarmJobHelper:
                             "distro": distro,
                             "arch": "x86_64",
                             "trigger": "commit",
-                            "initiator": "packit-fedora-ci",
+                            "initiator": "fedora-ci",
                         }
                     },
                 },

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -2684,7 +2684,7 @@ def test_koji_build_end_downstream(
                         "distro": "fedora-rawhide",
                         "arch": "x86_64",
                         "trigger": "commit",
-                        "initiator": "packit-fedora-ci",
+                        "initiator": "fedora-ci",
                     },
                 },
             },


### PR DESCRIPTION
To be compatible with the current/old implementation and prevent users from having to adjust their metadata.