### PR TITLE
Fix oc exec syntax for newer Openshift CLI compatibility

### DIFF
--- a/files/scripts/README.md
+++ b/files/scripts/README.md
@@ -7,7 +7,7 @@ You need to login to our OpenShift cluster and list all pods. Use the `allowlist
 List all requests pending approval:
 
 ```
-$ oc exec packit-worker-short-running-0 allowlist.py waiting
+$ oc exec packit-worker-short-running-0 -- allowlist.py waiting
 ```
 
 Use `oc exec -it ...` instead if you also want to approve a namespace from the waiting list and specify the number of namespace to approve.
@@ -17,7 +17,7 @@ Use `oc exec -it ...` instead if you also want to approve a namespace from the w
 In order to add to the allowlist manually:
 
 ```
-$ oc exec -it packit-worker-short-running-0 allowlist.py approve <path_to_namespace>
+$ oc exec -it packit-worker-short-running-0 -- allowlist.py approve <path_to_namespace>
 ```
 
 The `<path_to_namespace>` string should follow the same format which is used in the list of waiting requests, i.e. the domain should be included.
@@ -30,7 +30,7 @@ After approving, close the corresponding issue at [packit-service/notifications]
 List all denied namespaces:
 
 ```
-$ oc exec packit-worker-short-running-0 allowlist.py denied
+$ oc exec packit-worker-short-running-0 -- allowlist.py denied
 ```
 
 ## Denying
@@ -38,7 +38,7 @@ $ oc exec packit-worker-short-running-0 allowlist.py denied
 Denying a user:
 
 ```
-$ oc exec -it packit-worker-short-running-0 allowlist.py deny <path_to_namespace>
+$ oc exec -it packit-worker-short-running-0 -- allowlist.py deny <path_to_namespace>
 ```
 
 ## Removal
@@ -46,7 +46,7 @@ $ oc exec -it packit-worker-short-running-0 allowlist.py deny <path_to_namespace
 Removing a user or from the allowlist:
 
 ```
-$ oc exec -it packit-worker-short-running-0 allowlist.py remove <path_to_namespace>
+$ oc exec -it packit-worker-short-running-0 -- allowlist.py remove <path_to_namespace>
 ```
 
 # Cleaning up the database
@@ -57,12 +57,12 @@ project in order to be able to run the script.
 Then run
 
 ```
-$ oc exec packit-worker-long-running-0 db-cleanup.py
+$ oc exec packit-worker-long-running-0 -- db-cleanup.py
 ```
 
 which removes all data older than a year from the database. It's possible to
 remove even more, by specifying the maximum age of the data:
 
 ```
-$ oc exec packit-worker-long-running-0 db-cleanup.py '6 months'
+$ oc exec packit-worker-long-running-0 -- db-cleanup.py '6 months'
 ```


### PR DESCRIPTION
Update all oc exec commands in documentation to use the required `--` separator, as the old syntax without it was removed.
