### PR TITLE
Do not run CoprBuildHandler in long-running queue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,3 +118,6 @@ repos:
           - LICENSE_HEADER.txt
           - --comment-style
           - "#"
+
+ci:
+  autofix_prs: false

--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -135,7 +135,6 @@ Here is a list of commands to run if you need a local database with real data fr
   `arr-packit-[prod|stg]` S3 bucket
 
 2. Load it into your local postgres instance:
-
    1. Create a database named packit and owned by the packit user: `postgres=# create database packit owner=packit;`
    2. Copy the dump file into the database container: `podman cp ./dump-$ENV-$DATE.sql postgres:/tmp`
       This is a more reliable option than a direct load from your local filesystem.

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -252,7 +252,6 @@ def run_copr_build_end_handler(event: dict, package_config: dict, job_config: di
     bind=True,
     name=TaskName.copr_build,
     base=TaskWithRetry,
-    queue="long-running",
 )
 def run_copr_build_handler(
     self,


### PR DESCRIPTION
This was set in the past when we were building SRPMs as part of this handler (and therefore running user-defined actions)  ourselves and now isn't necessary.