### PR TITLE
Don't attempt to cancel builds that are not submitted yet

### DIFF
--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -1034,7 +1034,9 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             return
 
         # Cancel unique builds
-        unique_builds = {int(build.build_id) for (build,) in running_builds}
+        unique_builds = {
+            int(build.build_id) for (build,) in running_builds if build.build_id is not None
+        }
         for build_id in unique_builds:
             logger.debug("Cancelling Copr build #%s", build_id)
             self.api.copr_helper.cancel_build(build_id)


### PR DESCRIPTION
Those don't have their build_id set yet, so we can't do anything about them. Fixes #2806

