### PR TITLE
Trigger Log Detective for failed downstream Koji builds

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -19,6 +19,7 @@ from yaml import safe_load
 
 from packit_service.constants import (
     CONFIG_FILE_NAME,
+    LOGDETECTIVE_PACKIT_SERVER_URL,
     SANDCASTLE_DEFAULT_PROJECT,
     SANDCASTLE_IMAGE,
     SANDCASTLE_PVC,
@@ -108,6 +109,8 @@ class ServiceConfig(Config):
         appcode: Optional[str] = None,
         enabled_projects_for_fedora_ci: Optional[Union[set[str], list[str]]] = None,
         rate_limit_threshold: Optional[int] = None,
+        logdetective_enabled: bool = False,
+        logdetective_url: str = LOGDETECTIVE_PACKIT_SERVER_URL,
         **kwargs,
     ):
         if "authentication" in kwargs:
@@ -191,6 +194,12 @@ class ServiceConfig(Config):
         # to the rate-limited queue. If 0 disables moving to rate-limited queue.
         self.rate_limit_threshold = rate_limit_threshold
 
+        # Once the interface server instance is up, we will enable it in stg for tests/debug,
+        # and when we are satisfied with it, then prod.
+        self.logdetective_enabled = logdetective_enabled
+        # Default URL of the Log Detective interface server
+        self.logdetective_url = logdetective_url
+
     service_config = None
 
     def __repr__(self):
@@ -220,7 +229,9 @@ class ServiceConfig(Config):
             f"comment_command_prefix='{self.comment_command_prefix}', "
             f"redhat_api_refresh_token='{hide(self.redhat_api_refresh_token)}', "
             f"package_config_path_override='{self.package_config_path_override}', "
-            f"enabled_projects_for_fedora_ci='{self.enabled_projects_for_fedora_ci}')"
+            f"enabled_projects_for_fedora_ci='{self.enabled_projects_for_fedora_ci}', "
+            f"logdetective_enabled='{self.logdetective_enabled}', "
+            f"logdetective_url='{self.logdetective_url}')"
         )
 
     @classmethod

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -337,3 +337,7 @@ OPEN_SCAN_HUB_FEATURE_DESCRIPTION = (
     "setting `osh_diff_scan_after_copr_build` to `false`. For more information, "
     f"see [docs]({DOCS_URL}/configuration#osh_diff_scan_after_copr_build)."
 )
+
+
+# Default URL of the logdetective-packit interface server for sending the Log Detective requests.
+LOGDETECTIVE_PACKIT_SERVER_URL = "https://logdetective01.fedorainfracloud.org"

--- a/packit_service/worker/handlers/__init__.py
+++ b/packit_service/worker/handlers/__init__.py
@@ -30,7 +30,9 @@ from packit_service.worker.handlers.koji import (
     KojiBuildHandler,
     KojiTaskReportHandler,
 )
-from packit_service.worker.handlers.logdetective import DownstreamLogDetectiveResultsHandler
+from packit_service.worker.handlers.logdetective import (
+    DownstreamLogDetectiveResultsHandler,
+)
 from packit_service.worker.handlers.open_scan_hub import (
     CoprOpenScanHubTaskFinishedHandler,
     CoprOpenScanHubTaskStartedHandler,

--- a/packit_service/worker/handlers/logdetective.py
+++ b/packit_service/worker/handlers/logdetective.py
@@ -12,9 +12,7 @@ from typing import Optional, Union
 from packit.config import JobConfig
 from packit.config.package_config import PackageConfig
 
-from packit_service.events import (
-    logdetective,
-)
+from packit_service.events import logdetective
 from packit_service.models import (
     CoprBuildTargetModel,
     KojiBuildTargetModel,

--- a/packit_service/worker/helpers/logdetective.py
+++ b/packit_service/worker/helpers/logdetective.py
@@ -1,0 +1,108 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+"""
+Helper class for triggering Log Detective from within the koji task handler.
+"""
+
+import logging
+
+import requests
+
+from packit_service.events import koji
+from packit_service.models import (
+    LogDetectiveBuildSystem,
+    LogDetectiveResult,
+    LogDetectiveRunGroupModel,
+    LogDetectiveRunModel,
+)
+from packit_service.worker.monitoring import Pushgateway
+
+logger = logging.getLogger(__name__)
+
+
+class LogDetectiveKojiTriggerHelper:
+    """
+    Trigger Log Detective interface server for an analysis of a failed Downstream Koji build.
+    """
+
+    __test__ = False
+
+    def __init__(self, koji_event: koji.result.Task, pushgateway: Pushgateway, url: str):
+        self.koji_event = koji_event
+        # NOTE: LD analysis currently (Feb 2026) only works for one log file.
+        # Specifically "build.log" for Koji ("builder-live.log" for Copr).
+        # A multi-log analysis support is planned, in which case this will need to be expanded
+        # to include other files, like "mock_output.log", "root.log", etc.
+        self.artifacts = {
+            "build.log": self.koji_event.get_koji_build_logs_url(self.koji_event.task_id),
+        }
+        self.url = url
+        self.pushgateway = pushgateway
+
+    def trigger_log_detective_analysis(self) -> bool:
+        """
+        Gather relevant data and send a request to LogDetective for the failed Koji build.
+        This function assumes that the `self.koji_event` is already in the failed state,
+        and that the `self.koji_event.build_model` is set, and can be directly used.
+
+        Instead of returning TaskResults() object, as job handlers do,
+        we just return a boolean signaling whether or not the trigger succeeded.
+        """
+
+        endpoint_url = f"{self.url}/analyze"
+        request_json = {
+            "artifacts": self.artifacts,
+            "target_build": str(self.koji_event.task_id),
+            "build_system": LogDetectiveBuildSystem.koji.value,
+            "commit_sha": self.koji_event.commit_sha,
+            "project_url": self.koji_event.project_url,
+            "pr_id": self.koji_event.pr_id,
+        }
+
+        try:
+            response = requests.post(endpoint_url, json=request_json, timeout=30)
+            response.raise_for_status()
+        except (requests.exceptions.HTTPError, requests.exceptions.RequestException) as e:
+            msg = f"Failed to get response from Log Detective: {e}"
+            logger.warning(msg, exc_info=True)
+            return False
+
+        try:
+            data = response.json()
+            analysis_id = data.get("log_detective_analysis_id")
+            analysis_start = data.get("creation_time")
+            if analysis_id is None:
+                logger.warning("Log Detective response is missing log_detective_analysis_id")
+                return False
+            if analysis_start is None:
+                logger.warning("Log Detective response is missing creation_time")
+                return False
+        except requests.exceptions.JSONDecodeError as e:
+            msg = f"Failed to parse Log Detective response: {e}"
+            logger.warning(msg, exc_info=True)
+            return False
+
+        self.pushgateway.log_detective_runs_started.inc()
+
+        build_target = self.koji_event.build_model
+
+        pipelines = build_target.group_of_targets.runs
+        group_run = LogDetectiveRunGroupModel.create(pipelines)
+
+        LogDetectiveRunModel.create(
+            LogDetectiveResult.running,
+            str(self.koji_event.task_id),
+            self.koji_event.target,
+            LogDetectiveBuildSystem.koji,
+            analysis_id,
+            group_run,
+        )
+
+        build_target.add_log_detective_run(analysis_id)
+
+        logger.info(
+            f"Successfully triggered Log Detective at {analysis_start}"
+            f" for a failed Koji build {self.koji_event.task_id}"
+        )
+        return True

--- a/tests/integration/test_logdetective_koji.py
+++ b/tests/integration/test_logdetective_koji.py
@@ -1,0 +1,103 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+"""
+Integration tests for Log Detective with Koji builds.
+"""
+
+import pytest
+import requests
+from flexmock import Mock, flexmock
+from packit.config.common_package_config import Deployment
+
+from packit_service.config import ServiceConfig
+from packit_service.constants import LOGDETECTIVE_PACKIT_SERVER_URL
+from packit_service.events import koji
+from packit_service.models import (
+    KojiBuildTargetModel,
+    LogDetectiveRunGroupModel,
+    LogDetectiveRunModel,
+)
+from packit_service.worker.monitoring import Pushgateway
+from packit_service.worker.reporting import StatusReporter
+from packit_service.worker.tasks import run_downstream_koji_scratch_build_report_handler
+from tests.spellbook import first_dict_value
+
+
+@pytest.fixture
+def koji_scratch_build_fixture(build_successful):
+    return {
+        "task_id": 12345,
+        "state": "CLOSED" if build_successful else "FAILED",
+        "old_state": "OPEN",
+        "rpm_build_task_ids": {"x86_64": 123456, "noarch": 123457},
+        "start_time": 1767225600,
+        "completion_time": 1767225600 + 7200,
+    }
+
+
+@pytest.mark.parametrize("build_successful", [True, False])
+def test_logdetective_koji_build_scratch_downstream(
+    build_successful,
+    koji_scratch_build_fixture,
+    koji_build_pr_downstream: Mock,
+):
+    """
+    Failed downstream Koji build triggers Log Detective.
+    This tests the full flow: message => handler => helper => external calls.
+    """
+
+    service_config = flexmock(
+        logdetective_enabled=True,
+        logdetective_url=LOGDETECTIVE_PACKIT_SERVER_URL,
+        koji_logs_url="https://kojipkgs.fedoraproject.org",
+        deployment=Deployment.prod,
+    )
+
+    flexmock(ServiceConfig).should_receive("get_service_config").and_return(service_config)
+
+    koji_build_pr_downstream.target = "rawhide"
+    flexmock(koji.result.Task).should_receive("get_packages_config").and_return(None)
+    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").and_return(
+        koji_build_pr_downstream
+    )
+
+    koji_build_pr_downstream.should_receive("set_build_start_time").once()
+    koji_build_pr_downstream.should_receive("set_build_finished_time").once()
+    koji_build_pr_downstream.should_receive("set_status").with_args(
+        "success" if build_successful else "failure"
+    ).once()
+    koji_build_pr_downstream.should_receive("set_build_logs_urls").once()
+    koji_build_pr_downstream.should_receive("set_web_url").once()
+
+    flexmock(StatusReporter).should_receive("set_status").and_return().once()
+
+    if not build_successful:
+        mock_ld_response = flexmock(status_code=200)
+        mock_ld_response.should_receive("raise_for_status")
+        mock_ld_response.should_receive("json").and_return(
+            {
+                "log_detective_analysis_id": "test-analysis-id-123",
+                "creation_time": "2026-01-01T12:00:00Z",
+            }
+        )
+        flexmock(requests).should_receive("post").and_return(mock_ld_response)
+
+    ld_calls = 0 if build_successful else 1
+    mock_group_run = flexmock(id=1)
+    flexmock(LogDetectiveRunGroupModel).should_receive("create").times(ld_calls).and_return(
+        mock_group_run
+    )
+    flexmock(LogDetectiveRunModel).should_receive("create").times(ld_calls)
+
+    pushgateway = flexmock(log_detective_runs_started=flexmock())
+    pushgateway.log_detective_runs_started.should_receive("inc").times(ld_calls).and_return()
+    pushgateway.should_receive("push").and_return()
+    flexmock(Pushgateway).new_instances(pushgateway)
+
+    koji_build_pr_downstream.should_receive("add_log_detective_run").times(ld_calls)
+
+    results = run_downstream_koji_scratch_build_report_handler(
+        koji_scratch_build_fixture, None, None
+    )
+    assert first_dict_value(results["job"])["success"]

--- a/tests/unit/test_logdetective_koji_helper.py
+++ b/tests/unit/test_logdetective_koji_helper.py
@@ -1,0 +1,273 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+"""
+Unit tests for LogDetectiveKojiTriggerHelper class.
+"""
+
+import pytest
+import requests
+from flexmock import flexmock
+
+from packit_service.constants import LOGDETECTIVE_PACKIT_SERVER_URL, KojiTaskState
+from packit_service.models import (
+    LogDetectiveBuildSystem,
+    LogDetectiveResult,
+    LogDetectiveRunGroupModel,
+    LogDetectiveRunModel,
+)
+from packit_service.worker.helpers.logdetective import (
+    LogDetectiveKojiTriggerHelper,
+    logger,
+)
+
+
+@pytest.fixture
+def mock_pushgateway_log_detective_inc():
+    pushgateway = flexmock()
+    pushgateway.log_detective_runs_started = flexmock()
+    pushgateway.log_detective_runs_started.should_receive("inc").once()
+    pushgateway.should_receive("push").and_return()
+    return pushgateway
+
+
+@pytest.fixture
+def mock_pushgateway_log_detective_no_inc():
+    pushgateway = flexmock()
+    pushgateway.log_detective_runs_started = flexmock()
+    pushgateway.log_detective_runs_started.should_receive("inc").never()
+    pushgateway.should_receive("push").never()
+    return pushgateway
+
+
+@pytest.fixture
+def mock_koji_task_failed_event():
+    mock_group = flexmock(runs=[flexmock()])
+    mock_build_model = flexmock(group_of_targets=mock_group)
+
+    event = flexmock(
+        task_id=12345,
+        state=KojiTaskState.failed,
+        old_state=KojiTaskState.open,
+        commit_sha="abc123",
+        project_url="https://github.com/test/repo",
+        pr_id=42,
+        target="fedora-rawhide-x86_64",
+        build_model=mock_build_model,
+    )
+
+    event.should_receive("get_koji_build_logs_url").with_args(12345).and_return(
+        "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/build.log"
+    )
+    return event
+
+
+def test_logdetective_koji_init_sets_artifacts_correctly(mock_koji_task_failed_event):
+    helper = LogDetectiveKojiTriggerHelper(
+        mock_koji_task_failed_event,
+        flexmock(),
+        LOGDETECTIVE_PACKIT_SERVER_URL,
+    )
+
+    assert "build.log" in helper.artifacts
+    assert (
+        helper.artifacts["build.log"]
+        == "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/build.log"
+    )
+
+
+def test_logdetective_koji_success(mock_koji_task_failed_event, mock_pushgateway_log_detective_inc):
+    mock_response = flexmock(status_code=200)
+    mock_response.should_receive("raise_for_status")
+    mock_response.should_receive("json").and_return(
+        {
+            "log_detective_analysis_id": "test-uuid-123",
+            "creation_time": "2026-01-01T12:00:00",
+        }
+    )
+
+    flexmock(requests).should_receive("post").with_args(
+        f"{LOGDETECTIVE_PACKIT_SERVER_URL}/analyze",
+        json={
+            "artifacts": {
+                "build.log": "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/build.log"
+            },
+            "target_build": "12345",
+            "build_system": LogDetectiveBuildSystem.koji.value,
+            "commit_sha": "abc123",
+            "project_url": "https://github.com/test/repo",
+            "pr_id": 42,
+        },
+        timeout=30,
+    ).once().and_return(mock_response)
+
+    mock_group_run = flexmock()
+    flexmock(LogDetectiveRunGroupModel).should_receive("create").once().and_return(mock_group_run)
+    flexmock(LogDetectiveRunModel).should_receive("create").with_args(
+        LogDetectiveResult.running,
+        "12345",
+        "fedora-rawhide-x86_64",
+        LogDetectiveBuildSystem.koji,
+        "test-uuid-123",
+        mock_group_run,
+    ).once()
+
+    mock_koji_task_failed_event.build_model.should_receive("add_log_detective_run").with_args(
+        "test-uuid-123"
+    ).once()
+
+    flexmock(logger).should_receive("info").with_args(
+        "Successfully triggered Log Detective at 2026-01-01T12:00:00 for a failed Koji build 12345"
+    ).once()
+    flexmock(logger).should_call("warning").never()
+    flexmock(logger).should_call("error").never()
+
+    helper = LogDetectiveKojiTriggerHelper(
+        mock_koji_task_failed_event,
+        mock_pushgateway_log_detective_inc,
+        LOGDETECTIVE_PACKIT_SERVER_URL,
+    )
+    trigger_success = helper.trigger_log_detective_analysis()
+
+    assert trigger_success
+
+
+def test_logdetective_koji_http_error(
+    mock_koji_task_failed_event, mock_pushgateway_log_detective_no_inc
+):
+    mock_response = flexmock(status_code=500)
+    mock_response.should_receive("raise_for_status")
+
+    flexmock(requests).should_receive("post").and_raise(
+        requests.exceptions.HTTPError("500 Server Error")
+    )
+    flexmock(LogDetectiveRunGroupModel).should_receive("create").never()
+    flexmock(LogDetectiveRunModel).should_receive("create").never()
+    flexmock(logger).should_receive("warning").with_args(
+        "Failed to get response from Log Detective: 500 Server Error", exc_info=True
+    ).once()
+
+    helper = LogDetectiveKojiTriggerHelper(
+        mock_koji_task_failed_event,
+        mock_pushgateway_log_detective_no_inc,
+        LOGDETECTIVE_PACKIT_SERVER_URL,
+    )
+    trigger_success = helper.trigger_log_detective_analysis()
+
+    assert not trigger_success
+
+
+def test_logdetective_koji_connection_error(
+    mock_koji_task_failed_event, mock_pushgateway_log_detective_no_inc
+):
+    mock_response = flexmock()
+    mock_response.should_receive("raise_for_status")
+    flexmock(requests).should_receive("post").and_raise(requests.exceptions.ConnectionError)
+
+    flexmock(LogDetectiveRunGroupModel).should_receive("create").never()
+    flexmock(LogDetectiveRunModel).should_receive("create").never()
+    flexmock(logger).should_receive("warning").once()
+
+    helper = LogDetectiveKojiTriggerHelper(
+        mock_koji_task_failed_event,
+        mock_pushgateway_log_detective_no_inc,
+        LOGDETECTIVE_PACKIT_SERVER_URL,
+    )
+    trigger_success = helper.trigger_log_detective_analysis()
+
+    assert not trigger_success
+
+
+def test_logdetective_koji_json_decode_error(
+    mock_koji_task_failed_event, mock_pushgateway_log_detective_no_inc
+):
+    mock_response = flexmock()
+    mock_response.should_receive("raise_for_status")
+    mock_response.should_receive("json").and_raise(
+        requests.exceptions.JSONDecodeError("Invalid JSON", "", 0)
+    )
+
+    flexmock(requests).should_receive("post").and_return(mock_response)
+    flexmock(LogDetectiveRunGroupModel).should_receive("create").never()
+    flexmock(LogDetectiveRunModel).should_receive("create").never()
+    flexmock(logger).should_receive("warning").once()
+
+    helper = LogDetectiveKojiTriggerHelper(
+        mock_koji_task_failed_event,
+        mock_pushgateway_log_detective_no_inc,
+        LOGDETECTIVE_PACKIT_SERVER_URL,
+    )
+    trigger_success = helper.trigger_log_detective_analysis()
+
+    assert not trigger_success
+
+
+def test_logdetective_koji_timeout(
+    mock_koji_task_failed_event, mock_pushgateway_log_detective_no_inc
+):
+    flexmock(requests).should_receive("post").and_raise(
+        requests.exceptions.Timeout("Request timed out")
+    )
+    flexmock(logger).should_receive("warning").with_args(
+        "Failed to get response from Log Detective: Request timed out",
+        exc_info=True,
+    ).once()
+
+    helper = LogDetectiveKojiTriggerHelper(
+        mock_koji_task_failed_event,
+        mock_pushgateway_log_detective_no_inc,
+        LOGDETECTIVE_PACKIT_SERVER_URL,
+    )
+    trigger_success = helper.trigger_log_detective_analysis()
+
+    assert not trigger_success
+
+
+def test_logdetective_koji_missing_id(
+    mock_koji_task_failed_event, mock_pushgateway_log_detective_no_inc
+):
+    mock_response = flexmock(status_code=200)
+    mock_response.should_receive("raise_for_status")
+    mock_response.should_receive("json").and_return(
+        {
+            "creation_time": "2026-01-01T12:00:00",
+        }
+    )
+    flexmock(requests).should_receive("post").and_return(mock_response)
+    flexmock(logger).should_receive("warning").with_args(
+        "Log Detective response is missing log_detective_analysis_id",
+    ).once()
+
+    helper = LogDetectiveKojiTriggerHelper(
+        mock_koji_task_failed_event,
+        mock_pushgateway_log_detective_no_inc,
+        LOGDETECTIVE_PACKIT_SERVER_URL,
+    )
+    trigger_success = helper.trigger_log_detective_analysis()
+
+    assert not trigger_success
+
+
+def test_logdetective_koji_missing_time(
+    mock_koji_task_failed_event, mock_pushgateway_log_detective_no_inc
+):
+    mock_response = flexmock(status_code=200)
+    mock_response.should_receive("raise_for_status")
+    mock_response.should_receive("json").and_return(
+        {
+            "log_detective_analysis_id": "test-uuid-123",
+        }
+    )
+    flexmock(requests).should_receive("post").and_return(mock_response)
+    flexmock(logger).should_receive("warning").with_args(
+        "Log Detective response is missing creation_time",
+    ).once()
+
+    helper = LogDetectiveKojiTriggerHelper(
+        mock_koji_task_failed_event,
+        mock_pushgateway_log_detective_no_inc,
+        LOGDETECTIVE_PACKIT_SERVER_URL,
+    )
+    trigger_success = helper.trigger_log_detective_analysis()
+
+    assert not trigger_success


### PR DESCRIPTION
This is a complementary handler to the one from https://github.com/packit/packit-service/pull/2905 by @jpodivin 

This handler is supposed to detect changes in (downstream) Koji tasks and if they signal that the build has failed, it creates a json payload, then sends it to a middle-man server (implementation here: https://github.com/fedora-copr/logdetective-packit, the URL itself has not yet been determined) which triggers Log Detective. Additionally, some DB entries for the Log Detective run are also created. Analysis results themselves are then handled in another class. 

RELEASE NOTES BEGIN

Packit can now trigger Log Detective when it detects a failed downstream Koji task.

RELEASE NOTES END
