### PR TITLE
Do not report build statuses for tests without matching labels

### DIFF
--- a/packit_service/worker/handlers/copr.py
+++ b/packit_service/worker/handlers/copr.py
@@ -37,7 +37,6 @@ from packit_service.utils import (
     dump_job_config,
     dump_package_config,
     elapsed_seconds,
-    pr_labels_match_configuration,
 )
 from packit_service.worker.checker.abstract import Checker
 from packit_service.worker.checker.copr import (
@@ -484,15 +483,7 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
                 and not job_config.manual_trigger
                 # we need to check the labels here
                 # the same way as when scheduling jobs for event
-                and (
-                    job_config.trigger != JobConfigTriggerType.pull_request
-                    or not (job_config.require.label.present or job_config.require.label.absent)
-                    or pr_labels_match_configuration(
-                        pull_request=self.copr_build_helper.pull_request_object,
-                        configured_labels_absent=job_config.require.label.absent,
-                        configured_labels_present=job_config.require.label.present,
-                    )
-                )
+                and self.copr_build_helper.test_job_labels_match(job_config)
                 and self.copr_event.chroot
                 in self.copr_build_helper.build_targets_for_test_job(job_config)
             ):

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -1495,6 +1495,8 @@ def test_copr_build_end_testing_farm_labels_not_matching(copr_build_end, copr_bu
         update_feedback_time=object,
     ).once()
 
+    # Testing farm status should NOT be reported because labels don't match
+    # (PR has "another-label" but test requires "a-label")
     flexmock(StatusReporter).should_receive("report").with_args(
         state=BaseCommitStatus.pending,
         description="RPMs were built successfully.",
@@ -1503,12 +1505,14 @@ def test_copr_build_end_testing_farm_labels_not_matching(copr_build_end, copr_bu
         markdown_content=None,
         links_to_external_services=None,
         update_feedback_time=object,
-    ).once()
+    ).never()
 
     flexmock(GithubProject).should_receive("get_web_url").and_return(
         "https://github.com/foo/bar",
     )
 
+    # Testing farm task should NOT be submitted because labels don't match
+    flexmock(Signature).should_receive("apply_async").never()
     flexmock(celery_group).should_receive("apply_async").once()
 
     # skip SRPM url since it touches multiple classes


### PR DESCRIPTION
Fixes #2678

This could reduce the API requests for repos with lot of test jobs that require labels (e.g. tmt).

RELEASE NOTES BEGIN

When reporting status of a build, the related status for test job won't be reported if the labels on the PR don't match the configuration of the particular test job.

RELEASE NOTES END
