### PR TITLE
Support Github auto-format for retriggering with other PR

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -134,11 +134,21 @@ class CommentArguments:
 
     def parse_unknown_arguments(self, unknown_args: list[str]) -> None:
         # Process unknown_args to find pr_argument
+        # Supports these formats:
+        # - namespace/repo#<pr_id>
+        # - https://github.com/namespace/repo/pull/<pr_id> (GitHub auto-converts the above to this)
         pr_argument_pattern = re.compile(r"^[^/\s]+/[^#\s]+#\d+$")
+        github_url_pattern = re.compile(r"^https://github\.com/([^/\s]+)/([^/\s]+)/pull/(\d+)$")
         for arg in unknown_args:
             if pr_argument_pattern.match(arg):
                 self.pr_argument = arg
                 logger.debug(f"Parsed pr_argument: {self.pr_argument}")
+                break
+            if match := github_url_pattern.match(arg):
+                # Convert GitHub URL format back to namespace/repo#pr_id format
+                namespace, repo, pr_id = match.groups()
+                self.pr_argument = f"{namespace}/{repo}#{pr_id}"
+                logger.debug(f"Parsed pr_argument from GitHub URL: {arg} -> {self.pr_argument}")
                 break
 
 

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -2288,6 +2288,28 @@ def test_is_supported_architecture(target, use_internal_tf, supported):
             "namespace-2/repo-2#36",
             {"IP_FAMILY": "ipv6", "INSTALL_TYPE": ""},
         ),
+        # Test GitHub URL format (auto-converted by GitHub)
+        (
+            "/packit-dev test https://github.com/kontura/librepo/pull/4",
+            None,
+            None,
+            "kontura/librepo#4",
+            None,
+        ),
+        (
+            "/packit-dev test https://github.com/namespace-3/repo-3/pull/42 --identifier my-id-3",
+            "my-id-3",
+            None,
+            "namespace-3/repo-3#42",
+            None,
+        ),
+        (
+            "/packit-dev test --labels label1,label2 https://github.com/namespace-4/repo-4/pull/99",
+            None,
+            ["label1", "label2"],
+            "namespace-4/repo-4#99",
+            None,
+        ),
     ],
 )
 def test_parse_comment_arguments(


### PR DESCRIPTION
Fixes #2866

RELEASE NOTES BEGIN

For retriggering tests with builds from another pull request, Packit now supports Github's automatically converted URL format (`https://github.com/namespace/repo/pull/<pr_id>`, e.g. `/packit test https://github.com/namespace/repo/pull/<pr_id>`)

RELEASE NOTES END
