### PR TITLE
Event parsing of Log Detective results

### DIFF
--- a/packit_service/events/__init__.py
+++ b/packit_service/events/__init__.py
@@ -10,6 +10,7 @@ from . import (
     github,
     gitlab,
     koji,
+    logdetective,
     openscanhub,
     pagure,
     testing_farm,
@@ -29,4 +30,5 @@ __all__ = [
     event.__name__,
     testing_farm.__name__,
     vm_image.__name__,
+    logdetective.__name__,
 ]

--- a/packit_service/events/logdetective.py
+++ b/packit_service/events/logdetective.py
@@ -1,0 +1,46 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+from typing import Optional
+
+from packit_service.models import (
+    LogDetectiveBuildSystem,
+    LogDetectiveResult,
+)
+
+from .abstract.base import Result as AbstractResult
+
+logger = logging.getLogger(__name__)
+
+
+class Result(AbstractResult):
+    """Result of Log Detective analysis"""
+
+    @classmethod
+    def event_type(cls) -> str:
+        return "logdetective.result"
+
+    def __init__(
+        self,
+        target_build: str,
+        log_detective_response: dict,
+        status: LogDetectiveResult,
+        build_system: LogDetectiveBuildSystem,
+        identifier: str,
+    ):
+        super().__init__()
+        self.target_build = target_build
+        self.log_detective_response = log_detective_response
+        self.status = status
+        self.build_system = build_system
+        self.identifier = identifier
+
+    def get_dict(self, default_dict: Optional[dict] = None) -> dict:
+        """Return Log Detective result as a dictionary,
+        serializable as json."""
+        result = super().get_dict()
+        result["status"] = self.status.value
+        result["build_system"] = self.build_system.value
+
+        return result

--- a/tests/data/fedmsg/logdetective_analysis_result.json
+++ b/tests/data/fedmsg/logdetective_analysis_result.json
@@ -1,42 +1,32 @@
 {
-  "body": {
-    "log_detective_response": {
-      "explanation": {
-        "text": "The RPM build failed due to a test setup failure and a specific test case \"XXXX\" failing.\nThe overall result of the build process was also reported as FAIL.\nTo resolve this, investigate the test setup environment and the failing test case to identify the root cause.",
-        "logprobs": null
-      },
-      "response_certainty": 0.0,
-      "snippets": [
-        {
-          "explanation": {
-            "text": "The snippet indicates uncertainty about an event that occured during the build.",
-            "relevance": 95
-          },
-          "text": "What happened?",
-          "line_number": 0
-        },
-        {
-          "explanation": {
-            "text": "The log snippet indicates a generic failure during an RPM build process. The message 'Failure!' suggests that a command or script executed during the build returned a non-zero exit code, halting the process.",
-            "relevance": 95
-          },
-          "text": "Failure!",
-          "line_number": 0
-        }
-      ]
+  "log_detective_response": {
+    "explanation": {
+      "text": "The RPM build failed due to a test setup failure and a specific test case \"XXXX\" failing.\nThe overall result of the build process was also reported as FAIL.\nTo resolve this, investigate the test setup environment and the failing test case to identify the root cause.",
+      "logprobs": null
     },
-    "target_build": "9999",
-    "build_system": "koji",
-    "result": "complete"
+    "response_certainty": 0.0,
+    "snippets": [
+      {
+        "explanation": {
+          "text": "The snippet indicates uncertainty about an event that occured during the build.",
+          "relevance": 95
+        },
+        "text": "What happened?",
+        "line_number": 0
+      },
+      {
+        "explanation": {
+          "text": "The log snippet indicates a generic failure during an RPM build process. The message 'Failure!' suggests that a command or script executed during the build returned a non-zero exit code, halting the process.",
+          "relevance": 95
+        },
+        "text": "Failure!",
+        "line_number": 0
+      }
+    ]
   },
-  "headers": {
-    "fedora_messaging_schema": "base.message",
-    "fedora_messaging_severity": 20,
-    "priority": 0,
-    "sent-at": "2025-11-29T00:00:00+00:00"
-  },
-  "id": "197dc06b-3ae6-435a-93dc-baad4e39cda2",
-  "priority": 0,
-  "queue": null,
-  "topic": "org.fedoraproject.prod.logdetective.analysis"
+  "target_build": "9999",
+  "build_system": "koji",
+  "result": "complete",
+  "topic": "org.fedoraproject.prod.logdetective.analysis",
+  "log_detective_analysis_id": "4f2fa9aa-8fe6-4325-a317-473ca180e75d"
 }

--- a/tests/data/fedmsg/logdetective_analysis_result_error.json
+++ b/tests/data/fedmsg/logdetective_analysis_result_error.json
@@ -1,17 +1,7 @@
 {
-  "body": {
-    "target_build": "9999",
-    "build_system": "koji",
-    "result": "error"
-  },
-  "headers": {
-    "fedora_messaging_schema": "base.message",
-    "fedora_messaging_severity": 20,
-    "priority": 0,
-    "sent-at": "2025-11-29T00:00:00+00:00"
-  },
-  "id": "197dc06b-3ae6-435a-93dc-baad4e39cda2",
-  "priority": 0,
-  "queue": null,
-  "topic": "org.fedoraproject.prod.logdetective.analysis"
+  "target_build": "9999",
+  "build_system": "koji",
+  "result": "error",
+  "topic": "org.fedoraproject.prod.logdetective.analysis",
+  "log_detective_analysis_id": "4f2fa9aa-8fe6-4325-a317-473ca180e75d"
 }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,6 +7,7 @@ from flexmock import flexmock
 from packit.config.aliases import Distro
 from packit.config.job_config import JobConfigTriggerType, JobType
 
+from packit_service.events.logdetective import Result as LogDetectiveResultEvent
 from packit_service.models import (
     ProjectEventModel,
     ProjectEventModelType,
@@ -145,3 +146,8 @@ def add_pull_request_event_with_sha_528b80():
         commit_sha="528b803be6f93e19ca4130bf4976f2800a3004c4",
     ).and_return(db_project_object)
     yield db_project_object, db_project_event
+
+
+@pytest.fixture
+def log_detective_result_event_creation():
+    flexmock(LogDetectiveResultEvent).should_receive("db_project_object").and_return(None)

--- a/tests/unit/events/test_logdective.py
+++ b/tests/unit/events/test_logdective.py
@@ -1,0 +1,70 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import json
+
+import pytest
+
+from packit_service.events.logdetective import Result as LogDetectiveResultEvent
+from packit_service.models import LogDetectiveBuildSystem, LogDetectiveResult
+from packit_service.worker.parser import Parser
+
+
+def test_logdetective_result_event_type():
+    """Test event type return value"""
+
+    assert LogDetectiveResultEvent.event_type() == "logdetective.result"
+
+
+@pytest.mark.parametrize("result", [e.value for e in LogDetectiveResult])
+@pytest.mark.parametrize("build_system", [e.value for e in LogDetectiveBuildSystem])
+def test_parse_logdetective_analysis_result(
+    logdetective_analysis_result, log_detective_result_event_creation, build_system, result
+):
+    """Test standard message from Log Detective with all combinations of build systems
+    and result states"""
+
+    logdetective_analysis_result["build_system"] = build_system
+    logdetective_analysis_result["result"] = result
+
+    event_object = Parser.parse_event(logdetective_analysis_result)
+
+    assert isinstance(event_object, LogDetectiveResultEvent)
+    assert isinstance(event_object.log_detective_response, dict)
+    assert event_object.target_build == "9999"
+    assert event_object.status == result
+    assert event_object.build_system == LogDetectiveBuildSystem(build_system)
+
+    # Attempt to serialize dictionary form of the object
+    object_dict = event_object.get_dict()
+    json.dumps(object_dict)
+
+
+@pytest.mark.parametrize("build_system", [e.value for e in LogDetectiveBuildSystem])
+def test_parse_logdetective_analysis_result_error(
+    logdetective_analysis_result_error, log_detective_result_event_creation, build_system
+):
+    """When analysis returns `error` result, the `log_detective_response`
+    is left empty."""
+
+    logdetective_analysis_result_error["build_system"] = build_system
+    event_object = Parser.parse_event(logdetective_analysis_result_error)
+
+    assert isinstance(event_object, LogDetectiveResultEvent)
+    assert event_object.log_detective_response is None
+    assert event_object.target_build == "9999"
+    assert event_object.status == "error"
+    assert event_object.build_system == LogDetectiveBuildSystem(build_system)
+
+    # Attempt to serialize dictionary form of the object
+    object_dict = event_object.get_dict()
+    json.dumps(object_dict)
+
+
+def test_parse_logdetective_analysis_result_wrong_build_system(logdetective_analysis_result):
+    """Test that results from unsupported build systems are discarded"""
+
+    logdetective_analysis_result["build_system"] = "unsupported_build_system"
+    event_object = Parser.parse_event(logdetective_analysis_result)
+
+    assert event_object is None


### PR DESCRIPTION
This is another piece of the Log Detective integration puzzle. Information about state of requested Log Detective analysis will be posted on fedora message bus, under `logdetective.analysis` topic.

RELEASE NOTES BEGIN

Messages of Fedora Message Bus with `logdetective.analysis` topic, with information about states of Log Detective analysis for builds, are now handled.
 
RELEASE NOTES END
