### PR TITLE
fix(tf-client): ignore already requested or canceled

### DIFF
--- a/packit_service/worker/helpers/testing_farm_client.py
+++ b/packit_service/worker/helpers/testing_farm_client.py
@@ -103,10 +103,13 @@ class TestingFarmClient:
             endpoint=f"requests/{request_id}",
             method="DELETE",
         )
-        if response.status_code != 200:
+        if response.status_code not in (200, 204):
+            # 200: successful test cancellation
+            # 204: cancellation has already been requested, or even completed
             msg = f"Failed to cancel TF request {request_id}: {response.json()}"
             logger.error(msg)
             return False
+
         return True
 
     @classmethod


### PR DESCRIPTION
As opposed to the original TF API docs

    https://api.testing-farm.io/redoc#operation/delete_test_request_v0_1_requests__request_id__delete

It appears that TF API can also yield `204` when the request has already been requested to be canceled or even canceled altogether:

    https://gitlab.com/testing-farm/nucleus/-/blob/2ceed1a8c64e796bc2c9ee83e7b0221f30eaeaf3/api/src/tft/nucleus/api/middleware/test_request.py#L362-363

Therefore check for the status code being different to 200 (success), or 204 (already done).