### PR TITLE
Select compose command depending on environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ COV_REPORT ?= --cov=packit_service --cov-report=term-missing
 COLOR ?= yes
 SOURCE_BRANCH ?= $(shell git branch --show-current)
 CONTAINER_RUN_INTERACTIVE ?= -it
-COMPOSE ?= docker-compose
+COMPOSE ?= $(if $(shell command -v podman-compose 2>/dev/null),podman-compose,docker-compose)
 MY_ID ?= `id -u`
 
 service: files/install-deps.yaml files/recipe.yaml


### PR DESCRIPTION
The `COMPOSE` var is no longer hardcoded to `docker-compose`. Now it will be set to `podman-compose` preferentially, if one is available on the system.

The same approach is used in Log Detective. https://github.com/fedora-copr/logdetective/blob/main/Makefile#L4 

RELEASE NOTES BEGIN

Dynamically select command for compose when using Makefile.

RELEASE NOTES END
