### PR TITLE
Include head commit hash in Pagure status check UID

### DIFF
--- a/packit_service/worker/reporting/reporters/pagure.py
+++ b/packit_service/worker/reporting/reporters/pagure.py
@@ -38,7 +38,7 @@ class StatusReporterPagure(StatusReporter):
         Set status of a Pagure check.
 
         If used for a pull request, the UID is derived from SHA256
-        of `check_name` or combination of `check_name` and `target_branch`.
+        of `check_name` or combination of `check_name`, `target_branch` and `commit_sha`.
 
         Value of `url` defaults to `CONTACTS_URL`, since Pagure requires
         some URL to be submitted.
@@ -58,12 +58,14 @@ class StatusReporterPagure(StatusReporter):
             url = CONTACTS_URL
 
         if self.pull_request_object:
-            # generate a custom uid from the check_name and target_branch,
+            # generate a custom uid from the check_name, target_branch and commit SHA
             # so that we can update flags we set previously,
             # instead of creating new ones (Pagure specific behaviour)
             # the max length of uid is 32 chars
             composed_check_name = (
-                check_name if not target_branch else f"{check_name} - {target_branch}"
+                check_name
+                if not target_branch
+                else f"{check_name} - {target_branch} [{self.commit_sha[:7]}]"
             )
             uid = hashlib.sha256(composed_check_name.encode()).hexdigest()[:32]
             self.pull_request_object.set_flag(

--- a/tests/integration/test_dg_pr.py
+++ b/tests/integration/test_dg_pr.py
@@ -45,22 +45,22 @@ def distgit_pr_event():
     [
         pytest.param(
             "rawhide",
-            "e0091d5fbcb20572cbf2e6442af9bed5",
-            "Packit - scratch build - rawhide",
+            "da02b4ee9881488e777cd22bbb13987f",
+            "Packit - scratch build - rawhide [889f07a]",
             False,
             id="rawhide target branch",
         ),
         pytest.param(
             "rawhide",
-            "8edd48272efe6aff7d1d92bdffcaf9a0",
-            "Packit - scratch build - eln",
+            "f4a160072a397b8fca2304d80f36fc76",
+            "Packit - scratch build - eln [889f07a]",
             True,
             id="rawhide branch, rawhide + eln target",
         ),
         pytest.param(
             "f42",
-            "6f08c3bbb20660dc8c597bc7dbe4f056",
-            "Packit - scratch build - f42",
+            "44e52710e6df077ddc07e16df1cbf6b7",
+            "Packit - scratch build - f42 [889f07a]",
             False,
             id="f42 target branch",
         ),
@@ -75,8 +75,8 @@ def test_downstream_koji_scratch_build(distgit_pr_event, target_branch, uid, che
         .mock()
     )
     if eln:
-        check_name = "Packit - scratch build - rawhide"
-        uid = "e0091d5fbcb20572cbf2e6442af9bed5"
+        check_name = "Packit - scratch build - rawhide [889f07a]"
+        uid = "da02b4ee9881488e777cd22bbb13987f"
         (
             pr_object.should_receive("set_flag")
             .with_args(username=check_name, comment=str, url=str, status=CommitStatus, uid=uid)

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2460,14 +2460,14 @@ def test_koji_build_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added):
     [
         pytest.param(
             "rawhide",
-            "e0091d5fbcb20572cbf2e6442af9bed5",
-            "Packit - scratch build - rawhide",
+            "45f8d1e6ef3ca9f57d9ed4dc82919216",
+            "Packit - scratch build - rawhide [beaf90b]",
             id="rawhide target branch",
         ),
         pytest.param(
             "f42",
-            "6f08c3bbb20660dc8c597bc7dbe4f056",
-            "Packit - scratch build - f42",
+            "436202b02405a83e4f8cf57ed908c0cc",
+            "Packit - scratch build - f42 [beaf90b]",
             id="f42 target branch",
         ),
     ],
@@ -3449,18 +3449,30 @@ def _test_downstream_tf_retrigger_common(
         pytest.param(
             "rawhide",
             [
-                ("380723461ab74e1cde4eb89b711c8f1d", "Packit - installability test(s) - rawhide"),
-                ("27516f942959e4114b2856f76852577a", "Packit - rpminspect test(s) - rawhide"),
-                ("e02f17936a385a5031056e304b9c5de6", "Packit - rpmlint test(s) - rawhide"),
+                (
+                    "6d28c456bdf4e04a37e17a0527b0c633",
+                    "Packit - installability test(s) - rawhide [beaf90b]",
+                ),
+                (
+                    "a231e6f97db9f0eeae88562074829b96",
+                    "Packit - rpminspect test(s) - rawhide [beaf90b]",
+                ),
+                (
+                    "690a6d39ff6a64745b865d8bf60ae684",
+                    "Packit - rpmlint test(s) - rawhide [beaf90b]",
+                ),
             ],
             id="rawhide target branch",
         ),
         pytest.param(
             "f42",
             [
-                ("a478035df5f8599527e3e37bfc2ca25f", "Packit - installability test(s) - f42"),
-                ("e9d900e81542cc243d51d9058f1845d3", "Packit - rpminspect test(s) - f42"),
-                ("a4de9ef7a17005c5404c54acab49d599", "Packit - rpmlint test(s) - f42"),
+                (
+                    "a06b8e95e117b23181a5eb84e6693ed8",
+                    "Packit - installability test(s) - f42 [beaf90b]",
+                ),
+                ("2c66f7d41b22fefcbf2647b14ff52781", "Packit - rpminspect test(s) - f42 [beaf90b]"),
+                ("e0dd5f45df5956423b73de783fd211d0", "Packit - rpmlint test(s) - f42 [beaf90b]"),
             ],
             id="f42 target branch",
         ),
@@ -3486,22 +3498,22 @@ def test_downstream_testing_farm_retrigger_via_dist_git_pr_comment(
         pytest.param(
             "/packit-ci test installability",
             "rawhide",
-            "380723461ab74e1cde4eb89b711c8f1d",
-            "Packit - installability test(s) - rawhide",
+            "6d28c456bdf4e04a37e17a0527b0c633",
+            "Packit - installability test(s) - rawhide [beaf90b]",
             id="installability - rawhide target branch",
         ),
         pytest.param(
             "/packit-ci test installability",
             "f42",
-            "a478035df5f8599527e3e37bfc2ca25f",
-            "Packit - installability test(s) - f42",
+            "a06b8e95e117b23181a5eb84e6693ed8",
+            "Packit - installability test(s) - f42 [beaf90b]",
             id="installability - f42 target branch",
         ),
         pytest.param(
             "/packit-ci test rpminspect",
             "rawhide",
-            "27516f942959e4114b2856f76852577a",
-            "Packit - rpminspect test(s) - rawhide",
+            "a231e6f97db9f0eeae88562074829b96",
+            "Packit - rpminspect test(s) - rawhide [beaf90b]",
             id="rpminspect - rawhide target branch",
         ),
     ],


### PR DESCRIPTION
A push to a PR where a scratch build has already started can trigger another scratch build and the two share a status check, updating its status and target URL seemingly randomly, confusing users. If it is a force-push and the first scratch build is still pending in Koji, it will fail because the original ref doesn't exist anymore and the status check can end up in failed state even though another build is running, confusing users even more.
Similar thing can happen with subsequent test jobs.

Avoid this by including head commit hash of a PR in the status check UID calculation.

Fixes https://github.com/packit/packit-service/issues/2938.