### PR TITLE
Properly transform ELN chroots to compose

### DIFF
--- a/packit_service/worker/helpers/testing_farm_client.py
+++ b/packit_service/worker/helpers/testing_farm_client.py
@@ -231,6 +231,7 @@ class TestingFarmClient:
             .replace("Rhel", "RHEL")
             .replace("Oraclelinux", "Oracle-Linux")
             .replace("Latest", "latest")
+            .replace("Eln", "eln")
         )
         if compose == "CentOS-Stream":
             compose = "CentOS-Stream-8"


### PR DESCRIPTION
The right compose name is `Fedora-eln`.