### PR TITLE
Update DB cleanup script and prepare for scheduled running

### DIFF
--- a/files/scripts/db-cleanup.py
+++ b/files/scripts/db-cleanup.py
@@ -3,35 +3,21 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+"""
+Script for manual database cleanup operations.
+
+This script provides a CLI interface to the delete_old_data function
+from packit_service.worker.database module for manual DB cleanup.
+"""
+
 import argparse
+import sys
 
-from sqlalchemy import create_engine, delete, distinct, func, select, union
+from packit_service.worker.database import delete_old_data
 
-from packit_service.models import (
-    CoprBuildGroupModel,
-    CoprBuildTargetModel,
-    GitBranchModel,
-    GitProjectModel,
-    IssueModel,
-    JobTriggerModel,
-    JobTriggerModelType,
-    KojiBuildGroupModel,
-    KojiBuildTargetModel,
-    PipelineModel,
-    ProjectAuthenticationIssueModel,
-    ProjectReleaseModel,
-    PullRequestModel,
-    SRPMBuildModel,
-    SyncReleaseModel,
-    SyncReleaseTargetModel,
-    TFTTestRunGroupModel,
-    TFTTestRunTargetModel,
-    VMImageBuildTargetModel,
-    get_pg_url,
-    tf_copr_association_table,
-)
 
-if __name__ == "__main__":
+def main():
+    """CLI entry point for database cleanup script."""
     parser = argparse.ArgumentParser(
         description="""\
 Remove old data from the DB in order to speed up queries.
@@ -48,167 +34,16 @@ See get_pg_url() for details.
         help="Remove data older than this. For example: "
         "'1 year' or '6 months'. Defaults to '1 year'.",
     )
+
     args = parser.parse_args()
 
-    engine = create_engine(
-        get_pg_url(),
-        echo=True,
-    )
-    with engine.begin() as conn:
-        # Delete the pipelines older than AGE
-        stmt = delete(PipelineModel).where(func.age(PipelineModel.datetime) >= args.age)
-        conn.execute(stmt)
+    try:
+        delete_old_data(age=args.age)
+        return 0
+    except Exception as e:
+        print(f"Error during cleanup: {e}")
+        return 1
 
-        # Delete JobTriggers, SRPMBuilds and VMImageBuilds which don't belong to a pipeline
-        attr = [
-            (JobTriggerModel, PipelineModel.job_trigger_id),
-            (SRPMBuildModel, PipelineModel.srpm_build_id),
-            (VMImageBuildTargetModel, PipelineModel.vm_image_build_id),
-        ]
-        for model, field in attr:
-            orphaned = (
-                select(distinct(model.id))
-                .outerjoin(PipelineModel, field == model.id)
-                .filter(PipelineModel.id == None)  # noqa
-            )
-            stmt = delete(model).where(model.id.in_(orphaned))
-            conn.execute(stmt)
 
-        # Delete CoprBuildTargets and tf-copr associations which don't belong to a pipeline
-        orphaned = (
-            select(distinct(CoprBuildTargetModel.id))
-            .outerjoin_from(
-                CoprBuildGroupModel,
-                CoprBuildTargetModel,
-                CoprBuildTargetModel.copr_build_group_id == CoprBuildGroupModel.id,
-            )
-            .outerjoin(
-                PipelineModel,
-                PipelineModel.copr_build_group_id == CoprBuildGroupModel.id,
-            )
-            .filter(PipelineModel.id == None)  # noqa
-        )
-        stmt = delete(tf_copr_association_table).where(
-            tf_copr_association_table.c.copr_id.in_(orphaned),
-        )
-        conn.execute(stmt)
-        stmt = delete(CoprBuildTargetModel).where(CoprBuildTargetModel.id.in_(orphaned))
-        conn.execute(stmt)
-
-        # Delete KojiBuildTargets, TFTTestRunTargets and SyncReleaseTargets
-        # which don't belong to any pipeline
-        attr = [
-            (
-                KojiBuildTargetModel,
-                KojiBuildGroupModel,
-                PipelineModel.koji_build_group_id,
-                KojiBuildTargetModel.koji_build_group_id,
-            ),
-            (
-                TFTTestRunTargetModel,
-                TFTTestRunGroupModel,
-                PipelineModel.test_run_group_id,
-                TFTTestRunTargetModel.tft_test_run_group_id,
-            ),
-            (
-                SyncReleaseTargetModel,
-                SyncReleaseModel,
-                PipelineModel.sync_release_run_id,
-                SyncReleaseTargetModel.sync_release_id,
-            ),
-        ]
-        for target_m, group_m, id_f, model_group_id in attr:
-            print(f"Working on {target_m}...")
-            orphaned = (
-                select(distinct(target_m.id))
-                .outerjoin_from(group_m, target_m, model_group_id == group_m.id)
-                .outerjoin(PipelineModel, id_f == group_m.id)
-                .filter(PipelineModel.id == None)  # noqa
-            )
-            stmt = delete(target_m).where(target_m.id.in_(orphaned))
-            conn.execute(stmt)
-
-        # Now that the targets are all cleaned up, let's get rid of the Groups
-        # which don't reference any targets and are not referenced by any pipeline.
-        #   - CoprBuildGroups
-        #   - KojiBuildGroups
-        #   - TFTTestRunGroups
-        #   - SynReleaseRuns
-        groups = [
-            (
-                CoprBuildGroupModel,
-                CoprBuildTargetModel,
-                CoprBuildTargetModel.copr_build_group_id,
-                PipelineModel.copr_build_group_id,
-            ),
-            (
-                KojiBuildGroupModel,
-                KojiBuildTargetModel,
-                KojiBuildTargetModel.koji_build_group_id,
-                PipelineModel.koji_build_group_id,
-            ),
-            (
-                TFTTestRunGroupModel,
-                TFTTestRunTargetModel,
-                TFTTestRunTargetModel.tft_test_run_group_id,
-                PipelineModel.test_run_group_id,
-            ),
-        ]
-        for group, target, target_group_id, pipeline_group_id in groups:
-            orphaned_groups = (
-                select(distinct(group.id))
-                .outerjoin(
-                    target,
-                    group.id == target_group_id,
-                )
-                .outerjoin(
-                    PipelineModel,
-                    pipeline_group_id == group.id,
-                )
-                .filter(target.id == None)  # noqa
-                .filter(PipelineModel.id == None)  # noqa
-            )
-            stmt = delete(group).where(group.id.in_(orphaned_groups))
-            conn.execute(stmt)
-
-        # Delete the trigger objects which are not referenced by any JobTriggers
-        #   - PullRequestModel
-        #   - GitBranchModel
-        #   - ProjectReleaseModel
-        #   - IssueModel
-
-        trigger_types = [
-            (JobTriggerModelType.pull_request, PullRequestModel),
-            (JobTriggerModelType.branch_push, GitBranchModel),
-            (JobTriggerModelType.release, ProjectReleaseModel),
-            (JobTriggerModelType.issue, IssueModel),
-        ]
-        for trigger_type, trigger_model in trigger_types:
-            triggers = (
-                select(JobTriggerModel).filter(JobTriggerModel.type == trigger_type).subquery()
-            )
-            orphaned_triggers = (
-                select(trigger_model.id)
-                .outerjoin(triggers, trigger_model.id == triggers.columns.trigger_id)
-                .filter(triggers.columns.trigger_id == None)  # noqa
-            )
-            stmt = delete(trigger_model).where(trigger_model.id.in_(orphaned_triggers))
-            conn.execute(stmt)
-
-        # Delete the GitProjectModel not referenced by anything
-        # - PullRequestModel
-        # - GitBranchModel
-        # - ProjectReleaseModel
-        # - IssueModel
-        # - ProjectAuthenticationIssueModel
-        referenced_projects = union(
-            select(PullRequestModel.project_id),
-            select(GitBranchModel.project_id),
-            select(ProjectReleaseModel.project_id),
-            select(IssueModel.project_id),
-            select(ProjectAuthenticationIssueModel.project_id),
-        )
-        stmt = delete(GitProjectModel).where(
-            GitProjectModel.id.not_in(referenced_projects),
-        )
-        conn.execute(stmt)
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -141,6 +141,10 @@ SRPMBUILDS_OUTDATED_AFTER_DAYS = 30
 
 PACKAGE_CONFIGS_OUTDATED_AFTER_DAYS = 1
 
+# Pipelines older than this number of days are considered
+# outdated and can be deleted along with related data.
+PIPELINES_OUTDATED_AFTER_DAYS = 365
+
 ALLOWLIST_CONSTANTS = {
     "approved_automatically": "approved_automatically",
     "waiting": "waiting",

--- a/packit_service/worker/database.py
+++ b/packit_service/worker/database.py
@@ -7,16 +7,49 @@ from logging import DEBUG, INFO, getLogger
 from os import getenv
 from pathlib import Path
 from shutil import copyfileobj
+from typing import Optional
 
 from boto3 import client as boto3_client
 from botocore.exceptions import ClientError
 from packit.utils.commands import run_command
+from sqlalchemy import create_engine, delete, distinct, func, select, union
 
 from packit_service.constants import (
     PACKAGE_CONFIGS_OUTDATED_AFTER_DAYS,
+    PIPELINES_OUTDATED_AFTER_DAYS,
     SRPMBUILDS_OUTDATED_AFTER_DAYS,
 )
-from packit_service.models import ProjectEventModel, SRPMBuildModel, get_pg_url
+from packit_service.models import (
+    BodhiUpdateGroupModel,
+    BodhiUpdateTargetModel,
+    CoprBuildGroupModel,
+    CoprBuildTargetModel,
+    GitBranchModel,
+    GitProjectModel,
+    IssueModel,
+    KojiBuildGroupModel,
+    KojiBuildTargetModel,
+    KojiTagRequestGroupModel,
+    KojiTagRequestTargetModel,
+    OSHScanModel,
+    PipelineModel,
+    ProjectAuthenticationIssueModel,
+    ProjectEventModel,
+    ProjectEventModelType,
+    ProjectReleaseModel,
+    PullRequestModel,
+    SRPMBuildModel,
+    SyncReleaseModel,
+    SyncReleasePullRequestModel,
+    SyncReleaseTargetModel,
+    TFTTestRunGroupModel,
+    TFTTestRunTargetModel,
+    VMImageBuildTargetModel,
+    get_pg_url,
+    sync_release_pr_association_table,
+    tf_copr_association_table,
+    tf_koji_association_table,
+)
 
 logger = getLogger(__name__)
 
@@ -157,3 +190,277 @@ def backup():
         file.unlink(missing_ok=True)
         if compressed_file:
             compressed_file.unlink()
+
+
+def delete_old_data(age: Optional[str] = None):
+    """
+    Remove old data from the DB.
+
+    Args:
+        age: PostgreSQL interval string (e.g., '1 year', '6 months', '365 days').
+             If not provided, reads from PIPELINES_OUTDATED_AFTER_DAYS env var.
+    """
+    if age is None:
+        outdated_after_days = getenv(
+            "PIPELINES_OUTDATED_AFTER_DAYS",
+            PIPELINES_OUTDATED_AFTER_DAYS,
+        )
+        age = f"{outdated_after_days} days"
+
+    logger.info(f"About to delete data older than {age}")
+
+    engine = create_engine(get_pg_url(), echo=True)
+
+    with engine.begin() as conn:
+        # Delete the pipelines older than AGE
+        stmt = delete(PipelineModel).where(func.age(PipelineModel.datetime) >= age)
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} pipelines older than {age}")
+
+        # Delete ProjectEventModels which don't belong to any pipeline
+        orphaned_events = (
+            select(distinct(ProjectEventModel.id))
+            .outerjoin(PipelineModel, PipelineModel.project_event_id == ProjectEventModel.id)
+            .filter(PipelineModel.id == None)  # noqa
+        )
+        stmt = delete(ProjectEventModel).where(ProjectEventModel.id.in_(orphaned_events))
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} orphaned ProjectEventModels")
+
+        # Delete SRPMBuilds and VMImageBuilds which don't belong to a pipeline
+        attr = [
+            (SRPMBuildModel, PipelineModel.srpm_build_id),
+            (VMImageBuildTargetModel, PipelineModel.vm_image_build_id),
+        ]
+        for model, field in attr:
+            orphaned = (
+                select(distinct(model.id))  # type: ignore
+                .outerjoin(PipelineModel, field == model.id)  # type: ignore
+                .filter(PipelineModel.id == None)  # noqa
+            )
+            stmt = delete(model).where(model.id.in_(orphaned))  # type: ignore
+            result = conn.execute(stmt)
+            logger.info(f"Deleted {result.rowcount} orphaned {model.__name__}")
+
+        # Delete CoprBuildTargets and tf-copr associations which don't belong to a pipeline
+        orphaned = (
+            select(distinct(CoprBuildTargetModel.id))
+            .outerjoin_from(
+                CoprBuildGroupModel,
+                CoprBuildTargetModel,
+                CoprBuildTargetModel.copr_build_group_id == CoprBuildGroupModel.id,
+            )
+            .outerjoin(
+                PipelineModel,
+                PipelineModel.copr_build_group_id == CoprBuildGroupModel.id,
+            )
+            .filter(PipelineModel.id == None)  # noqa
+        )
+        stmt = delete(tf_copr_association_table).where(
+            tf_copr_association_table.c.copr_id.in_(orphaned),
+        )
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} orphaned tf-copr associations")
+
+        # Delete OpenScanHub scans that reference orphaned copr build targets
+        stmt = delete(OSHScanModel).where(OSHScanModel.copr_build_target_id.in_(orphaned))
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} orphaned OSHScanModel records")
+
+        stmt = delete(CoprBuildTargetModel).where(CoprBuildTargetModel.id.in_(orphaned))
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} orphaned CoprBuildTargets")
+
+        # Delete KojiBuildTargets and tf-koji associations which don't belong to a pipeline
+        orphaned_koji = (
+            select(distinct(KojiBuildTargetModel.id))
+            .outerjoin_from(
+                KojiBuildGroupModel,
+                KojiBuildTargetModel,
+                KojiBuildTargetModel.koji_build_group_id == KojiBuildGroupModel.id,
+            )
+            .outerjoin(
+                PipelineModel,
+                PipelineModel.koji_build_group_id == KojiBuildGroupModel.id,
+            )
+            .filter(PipelineModel.id == None)  # noqa
+        )
+        stmt = delete(tf_koji_association_table).where(
+            tf_koji_association_table.c.koji_id.in_(orphaned_koji),
+        )
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} orphaned tf-koji associations")
+
+        stmt = delete(KojiBuildTargetModel).where(KojiBuildTargetModel.id.in_(orphaned_koji))
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} orphaned KojiBuildTargets")
+
+        # Delete TFTTestRunTargets and their associations
+        logger.info("Working on TFTTestRunTargetModel...")
+        orphaned_tft = (
+            select(distinct(TFTTestRunTargetModel.id))
+            .outerjoin_from(
+                TFTTestRunGroupModel,
+                TFTTestRunTargetModel,
+                TFTTestRunTargetModel.tft_test_run_group_id == TFTTestRunGroupModel.id,
+            )
+            .outerjoin(
+                PipelineModel,
+                PipelineModel.test_run_group_id == TFTTestRunGroupModel.id,
+            )
+            .filter(PipelineModel.id == None)  # noqa
+        )
+
+        # Delete associations referencing these orphaned TFT targets
+        stmt = delete(tf_copr_association_table).where(
+            tf_copr_association_table.c.tft_id.in_(orphaned_tft)
+        )
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} tf-copr associations (by tft_id)")
+
+        stmt = delete(tf_koji_association_table).where(
+            tf_koji_association_table.c.tft_id.in_(orphaned_tft)
+        )
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} tf-koji associations (by tft_id)")
+
+        stmt = delete(TFTTestRunTargetModel).where(TFTTestRunTargetModel.id.in_(orphaned_tft))
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} orphaned TFTTestRunTargets")
+
+        # Delete SyncReleaseTargets and their associations
+        logger.info("Working on SyncReleaseTargetModel...")
+        orphaned_sync = (
+            select(distinct(SyncReleaseTargetModel.id))
+            .outerjoin_from(
+                SyncReleaseModel,
+                SyncReleaseTargetModel,
+                SyncReleaseTargetModel.sync_release_id == SyncReleaseModel.id,
+            )
+            .outerjoin(
+                PipelineModel,
+                PipelineModel.sync_release_run_id == SyncReleaseModel.id,
+            )
+            .filter(PipelineModel.id == None)  # noqa
+        )
+
+        # Delete associations referencing these orphaned SyncRelease targets
+        stmt = delete(sync_release_pr_association_table).where(
+            sync_release_pr_association_table.c.sync_release_target_id.in_(orphaned_sync)
+        )
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} sync-release-pr associations")
+
+        stmt = delete(SyncReleaseTargetModel).where(SyncReleaseTargetModel.id.in_(orphaned_sync))
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} orphaned SyncReleaseTargets")
+
+        # Delete remaining target types (BodhiUpdate and KojiTagRequest) using generic logic
+        attr = [
+            (  # type: ignore
+                BodhiUpdateTargetModel,
+                BodhiUpdateGroupModel,
+                PipelineModel.bodhi_update_group_id,
+                BodhiUpdateTargetModel.bodhi_update_group_id,
+            ),
+            (  # type: ignore
+                KojiTagRequestTargetModel,
+                KojiTagRequestGroupModel,
+                PipelineModel.koji_tag_request_group_id,
+                KojiTagRequestTargetModel.koji_tag_request_group_id,
+            ),
+        ]
+        for target_m, group_m, id_f, model_group_id in attr:  # type: ignore
+            logger.info(f"Working on {target_m.__name__}...")
+            orphaned = (
+                select(distinct(target_m.id))  # type: ignore
+                .outerjoin_from(group_m, target_m, model_group_id == group_m.id)  # type: ignore
+                .outerjoin(PipelineModel, id_f == group_m.id)  # type: ignore
+                .filter(PipelineModel.id == None)  # noqa
+            )
+            stmt = delete(target_m).where(target_m.id.in_(orphaned))  # type: ignore
+            result = conn.execute(stmt)
+            logger.info(f"Deleted {result.rowcount} orphaned {target_m.__name__}")
+
+        # Delete orphaned Groups
+        groups = [  # type: ignore
+            (
+                CoprBuildGroupModel,
+                CoprBuildTargetModel,
+                CoprBuildTargetModel.copr_build_group_id,
+                PipelineModel.copr_build_group_id,
+            ),
+            (
+                KojiBuildGroupModel,
+                KojiBuildTargetModel,
+                KojiBuildTargetModel.koji_build_group_id,
+                PipelineModel.koji_build_group_id,
+            ),
+            (
+                TFTTestRunGroupModel,
+                TFTTestRunTargetModel,
+                TFTTestRunTargetModel.tft_test_run_group_id,
+                PipelineModel.test_run_group_id,
+            ),
+            (
+                BodhiUpdateGroupModel,
+                BodhiUpdateTargetModel,
+                BodhiUpdateTargetModel.bodhi_update_group_id,
+                PipelineModel.bodhi_update_group_id,
+            ),
+            (
+                KojiTagRequestGroupModel,
+                KojiTagRequestTargetModel,
+                KojiTagRequestTargetModel.koji_tag_request_group_id,
+                PipelineModel.koji_tag_request_group_id,
+            ),
+        ]
+        for group, target, target_group_id, pipeline_group_id in groups:  # type: ignore
+            orphaned_groups = (
+                select(distinct(group.id))  # type: ignore
+                .outerjoin(target, group.id == target_group_id)  # type: ignore
+                .outerjoin(PipelineModel, pipeline_group_id == group.id)  # type: ignore
+                .filter(target.id == None)  # type: ignore  # noqa
+                .filter(PipelineModel.id == None)  # noqa
+            )
+            stmt = delete(group).where(group.id.in_(orphaned_groups))  # type: ignore
+            result = conn.execute(stmt)
+            logger.info(f"Deleted {result.rowcount} orphaned {group.__name__}")
+
+        # Delete orphaned project event trigger objects
+        trigger_types = [
+            (ProjectEventModelType.pull_request, PullRequestModel),
+            (ProjectEventModelType.branch_push, GitBranchModel),
+            (ProjectEventModelType.release, ProjectReleaseModel),
+            (ProjectEventModelType.issue, IssueModel),
+        ]
+        for event_type, trigger_model in trigger_types:
+            # Find trigger objects not referenced by any ProjectEventModel
+            project_events = (
+                select(ProjectEventModel).filter(ProjectEventModel.type == event_type).subquery()
+            )
+            orphaned_triggers = (
+                select(trigger_model.id)  # type: ignore
+                .outerjoin(project_events, trigger_model.id == project_events.c.event_id)  # type: ignore
+                .filter(project_events.c.event_id == None)  # noqa
+            )
+            stmt = delete(trigger_model).where(trigger_model.id.in_(orphaned_triggers))  # type: ignore
+            result = conn.execute(stmt)
+            logger.info(f"Deleted {result.rowcount} orphaned {trigger_model.__name__}")
+
+        # Delete orphaned GitProjectModel records
+        referenced_projects = union(
+            select(PullRequestModel.project_id),
+            select(GitBranchModel.project_id),
+            select(ProjectReleaseModel.project_id),
+            select(IssueModel.project_id),
+            select(ProjectAuthenticationIssueModel.project_id),
+            select(SyncReleasePullRequestModel.project_id),
+        )
+        stmt = delete(GitProjectModel).where(
+            GitProjectModel.id.not_in(referenced_projects),
+        )
+        result = conn.execute(stmt)
+        logger.info(f"Deleted {result.rowcount} orphaned GitProjectModels")
+
+    logger.info("Finished deleting old data from database")

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -813,9 +813,11 @@ def babysit_pending_tft_runs() -> None:
 
 @celery_app.task
 def database_maintenance() -> None:
+    backup()
+    # TODO: uncomment once we did the first manual cleanup
+    # delete_old_data()
     discard_old_srpm_build_logs()
     discard_old_package_configs()
-    backup()
 
 
 @celery_app.task


### PR DESCRIPTION
The script was updated to accommodate the DB schema changes since it was written. The logic was also moved to the database.py since we plan to run it as a periodic task.

The current version was tested against dumps from both prod and stg from last week and works. But for prod it took 4h on my M3 mac. I am looking into possible optimisations.

Related to #1923