### PR TITLE
Notify users when command's label or identifier mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ secrets
 *.egg-info
 .mypy_cache/
 /build/
+node_modules

--- a/packit_service/worker/checker/abstract.py
+++ b/packit_service/worker/checker/abstract.py
@@ -29,9 +29,27 @@ class Checker(ConfigFromEventMixin, PackitAPIWithDownstreamMixin):
         self.job_config = job_config
         self.data = EventData.from_event_dict(event)
         self.task_name = task_name
+        self._mismatch_data: Optional[dict] = None
 
     @abstractmethod
     def pre_check(self) -> bool: ...
+
+    def get_failure_message(self) -> Optional[dict]:
+        """
+        Get the failure message/mismatch data if the check failed.
+        This is used to aggregate failure messages into a single comment.
+
+        Returns:
+            Failure message/mismatch data if check failed, None otherwise.
+            Dict with structured data:
+            {
+                "type": str, # type of the matcher failure
+                "job_value": str | list[str],  # job's identifier or labels
+                "comment_value": str | list[str],  # what was specified in command
+                "targets": list[str],  # all targets for this job
+            }
+        """
+        return self._mismatch_data
 
 
 class ActorChecker(Checker):

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -332,7 +332,7 @@ def test_downstream_koji_build(sidetag_group):
         flexmock(grouped_targets=[koji_build]),
     )
 
-    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True)
+    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True, [])
 
     flexmock(LocalProjectBuilder, _refresh_the_state=lambda *args: None)
     flexmock(group).should_receive("apply_async").once()
@@ -433,7 +433,7 @@ def test_downstream_koji_build_failure_no_issue():
         flexmock(id=1, grouped_targets=[koji_build]),
     )
 
-    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True)
+    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True, [])
 
     flexmock(Pushgateway).should_receive("push").times(1).and_return()
     flexmock(LocalProjectBuilder, _refresh_the_state=lambda *args: None)
@@ -531,7 +531,7 @@ def test_downstream_koji_build_failure_issue_created():
 
     flexmock(DistGit).should_receive("get_nvr").and_return(nvr)
 
-    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True)
+    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True, [])
 
     flexmock(KojiBuildTargetModel).should_receive("create").and_return(koji_build)
     flexmock(KojiBuildTargetModel).should_receive(
@@ -651,7 +651,7 @@ def test_downstream_koji_build_failure_issue_comment():
         flexmock(grouped_targets=[koji_build]),
     )
 
-    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True)
+    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True, [])
 
     flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(LocalProjectBuilder, _refresh_the_state=lambda *args: None)
@@ -836,7 +836,7 @@ def test_downstream_koji_build_where_multiple_branches_defined(jobs_config):
 
     flexmock(DistGit).should_receive("get_nvr").and_return(nvr)
 
-    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True)
+    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True, [])
 
     flexmock(KojiBuildTargetModel).should_receive("create").and_return(koji_build)
     flexmock(KojiBuildTargetModel).should_receive(
@@ -1025,7 +1025,8 @@ def test_precheck_koji_build_push(
     )
     job_config = jobs[0]
     event = distgit_push_event.get_dict()
-    assert DownstreamKojiBuildHandler.pre_check(package_config, job_config, event) == should_pass
+    checks_pass, _ = DownstreamKojiBuildHandler.pre_check(package_config, job_config, event)
+    assert checks_pass == should_pass
 
 
 @pytest.mark.parametrize(
@@ -1102,4 +1103,5 @@ def test_precheck_koji_build_push_pr(
     )
     job_config = jobs[0]
     event = distgit_push_event.get_dict()
-    assert DownstreamKojiBuildHandler.pre_check(package_config, job_config, event) == should_pass
+    checks_pass, _ = DownstreamKojiBuildHandler.pre_check(package_config, job_config, event)
+    assert checks_pass == should_pass

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -126,7 +126,8 @@ def test_precheck(github_pr_event):
     flexmock(CoprBuildJobHelper).should_receive(
         "is_custom_copr_project_defined",
     ).and_return(False).once()
-    assert CoprBuildHandler.pre_check(package_config, job_config, event)
+    checks_pass, _ = CoprBuildHandler.pre_check(package_config, job_config, event)
+    assert checks_pass
 
 
 def test_precheck_gitlab(gitlab_mr_event):
@@ -180,7 +181,8 @@ def test_precheck_gitlab(gitlab_mr_event):
     flexmock(CoprBuildJobHelper).should_receive(
         "is_custom_copr_project_defined",
     ).and_return(False).once()
-    assert CoprBuildHandler.pre_check(package_config, job_config, event)
+    checks_pass, _ = CoprBuildHandler.pre_check(package_config, job_config, event)
+    assert checks_pass
 
 
 def test_precheck_push(github_push_event):
@@ -279,7 +281,8 @@ def test_precheck_push_to_a_different_branch(github_push_event):
         },
     )
     event = github_push_event.get_dict()
-    assert not CoprBuildHandler.pre_check(package_config, job_config, event)
+    checks_pass, _ = CoprBuildHandler.pre_check(package_config, job_config, event)
+    assert not checks_pass
 
 
 def test_precheck_push_actor_check(github_push_event):
@@ -370,4 +373,5 @@ def test_precheck_koji_build_non_scratch(github_pr_event):
         },
     )
     event = github_pr_event.get_dict()
-    assert not KojiBuildHandler.pre_check(package_config, job_config, event)
+    checks_pass, _ = KojiBuildHandler.pre_check(package_config, job_config, event)
+    assert not checks_pass

--- a/tests/integration/test_koji_build.py
+++ b/tests/integration/test_koji_build.py
@@ -183,7 +183,7 @@ def test_koji_build_error_msg(distgit_push_packit):
         flexmock(grouped_targets=[koji_build]),
     )
 
-    flexmock(DownstreamKojiBuildHandler).should_receive("pre_check").and_return(True)
+    flexmock(DownstreamKojiBuildHandler).should_receive("pre_check").and_return((True, []))
     flexmock(Pushgateway).should_receive("push").times(2).and_return()
     flexmock(group).should_receive("apply_async").once()
 

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -2996,8 +2996,8 @@ def test_koji_build_tag(
         "get_package_config_from_repo",
     ).and_return(pc_koji_build_tag_specfile).and_return(pc_koji_build_tag_packit)
 
-    flexmock(DownstreamKojiBuildHandler).should_receive("pre_check").and_return(True)
-    flexmock(BodhiUpdateFromSidetagHandler).should_receive("pre_check").and_return(True)
+    flexmock(DownstreamKojiBuildHandler).should_receive("pre_check").and_return((True, []))
+    flexmock(BodhiUpdateFromSidetagHandler).should_receive("pre_check").and_return((True, []))
 
     flexmock(Signature).should_receive("apply_async").twice()
     flexmock(celery_group).should_receive("apply_async").once()

--- a/tests/unit/test_checkers.py
+++ b/tests/unit/test_checkers.py
@@ -561,7 +561,10 @@ def test_tf_comment_identifier(comment, result):
         pr_id=1,
     )
     flexmock(EventData).should_receive("db_project_event").and_return(
-        flexmock().should_receive("get_project_event_object").and_return(db_project_object).mock(),
+        flexmock(id=1)
+        .should_receive("get_project_event_object")
+        .and_return(db_project_object)
+        .mock(),
     )
 
     checker = IsIdentifierFromCommentMatching(
@@ -654,7 +657,10 @@ def test_tf_comment_default_identifier(
         pr_id=1,
     )
     flexmock(EventData).should_receive("db_project_event").and_return(
-        flexmock().should_receive("get_project_event_object").and_return(db_project_object).mock(),
+        flexmock(id=1)
+        .should_receive("get_project_event_object")
+        .and_return(db_project_object)
+        .mock(),
     )
 
     checker = IsIdentifierFromCommentMatching(
@@ -662,6 +668,7 @@ def test_tf_comment_default_identifier(
         job_config=job_config,
         event=event,
     )
+
     assert checker.pre_check() == result
 
 
@@ -719,7 +726,10 @@ def test_tf_comment_labels(comment, result):
         pr_id=1,
     )
     flexmock(EventData).should_receive("db_project_event").and_return(
-        flexmock().should_receive("get_project_event_object").and_return(db_project_object).mock(),
+        flexmock(id=1)
+        .should_receive("get_project_event_object")
+        .and_return(db_project_object)
+        .mock(),
     )
 
     checker = IsLabelFromCommentMatching(
@@ -808,7 +818,10 @@ def test_tf_comment_default_labels(comment, default_labels, job_labels, result):
         pr_id=1,
     )
     flexmock(EventData).should_receive("db_project_event").and_return(
-        flexmock().should_receive("get_project_event_object").and_return(db_project_object).mock(),
+        flexmock(id=1)
+        .should_receive("get_project_event_object")
+        .and_return(db_project_object)
+        .mock(),
     )
 
     checker = IsLabelFromCommentMatching(
@@ -871,7 +884,10 @@ def test_tf_comment_labels_none_in_config(comment, result):
         pr_id=1,
     )
     flexmock(EventData).should_receive("db_project_event").and_return(
-        flexmock().should_receive("get_project_event_object").and_return(db_project_object).mock(),
+        flexmock(id=1)
+        .should_receive("get_project_event_object")
+        .and_return(db_project_object)
+        .mock(),
     )
 
     checker = IsLabelFromCommentMatching(

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -1021,16 +1021,14 @@ def test_check_if_actor_can_run_job_and_report(jobs, should_pass):
     if not should_pass:
         flexmock(CoprBuildJobHelper).should_receive("report_status_to_build").once()
 
-    assert (
-        CoprBuildHandler.pre_check(
-            package_config,
-            jobs[0],
-            {
-                "event_type": "github.pr.Action",
-                "actor": "actor",
-                "project_url": "url",
-                "commit_sha": "abcdef",
-            },
-        )
-        == should_pass
+    checks_pass, _ = CoprBuildHandler.pre_check(
+        package_config,
+        jobs[0],
+        {
+            "event_type": "github.pr.Action",
+            "actor": "actor",
+            "project_url": "url",
+            "commit_sha": "abcdef",
+        },
     )
+    assert checks_pass == should_pass

--- a/tests/unit/test_distgit.py
+++ b/tests/unit/test_distgit.py
@@ -106,12 +106,12 @@ def test_retrigger_downstream_koji_build_pre_check(user_groups, data, check_pass
 
     flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True)
 
-    result = DownstreamKojiBuildHandler.pre_check(
+    checks_pass, _ = DownstreamKojiBuildHandler.pre_check(
         None,
         flexmock(issue_repository=flexmock()),
         data_dict,
     )
-    assert result == check_passed
+    assert checks_pass == check_passed
 
 
 def test_downstream_handler_init_order():

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -3451,7 +3451,7 @@ def test_create_tasks_tf_identifier(
     ).and_return(flexmock().should_receive("apply_async").mock())
     statuses_check_feedback = flexmock()
     assert tasks_created == len(
-        SteveJobs(event).create_tasks(jobs, handler_kls, statuses_check_feedback),
+        SteveJobs(event).create_tasks(jobs, handler_kls, statuses_check_feedback)[0],
     )
 
 
@@ -3607,7 +3607,8 @@ def test_invalid_packit_deployment():
     job_config = flexmock(packit_instances=["dev", "stg"])
 
     # handler class doesn't matter in this case
-    assert not jobs.should_task_be_created_for_job_config_and_handler(job_config, None)
+    checks_pass, _ = jobs.should_task_be_created_for_job_config_and_handler(job_config, None)
+    assert not checks_pass
 
 
 def test_unapproved_jobs():

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -2197,7 +2197,8 @@ def test_check_if_actor_can_run_job_and_report(jobs, event, should_pass):
 
     event.update({"actor": "actor", "project_url": "url"})
 
-    assert TestingFarmHandler.pre_check(package_config, jobs[0], event) == should_pass
+    checks_pass, _ = TestingFarmHandler.pre_check(package_config, jobs[0], event)
+    assert checks_pass == should_pass
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

<!-- notes for reviewers -->

This PR adds a functionality to notify users when labels or identifier doesn't match with any defined packit job.

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes https://github.com/packit/packit-service/issues/2864

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now notify users when there is a mismatch in trigger command's label/identifier and existing jobs.

RELEASE NOTES END
