### PR TITLE
fix(worker): fetch the host keys from admin.fedoraproject.org

### DIFF
--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -17,7 +17,7 @@ chmod 0700 "${PACKIT_HOME}/.ssh"
 pushd "${PACKIT_HOME}/.ssh"
 install -m 0400 /packit-ssh/id_ed25519* .
 if [[ -f /packit-ssh/config ]]; then install -m 0400 /packit-ssh/config .; fi
-grep -q pkgs.fedoraproject.org known_hosts || curl https://admin.fedoraproject.org/ssh_known_hosts >> known_hosts
+grep -q pkgs.fedoraproject.org known_hosts 2>/dev/null || curl -fsSL https://admin.fedoraproject.org/ssh_known_hosts >> known_hosts
 grep -q gitlab.com known_hosts || ssh-keyscan gitlab.com >> known_hosts
 popd
 

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -17,8 +17,8 @@ chmod 0700 "${PACKIT_HOME}/.ssh"
 pushd "${PACKIT_HOME}/.ssh"
 install -m 0400 /packit-ssh/id_ed25519* .
 if [[ -f /packit-ssh/config ]]; then install -m 0400 /packit-ssh/config .; fi
-grep -q pkgs.fedoraproject.org known_hosts || ssh-keyscan pkgs.fedoraproject.org >>known_hosts
-grep -q gitlab.com known_hosts || ssh-keyscan gitlab.com >>known_hosts
+grep -q pkgs.fedoraproject.org known_hosts || curl https://admin.fedoraproject.org/ssh_known_hosts >> known_hosts
+grep -q gitlab.com known_hosts || ssh-keyscan gitlab.com >> known_hosts
 popd
 
 # Whether to run Celery worker or beat (task scheduler)


### PR DESCRIPTION
As it appears, there is some ongoing issue with `ssh-keyscan` that blocks running this action. The host keys are also present at a specific subpage of admin.fedoraproject.org, so fetch them from there until this issue is resolved.

Also pods trying to retry "bootstrap" can be in issue because of the Fedora's DDoS protection.

I've also considered "baking in" the known hosts, but that could result in issues during the image build.

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->
