### PR TITLE
Upgrade gitleaks to version 8.29.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
         files: /tests_openshift.*\.yaml$
         stages: [manual, pre-push]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.23.1
+    rev: v8.29.0
     hooks:
       - id: gitleaks
         # The hook runs 'gitleaks protect --staged' which parses output of


### PR DESCRIPTION
Updated gitleaks version from v8.23.1 to v8.29.0

This will resolve the issue causing  `panic: wasm error: invalid table access` as well as other issues that were resolved in the versions released since v8.23.1

Fixes

https://github.com/gitleaks/gitleaks/issues/1751
