### PR TITLE
Remove references to closed Kanban board

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,8 +8,6 @@ body:
         Please search existing issues to avoid creating duplicates.
         You may also check our status page for incidents/outages: https://status.packit.dev/
 
-        You can also see our current priorities on our board: https://github.com/orgs/packit/projects/7/views/29
-
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,8 +7,6 @@ body:
       value: |
         Please search existing issues to avoid creating duplicates.
 
-        You can also see our current priorities on our board: https://github.com/orgs/packit/projects/7/views/29
-
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/fedora-ci.yml
+++ b/.github/ISSUE_TEMPLATE/fedora-ci.yml
@@ -7,7 +7,6 @@ body:
       value: |
         Please search existing issues to avoid creating duplicates.
         If this is more of a discussion topic, you might rather want to create a new thread [here](https://github.com/packit/packit/discussions/2520).
-        You can also see our current priorities on our board: https://github.com/orgs/packit/projects/7/views/29
 
   - type: textarea
     id: description

--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@ A service which helps you integrate your upstream GitHub project into Fedora
 ecosystem. Think of it as [packit](https://github.com/packit/packit) on
 steroids.
 
-## Current status
-
-If you are interested in the status of the development,
-take a look at [our Kanban board](https://github.com/orgs/packit/projects/7).
-Bigger stories can be seen [here](https://github.com/orgs/packit/projects/7/views/18)
-and the ones that are being worked on this quarter are [here](https://github.com/orgs/packit/projects/7/views/25).
-
 ## More info
 
 If you'd like to know more about packit, please check:

--- a/packit_service/worker/reporting/news.py
+++ b/packit_service/worker/reporting/news.py
@@ -19,8 +19,6 @@ class News:
         "Did you know Packit is on Mastodon? Or, more specifically, on Fosstodon? "
         "Follow [@packit@fosstodon.org](https://fosstodon.org/@packit) "
         "and be one of the first to know about all the news!",
-        "Interested in the Packit team plans and priorities? "
-        "Check [our epic board](https://github.com/orgs/packit/projects/7/views/29).",
         "Want to catch security issues early? [Read more](https://packit.dev/posts/openscanhub-prototype)"
         " about our SAST integration!",
     ]


### PR DESCRIPTION
The planning was moved to a private Jira.
