### PR TITLE
Use TFTTestRunGroupModel.create to handle race conditions

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -3448,6 +3448,7 @@ class TFTTestRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
                 new_run_model.package_name = locked_run_model.package_name
                 new_run_model.srpm_build = locked_run_model.srpm_build
                 new_run_model.copr_build_group = locked_run_model.copr_build_group
+                new_run_model.koji_build_group = locked_run_model.koji_build_group
                 new_run_model.test_run_group = test_run_group
                 session.add(new_run_model)
             else:

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -176,12 +176,11 @@ class TestingFarmHandler(
             # connected to the same pipeline, just take the first one
             else next(iter(builds.values())).group_of_targets.runs[-1]
         )
-        group = (
-            TFTTestRunGroupModel.create(
-                run_model, ranch=self.testing_farm_job_helper.tft_client.default_ranch
-            )
-            if not run_model.test_run_group
-            else run_model.test_run_group
+        # Always call create() to handle race conditions properly.
+        # The create() method will lock the run_model, check if it already has a test_run_group,
+        # and clone the pipeline if needed. This ensures each identifier gets its own pipeline.
+        group = TFTTestRunGroupModel.create(
+            run_model, ranch=self.testing_farm_job_helper.tft_client.default_ranch
         )
         runs = []
         for target, build in builds.items():
@@ -418,12 +417,11 @@ class DownstreamTestingFarmHandler(
             return target_model.group_of_targets, [target_model]
 
         run_model = self.koji_build.group_of_targets.runs[-1]
-        group = (
-            TFTTestRunGroupModel.create(
-                run_model, ranch=self.downstream_testing_farm_job_helper.tft_client.default_ranch
-            )
-            if not run_model.test_run_group
-            else run_model.test_run_group
+        # Always call create() to handle race conditions properly.
+        # The create() method will lock the run_model, check if it already has a test_run_group,
+        # and clone the pipeline if needed. This ensures each identifier gets its own pipeline.
+        group = TFTTestRunGroupModel.create(
+            run_model, ranch=self.downstream_testing_farm_job_helper.tft_client.default_ranch
         )
 
         # convert dist-git branch to distro


### PR DESCRIPTION
I think the changes in this PR could help with the following database inconsistencies:

### identifier -> full,  pipeline row does not exist
```
-- Query 1: Check if the test run exists
SELECT 
    id,
    pipeline_id,
    tft_test_run_group_id,
    status,
    target,
    submitted_time
FROM tft_test_run_targets
WHERE pipeline_id = '19e18bcb-52ec-45f1-8532-1c63910e1096';

   id    |             pipeline_id              | tft_test_run_group_id | status |      target      |       submitted_time       
---------+--------------------------------------+-----------------------+--------+------------------+----------------------------
 1342990 | 19e18bcb-52ec-45f1-8532-1c63910e1096 |                248191 | failed | fedora-42-x86_64 | 2026-01-14 08:05:46.317095

-- Query 2: Check if the test run group exists (use the tft_test_run_group_id from Query 1)
SELECT 
    id,
    submitted_time,
    ranch
FROM tft_test_run_groups
WHERE id = 248191;

   id   |      submitted_time       | ranch  
--------+---------------------------+--------
 248191 | 2026-01-14 08:05:45.53505 | public

-- Query 3: Check if there's a pipeline linked to the test run group
SELECT 
    id,
    test_run_group_id,
    project_event_id,
    package_name,
    datetime
FROM pipelines
WHERE test_run_group_id = 248191;

 id | test_run_group_id | project_event_id | package_name | datetime 
----+-------------------+------------------+--------------+----------

``` 

### identifier -> provision-bootc, ok

```
SELECT 
    id,
    pipeline_id,
    tft_test_run_group_id,
    status,
    target,
    submitted_time
FROM tft_test_run_targets
WHERE pipeline_id = '984260e5-5fc3-4cea-82d5-a5149d41fd2e';

   id    |             pipeline_id              | tft_test_run_group_id | status |      target      |       submitted_time       
---------+--------------------------------------+-----------------------+--------+------------------+----------------------------
 1342992 | 984260e5-5fc3-4cea-82d5-a5149d41fd2e |                248192 | passed | fedora-42-x86_64 | 2026-01-14 08:05:46.935009

SELECT 
    id,
    submitted_time,
    ranch
FROM tft_test_run_groups
WHERE id = 248192;

   id   |       submitted_time       | ranch  
--------+----------------------------+--------
 248192 | 2026-01-14 08:05:45.684351 | redhat

SELECT 
    id,
    test_run_group_id,
    project_event_id,
    package_name,
    datetime
FROM pipelines
WHERE test_run_group_id = 248192;

   id    | test_run_group_id | project_event_id | package_name |          datetime          
---------+-------------------+------------------+--------------+----------------------------
 1098374 |            248192 |           672653 | tmt          | 2026-01-14 08:03:23.035723

```

### Pipeline table has really few pipeline associated to the event if compared with all identifiers in the PR

```
packit=# select * from pipelines where project_event_id = 672653;
   id    |          datetime          | project_event_id | srpm_build_id | sync_release_run_id | vm_image_build_id | test_run_group_id | copr_build_group_id | koji_build_group_id | package_name | bodhi_update_group_id | koji_tag_request_group
_id 
---------+----------------------------+------------------+---------------+---------------------+-------------------+-------------------+---------------------+---------------------+--------------+-----------------------+-----------------------
----
 1098373 | 2026-01-14 08:03:10.238277 |           672653 |               |                     |                   |            248187 |                     |                     | tmt          |                       |                       
   
 1098374 | 2026-01-14 08:03:23.035723 |           672653 |        530867 |                     |                   |            248192 |              522839 |                     | tmt          |                       |                       
   
 1098635 | 2026-01-14 13:14:06.927305 |           672653 |               |                     |                   |            248301 |                     |                     | tmt          |

```