### PR TITLE
Changing the to check the second element

### DIFF
--- a/tests_openshift/database/test_events.py
+++ b/tests_openshift/database/test_events.py
@@ -481,7 +481,7 @@ def test_filter_failed_models_targets_copr(
     assert len(builds_list) == 3
 
     # these targets should be different
-    assert builds_list[0].target != builds_list[2].target
+    assert builds_list[0].target != builds_list[1].target
     # 2 builds with failed status and one with success
     builds_list[0].set_status(BuildStatus.failure)
     builds_list[1].set_status(BuildStatus.failure)


### PR DESCRIPTION
The assertion was broken by a change in the `get_all_by` method of `CoprBuildTargetModel`. https://github.com/packit/packit-service/commit/9866a4c485fc684d0b3c297c2cb89353eecc84a6

Somewhat counterintuitively, the mock was always written in a way that would suggest comparison between first and second element, rather than first and third.