### PR TITLE
perf: share Copr client in periodic babysit run

### DIFF
--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -550,6 +550,9 @@ def test_check_pending_copr_builds_no_builds():
 
 
 def test_check_pending_copr_builds():
+    client = flexmock()
+    flexmock(Client).should_receive("create_from_config_file").and_return(client)
+
     build1 = flexmock(status=BuildStatus.pending, build_id="1")
     build2 = flexmock(status=BuildStatus.pending, build_id="2")
     build3 = flexmock(status=BuildStatus.pending, build_id="1")
@@ -558,10 +561,10 @@ def test_check_pending_copr_builds():
     ).and_return([build1, build2, build3])
     flexmock(packit_service.worker.helpers.build.babysit).should_receive(
         "update_copr_builds",
-    ).with_args(1, [build1, build3]).once()
+    ).with_args(1, [build1, build3], copr_client=client).once()
     flexmock(packit_service.worker.helpers.build.babysit).should_receive(
         "update_copr_builds",
-    ).with_args(2, [build2]).once()
+    ).with_args(2, [build2], copr_client=client).once()
     check_pending_copr_builds()
 
 


### PR DESCRIPTION
Currently each call to ‹update_copr_builds› creates a new instance of ‹CoprClient› from the config file, this involves IO operations (lookup and opening of the config), constructing the client (parsing the config
+ constructing proxy objects where each has its own ‹Requests› instance).

This can slow down the babysit task as a whole. Therefore create one shared ‹CoprClient› instance that can be used for checking all of the pending Copr builds.