### PR TITLE
Add default TF mapping for branched minor versions of EL 10+

### DIFF
--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -16,7 +16,6 @@ from packit.config import JobConfig, JobType, aliases
 from packit.config.package_config import PackageConfig
 
 from packit_service.config import ServiceConfig
-from packit_service.constants import DEFAULT_MAPPING_TF
 from packit_service.events import (
     abstract,
     github,
@@ -39,7 +38,7 @@ from packit_service.service.urls import (
     get_copr_build_info_url,
     get_testing_farm_info_url,
 )
-from packit_service.utils import elapsed_seconds
+from packit_service.utils import elapsed_seconds, get_default_tf_mapping
 from packit_service.worker.checker.abstract import Checker
 from packit_service.worker.checker.distgit import (
     PackageNeedsELNBuildFromRawhide,
@@ -431,7 +430,7 @@ class DownstreamTestingFarmHandler(
         # convert dist-git branch to distro
         [target] = aliases.get_build_targets(self.koji_build.target)
         distro = target.rsplit("-", 1)[0]
-        distro = DEFAULT_MAPPING_TF.get(distro, distro)
+        distro = get_default_tf_mapping(internal=False).get(distro, distro)
 
         runs = []
         for test in fedora_ci_tests:

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -35,8 +35,6 @@ from packit_service.constants import (
     CUSTOM_COPR_PROJECT_NOT_ALLOWED_CONTENT,
     CUSTOM_COPR_PROJECT_NOT_ALLOWED_STATUS,
     DASHBOARD_JOBS_TESTING_FARM_PATH,
-    DEFAULT_MAPPING_INTERNAL_TF,
-    DEFAULT_MAPPING_TF,
     DEFAULT_RETRY_LIMIT_OUTAGE,
     GIT_FORGE_PROJECT_NOT_ALLOWED_TO_BUILD_IN_COPR,
     MISSING_PERMISSIONS_TO_BUILD_IN_COPR,
@@ -57,7 +55,7 @@ from packit_service.service.urls import (
     get_copr_build_info_url,
     get_srpm_build_info_url,
 )
-from packit_service.utils import elapsed_seconds
+from packit_service.utils import elapsed_seconds, get_default_tf_mapping
 from packit_service.worker.celery_task import CeleryTask
 from packit_service.worker.helpers.build.build_helper import BaseBuildJobHelper
 from packit_service.worker.monitoring import Pushgateway
@@ -333,12 +331,10 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         if configured_distros:
             distro_arch_list = [(distro, arch) for distro in configured_distros]
         else:
-            mapping = (
-                DEFAULT_MAPPING_INTERNAL_TF
-                if test_job_config.use_internal_tf
-                else DEFAULT_MAPPING_TF
+            # if not explicitly configured, try to get the default compose for this target
+            distro = get_default_tf_mapping(internal=test_job_config.use_internal_tf).get(
+                distro, distro
             )
-            distro = mapping.get(distro, distro)
             distro_arch_list = [(distro, arch)]
 
         return {f"{distro}-{arch}" for (distro, arch) in distro_arch_list}

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -2764,6 +2764,7 @@ def test_koji_build_end_downstream(
         },
     }
 
+    flexmock(aliases).should_receive("get_aliases").and_return({"fedora-all": [], "epel-all": []})
     flexmock(aliases).should_receive("get_build_targets").with_args("rawhide").and_return(
         ["fedora-rawhide-x86_64"]
     )


### PR DESCRIPTION
For Fedora dist-git CI, this makes test jobs on `epel10.1` (and future minor version branches) PRs run on CentOS Stream (which is not exactly correct but better than instant failure). For upstream test jobs, this makes tests with `rhel+epel-10` Copr builds run by default on CentOS Stream (same as before) or on the correct RHEL minor version compose if `use_internal_tf` is true.