### PR TITLE
Make Fedora CI work on PRs against the `main` branch

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -816,11 +816,14 @@ class DownstreamKojiScratchBuildHandler(
 
     @property
     def dist_git_branch(self) -> str:
-        return (
+        target_branch = (
             self.project.get_pr(self.data.pr_id).target_branch
             if self.data.event_type in (pagure.pr.Comment.event_type(),)
             else self.data.event_dict.get("target_branch")
         )
+        if target_branch == "main":
+            return "rawhide"
+        return target_branch
 
     @staticmethod
     def get_checkers() -> tuple[type[Checker], ...]:


### PR DESCRIPTION
This will make status checks have `rawhide` in the description rather than `main`, but hopefully that's fine, I'm afraid implementing it the other way would be rather complex, if even possible.

See e.g.: https://src.fedoraproject.org/rpms/python-specfile/pull-request/718
