### PR TITLE
Provide direct links when reporting for Fedora CI

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -905,12 +905,14 @@ class DownstreamKojiScratchBuildHandler(
         )
         try:
             stdout = self.run_koji_build()
+            web_url = None
             if stdout:
                 task_id, web_url = get_koji_task_id_and_url_from_stdout(stdout)
                 koji_build.set_task_id(str(task_id))
                 koji_build.set_web_url(web_url)
                 koji_build.set_build_submission_stdout(stdout)
-            url = get_koji_build_info_url(koji_build.id)
+            # try to link directly to Koji interface instead of dashboard for Fedora CI
+            url = web_url or get_koji_build_info_url(koji_build.id)
             self.report(
                 commit_status=BaseCommitStatus.running,
                 description="RPM build was submitted ...",

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -684,12 +684,13 @@ class DownstreamTestingFarmResultsHandler(
             self.pushgateway.test_run_finished_time.observe(test_run_time)
 
         test_run_model.set_web_url(self.log_url)
-        url = get_testing_farm_info_url(test_run_model.id) if test_run_model else None
+        # For Fedora CI, try to link directly to Testing Farm results instead of dashboard
+        url = self.log_url or get_testing_farm_info_url(test_run_model.id)
         self.downstream_testing_farm_job_helper.report(
             test_run=test_run_model,
             state=status,
             description=summary,
-            url=url if url else self.log_url,
+            url=url,
         )
 
         test_run_model.set_status(self.result, created=self.created)

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -2626,7 +2626,7 @@ def test_koji_build_end_downstream(
     flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").and_return(
         koji_build_pr_downstream,
     )
-    url = get_koji_build_info_url(1)
+    url = koji_build_pr_downstream.web_url
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
 

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -301,7 +301,7 @@ def test_downstream_testing_farm_response(
     flexmock(StatusReporter).should_receive("set_status").with_args(
         state=status_status,
         description=status_message,
-        url="https://dashboard.localhost/jobs/testing-farm/123",
+        url="some url",
         check_name="Packit - installability test(s)",
         target_branch="rawhide",
     ).once()


### PR DESCRIPTION
Fixes #2929

RELEASE NOTES BEGIN

For Fedora CI, we are now providing direct links to Koji/Testing Farm instead of our dashboard, when possible.

RELEASE NOTES END
