### PR TITLE
Setting task_accepted_time before serialization

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -749,6 +749,11 @@ class SteveJobs:
                     job_config=job_config,
                     update_feedback_time=lambda t: statuses_check_feedback.append(t),
                 )
+
+                # Set time when the task was accepted
+                if not self.event.task_accepted_time and statuses_check_feedback:
+                    self.event.task_accepted_time = statuses_check_feedback[0]
+
                 if handler_kls in (
                     CoprBuildHandler,
                     TestingFarmHandler,
@@ -1170,9 +1175,6 @@ class SteveJobs:
             logger.error(
                 f"Event {self.event.event_type()} took more than 15s to process.",
             )
-        # set the time when the accepted status was set so that we
-        # can use it later for measurements
-        self.event.task_accepted_time = statuses_check_feedback[0]
 
         response_time = elapsed_seconds(
             begin=self.event.created_at,

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -3449,7 +3449,7 @@ def test_create_tasks_tf_identifier(
     flexmock(celery).should_receive("group").with_args(
         tasks_created * [None],
     ).and_return(flexmock().should_receive("apply_async").mock())
-    statuses_check_feedback = flexmock()
+    statuses_check_feedback = []
     assert tasks_created == len(
         SteveJobs(event).create_tasks(jobs, handler_kls, statuses_check_feedback),
     )


### PR DESCRIPTION
If we set`task_accepted_time` on the Event object before it proceeds to serialization, the value will correctly propagate to the database, and `copr_build_finished_time` should start getting reported again.

Since this code runs in a loop, and new times are getting appended, the last element of the list is used to set the value.