### PR TITLE
Provide dashboard URL when submitting tests

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -784,6 +784,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             state=BaseCommitStatus.running,
             description=f"{'Build succeeded. ' if not self.skip_build else ''}"
             f"Submitting the tests ...",
+            url=get_testing_farm_info_url(test_run.id),
             target=test_run.target,
         )
 
@@ -1373,6 +1374,7 @@ class DownstreamTestingFarmJobHelper:
             test_run=test_run,
             state=BaseCommitStatus.running,
             description="Submitting the tests ...",
+            url=get_testing_farm_info_url(test_run.id),
         )
 
         return self.prepare_and_send_tf_request(test_run)

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -48,6 +48,7 @@ from packit_service.service.urls import (
     get_copr_build_info_url,
     get_koji_build_info_url,
     get_srpm_build_info_url,
+    get_testing_farm_info_url,
 )
 from packit_service.worker.handlers import CoprBuildEndHandler
 from packit_service.worker.handlers.bodhi import BodhiUpdateFromSidetagHandler
@@ -745,7 +746,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         state=BaseCommitStatus.running,
         description="Build succeeded. Submitting the tests ...",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
-        url="",
+        url=get_testing_farm_info_url(5),
         markdown_content=None,
         links_to_external_services=None,
         update_feedback_time=object,
@@ -2008,6 +2009,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
 
     test = (
         flexmock(
+            id=1,
             status=TestingFarmResult.new,
             copr_builds=[copr_build_pr],
             target="fedora-rawhide-x86_64",
@@ -2044,7 +2046,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         state=BaseCommitStatus.running,
         description="Build succeeded. Submitting the tests ...",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
-        url="",
+        url=get_testing_farm_info_url(1),
         markdown_content=None,
         links_to_external_services=None,
         update_feedback_time=object,
@@ -2199,6 +2201,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
 
     test = (
         flexmock(
+            id=1,
             status=TestingFarmResult.new,
             copr_builds=[copr_build_pr],
             target="fedora-rawhide-x86_64",
@@ -2236,7 +2239,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         state=BaseCommitStatus.running,
         description="Build succeeded. Submitting the tests ...",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
-        url="",
+        url=get_testing_farm_info_url(1),
         markdown_content=None,
         links_to_external_services=None,
         update_feedback_time=object,
@@ -2936,7 +2939,7 @@ def test_koji_build_end_downstream(
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Submitting the tests ...",
-        url="",
+        url="https://dashboard.localhost/jobs/testing-farm/5",
         check_name="Packit - installability test(s)",
         target_branch="rawhide",
     ).once()
@@ -2950,7 +2953,7 @@ def test_koji_build_end_downstream(
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Submitting the tests ...",
-        url="",
+        url="https://dashboard.localhost/jobs/testing-farm/6",
         check_name="Packit - custom test(s)",
         target_branch="rawhide",
     ).once()
@@ -2964,7 +2967,7 @@ def test_koji_build_end_downstream(
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Submitting the tests ...",
-        url="",
+        url="https://dashboard.localhost/jobs/testing-farm/7",
         check_name="Packit - rpminspect test(s)",
         target_branch="rawhide",
     ).once()
@@ -2978,7 +2981,7 @@ def test_koji_build_end_downstream(
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=BaseCommitStatus.running,
         description="Submitting the tests ...",
-        url="",
+        url="https://dashboard.localhost/jobs/testing-farm/8",
         check_name="Packit - rpmlint test(s)",
         target_branch="rawhide",
     ).once()

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -67,6 +67,7 @@ from packit_service.models import (
     TFTTestRunTargetModel,
 )
 from packit_service.service.db_project_events import AddPullRequestEventToDb
+from packit_service.service.urls import get_testing_farm_info_url
 from packit_service.utils import (
     get_packit_commands_from_comment,
 )
@@ -920,6 +921,7 @@ def test_pr_test_command_handler_retries(
         "https://api.dev.testing-farm.io/v0.1/"
     )
     ServiceConfig.get_service_config().testing_farm_secret = "secret-token"
+    urls.DASHBOARD_URL = "https://dashboard.localhost"
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Allowlist, check_and_report=True)
@@ -1004,7 +1006,7 @@ def test_pr_test_command_handler_retries(
         state=BaseCommitStatus.running,
         description="Submitting the tests ...",
         check_name="testing-farm:fedora-rawhide-x86_64",
-        url="",
+        url=get_testing_farm_info_url(1),
         markdown_content=None,
         links_to_external_services=None,
     ).once()
@@ -1036,11 +1038,11 @@ def test_pr_test_command_handler_retries(
     if retry_number == 2:
         flexmock(test_run).should_receive("set_status").with_args(
             TestingFarmResult.error,
-        )
+        ).once()
     else:
         flexmock(test_run).should_receive("set_status").with_args(
             TestingFarmResult.retry,
-        )
+        ).once()
 
     flexmock(StatusReporterGithubChecks).should_receive("set_status").with_args(
         state=status,
@@ -1209,7 +1211,7 @@ def test_pr_test_command_handler_skip_build_option(
         state=BaseCommitStatus.running,
         description="Submitting the tests ...",
         check_names="testing-farm:fedora-rawhide-x86_64",
-        url="",
+        url=get_testing_farm_info_url(5),
         markdown_content=None,
         links_to_external_services=None,
         update_feedback_time=object,
@@ -1354,7 +1356,7 @@ def test_pr_test_command_handler_compose_not_present(
         state=BaseCommitStatus.running,
         description="Submitting the tests ...",
         check_names="testing-farm:fedora-rawhide-x86_64",
-        url="",
+        url=get_testing_farm_info_url(1),
         markdown_content=None,
         links_to_external_services=None,
         update_feedback_time=object,
@@ -1482,7 +1484,7 @@ def test_pr_test_command_handler_composes_not_available(
         state=BaseCommitStatus.running,
         description="Submitting the tests ...",
         check_names="testing-farm:fedora-rawhide-x86_64",
-        url="",
+        url=get_testing_farm_info_url(1),
         markdown_content=None,
         links_to_external_services=None,
         update_feedback_time=object,
@@ -1912,7 +1914,7 @@ def test_pr_test_command_handler_skip_build_option_no_fmf_metadata(
         state=BaseCommitStatus.running,
         description="Submitting the tests ...",
         check_names="testing-farm:fedora-rawhide-x86_64",
-        url="",
+        url=get_testing_farm_info_url(1),
         markdown_content=None,
         links_to_external_services=None,
         update_feedback_time=object,
@@ -2192,7 +2194,7 @@ def test_pr_test_command_handler_multiple_builds(
         state=BaseCommitStatus.running,
         description="Build succeeded. Submitting the tests ...",
         check_names="testing-farm:fedora-rawhide-x86_64",
-        url="",
+        url=get_testing_farm_info_url(5),
         markdown_content=None,
         links_to_external_services=None,
         update_feedback_time=object,


### PR DESCRIPTION
Related to https://github.com/packit/packit/issues/2668

RELEASE NOTES BEGIN

When submitting the tests, we are now providing the URL to the dashboard test job (this should result in better UX especially for GitLab integration).

RELEASE NOTES END
