### PR TITLE
Revert "Do not run CoprBuildHandler in long-running queue"

### DIFF
--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -248,11 +248,7 @@ def run_copr_build_end_handler(event: dict, package_config: dict, job_config: di
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(
-    bind=True,
-    name=TaskName.copr_build,
-    base=TaskWithRetry,
-)
+@celery_app.task(bind=True, name=TaskName.copr_build, base=TaskWithRetry, queue="long-running")
 def run_copr_build_handler(
     self,
     event: dict,


### PR DESCRIPTION
Reverts commit 9791111bc87c275e3f0aa7f57081adf5c07b448d We have noticed some performance degradation after introducing this, let's see if reverting this helps.
