### PR TITLE
fix(tf): ignore conflicts when cancelling

### DIFF
--- a/packit_service/worker/helpers/testing_farm_client.py
+++ b/packit_service/worker/helpers/testing_farm_client.py
@@ -3,6 +3,7 @@
 
 import logging
 import re
+from http import HTTPStatus
 from re import Pattern
 from typing import Any, Callable, Optional
 
@@ -103,18 +104,20 @@ class TestingFarmClient:
             endpoint=f"requests/{request_id}",
             method="DELETE",
         )
-        if response.status_code not in (200, 204, 409):
-            # 200: successful test cancellation
-            # 204: cancellation has already been requested, or even completed
-            # 409: “conflict”, i.e., the request has already errored out or has
-            #      finished
+        if response.status_code not in (HTTPStatus.OK, HTTPStatus.NO_CONTENT, HTTPStatus.CONFLICT):
+            # OK:
+            #   successful test cancellation
+            # NO_CONTENT:
+            #   cancellation has already been requested, or even completed
+            # CONFLICT:
+            #   the request has already errored out or has finished
             msg = f"Failed to cancel TF request {request_id}: {response.json()}"
             logger.error(msg)
             return False
 
         # [TODO] Reconsider implicit ‹True› instead of checking for status codes
         # Currently we set ‹cancel_requested› in the DB when returning ‹True›,
-        # but it does not conform very well with suppressed 409 (which is
+        # but it does not conform very well with suppressed CONFLICT (which is
         # returned when the test run has already errored out or has finished),
         # but it should be overriden by the webhook with test results from the
         # Testing Farm.


### PR DESCRIPTION
Do not log an error and and unsuccessful cancelling of the TF request when the job has already failed or finished successfully.

Fixes #2830