### PR TITLE
Setting name of ProjectEventModelType to projecteventtype

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1610,7 +1610,7 @@ class ProjectEventModel(Base):
 
     __tablename__ = "project_events"
     id = Column(Integer, primary_key=True)  # our database PK
-    type = Column(Enum(ProjectEventModelType))
+    type = Column(Enum(ProjectEventModelType, name="projecteventtype"))
     event_id = Column(Integer, index=True)
     commit_sha = Column(String, index=True)
     packages_config = Column(JSON)


### PR DESCRIPTION
This is my second attempt to resolve the schema discrepancy after ill fated https://github.com/packit/packit-service/pull/2874. 

When attempting to generate new alembic revision, even from a 'clean' state, the change of projecteventtype to projecteventmodeltype is picked up. It appears that when the change to enum name was originally introduced, the schema was not updated.

This is a problem. Because when someone else tries to make changes to the schema, this discrepancy between expected and actual state is picked up and included as part of the revision. Leaving only two options, include an unrelated change, and compromise the PR. Or remove it manually from the patch, thus kicking that can down the road.

To make things worse. The #2874 has proven that if this change is applied, the staging instance suffers from:
`sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedObject) type "projecteventmodeltype" does not exist`.

This is especially odd, since the type is defined. But more importantly, it eliminates the first option of dealing with the issue.

So this is my second attempt at workaround. Instead of applying revision generated by alembic, avoid it entirely, by changing name of the enum, to what it previously was, and what it likely still is in the database. With this change, alembic no longer picks up anything, and revisions are generated empty. Signifying that the expected and actual state of the schema match. Database tests are also passing.

Unfortunately. It is impossible to determine how will this change behave in the staging instance. It may be, that the database there has diverged further from the expected schema. 

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related https://github.com/packit/packit-service/pull/2874 

<!-- release notes footer -->

RELEASE NOTES BEGIN

The data type of the `type` column in the `project_events` table now has a name `projecteventtype` matching the schema expectations and eliminating the need for further revisions.

RELEASE NOTES END
