### PR TITLE
Improving mocks to properly cover new metric and get_rate_limit_remaining method

### DIFF
--- a/tests_openshift/service/conftest.py
+++ b/tests_openshift/service/conftest.py
@@ -96,6 +96,7 @@ def mock_metrics_counters():
     mock_pushgateway.events_processed = mock_counter
     mock_pushgateway.events_not_handled = mock_counter
     mock_pushgateway.events_pre_check_failed = mock_counter
+    mock_pushgateway.rate_limited_tasks_enqueued = mock_counter
 
     # Inject the mock instance
     flexmock(Pushgateway).new_instances(mock_pushgateway)

--- a/tests_openshift/service/test_logdetective.py
+++ b/tests_openshift/service/test_logdetective.py
@@ -128,10 +128,12 @@ def test_logdetective_process_message(
     service_config.deployment = Deployment.prod
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(service_config)
 
+    mock_service = flexmock(instance_url="https://github.com", hostname="github.com")
+    mock_service.should_receive("get_rate_limit_remaining").and_return(10000)
     mock_project = flexmock(
         repo="packit",
         namespace="packit",
-        service=flexmock(instance_url="https://github.com", hostname="github.com"),
+        service=mock_service,
     )
     # Mock retrieving the PR and its target branch
     mock_project.should_receive("get_pr").with_args(123).and_return(flexmock(target_branch="main"))
@@ -280,10 +282,12 @@ def test_logdetective_process_message_error(
     service_config.deployment = Deployment.prod
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(service_config)
 
+    mock_service = flexmock(instance_url="https://github.com", hostname="github.com")
+    mock_service.should_receive("get_rate_limit_remaining").and_return(10000)
     mock_project = flexmock(
         repo="packit",
         namespace="packit",
-        service=flexmock(instance_url="https://github.com", hostname="github.com"),
+        service=mock_service,
     )
     # Mock retrieving the PR and its target branch
     mock_project.should_receive("get_pr").with_args(123).and_return(flexmock(target_branch="main"))


### PR DESCRIPTION
Tests were broken following a modification of the source. Since these tests don't run in CI, issues like this are inevitable.

New mock ensures that the rate limit is properly returned, and that the new metric is handled, including assertion on increment.