### PR TITLE
Renaming time stamp field in API responses

### DIFF
--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -41,7 +41,7 @@ class CoprBuildsList(Resource):
                 "build_id": build.build_id,
                 "status_per_chroot": {},
                 "packit_id_per_chroot": {},
-                "build_submitted_time": optional_timestamp(
+                "submitted_time": optional_timestamp(
                     build_info.submitted_time,
                 ),
                 "web_url": build_info.web_url,
@@ -86,7 +86,7 @@ class CoprBuildItem(Resource):
             "build_id": build.build_id,
             "status": build.status,
             "chroot": build.target,
-            "build_submitted_time": optional_timestamp(build.submitted_time),
+            "submitted_time": optional_timestamp(build.submitted_time),
             "build_start_time": optional_timestamp(build.build_start_time),
             "build_finished_time": optional_timestamp(build.build_finished_time),
             "commit_sha": build.commit_sha,

--- a/packit_service/service/api/koji_builds.py
+++ b/packit_service/service/api/koji_builds.py
@@ -38,7 +38,7 @@ class KojiBuildsList(Resource):
                 "task_id": build.task_id,
                 "scratch": build.scratch,
                 "status": build.status,
-                "build_submitted_time": optional_timestamp(build.submitted_time),
+                "submitted_time": optional_timestamp(build.submitted_time),
                 "chroot": build.target,
                 "web_url": build.web_url,
                 # from old data, sometimes build_logs_url is same and sometimes different to web_url
@@ -90,7 +90,7 @@ class KojiBuildItem(Resource):
             "scratch": build.scratch,
             "build_start_time": optional_timestamp(build.build_start_time),
             "build_finished_time": optional_timestamp(build.build_finished_time),
-            "build_submitted_time": optional_timestamp(build.submitted_time),
+            "submitted_time": optional_timestamp(build.submitted_time),
             "commit_sha": build.commit_sha,
             "web_url": build.web_url,
             # from old data, sometimes build_logs_url is same and sometimes different to web_url

--- a/packit_service/service/api/srpm_builds.py
+++ b/packit_service/service/api/srpm_builds.py
@@ -31,7 +31,7 @@ class SRPMBuildsList(Resource):
                 "srpm_build_id": build.id,
                 "status": build.status,
                 "log_url": get_srpm_build_info_url(build.id),
-                "build_submitted_time": optional_timestamp(build.submitted_time),
+                "submitted_time": optional_timestamp(build.submitted_time),
             }
 
             # It's possible that jobtrigger isn't stored in db
@@ -68,7 +68,7 @@ class SRPMBuildItem(Resource):
 
         build_dict = {
             "status": build.status,
-            "build_submitted_time": optional_timestamp(build.submitted_time),
+            "submitted_time": optional_timestamp(build.submitted_time),
             "build_start_time": optional_timestamp(build.build_start_time),
             "build_finished_time": optional_timestamp(build.build_finished_time),
             "url": build.url,

--- a/tests_openshift/service/test_api.py
+++ b/tests_openshift/service/test_api.py
@@ -38,7 +38,7 @@ def test_copr_builds_list(client, clean_before_and_after, multiple_copr_builds):
     assert response_dict[1]["pr_id"] == SampleValues.pr_id
     assert {len(response_build["status_per_chroot"]) for response_build in response_dict} == {1, 2}
 
-    assert response_dict[1]["build_submitted_time"] is not None
+    assert response_dict[1]["submitted_time"] is not None
     assert response_dict[1]["project_url"] == SampleValues.project_url
 
     # four builds, but three unique build ids
@@ -66,7 +66,7 @@ def test_pagination(client, clean_before_and_after, too_many_copr_builds):
     )
     response_dict_1 = response_1.json
     assert len(list(response_dict_1[1]["status_per_chroot"])) == 2
-    assert response_dict_1[1]["build_submitted_time"] is not None
+    assert response_dict_1[1]["submitted_time"] is not None
     assert len(response_dict_1) == 20  # three builds, but two unique build ids
 
     response_2 = client.get(
@@ -74,7 +74,7 @@ def test_pagination(client, clean_before_and_after, too_many_copr_builds):
     )
     response_dict_2 = response_2.json
     assert len(list(response_dict_2[1]["status_per_chroot"])) == 2
-    assert response_dict_2[1]["build_submitted_time"] is not None
+    assert response_dict_2[1]["submitted_time"] is not None
     assert len(response_dict_2) == 30  # three builds, but two unique build ids
 
 
@@ -87,7 +87,7 @@ def test_detailed_copr_build_info(client, clean_before_and_after, a_copr_build_f
     assert response_dict["build_id"] == SampleValues.build_id
     assert response_dict["status"] == SampleValues.status_pending
     assert response_dict["chroot"] == SampleValues.target
-    assert response_dict["build_submitted_time"] is not None
+    assert response_dict["submitted_time"] is not None
     assert "build_start_time" in response_dict
     assert "build_finished_time" in response_dict
     assert response_dict["commit_sha"] == SampleValues.commit_sha
@@ -119,7 +119,7 @@ def test_koji_builds_list(client, clean_before_and_after, multiple_koji_builds):
     assert response_dict[1]["project_url"] == SampleValues.project_url
     assert response_dict[1]["pr_id"] == SampleValues.pr_id
 
-    assert response_dict[1]["build_submitted_time"] is not None
+    assert response_dict[1]["submitted_time"] is not None
 
     assert {response_build["task_id"] for response_build in response_dict} == {
         build.task_id for build in multiple_koji_builds
@@ -152,7 +152,7 @@ def test_detailed_koji_build_info(client, clean_before_and_after, a_koji_build_f
     assert response_dict["task_id"] == SampleValues.build_id
     assert response_dict["status"] == SampleValues.status_pending
     assert response_dict["chroot"] == SampleValues.target
-    assert response_dict["build_submitted_time"] is not None
+    assert response_dict["submitted_time"] is not None
     assert "build_start_time" in response_dict
     assert "build_finished_time" in response_dict
     assert response_dict["commit_sha"] == SampleValues.commit_sha
@@ -184,7 +184,7 @@ def test_detailed_koji_build_info_non_scratch(
     assert response_dict["task_id"] == SampleValues.build_id
     assert response_dict["status"] == SampleValues.status_pending
     assert response_dict["chroot"] == SampleValues.target
-    assert response_dict["build_submitted_time"] is not None
+    assert response_dict["submitted_time"] is not None
     assert "build_start_time" in response_dict
     assert "build_finished_time" in response_dict
     assert response_dict["commit_sha"] == SampleValues.commit_sha
@@ -243,7 +243,7 @@ def test_srpm_builds_list(client, clean_before_and_after, a_copr_build_for_pr):
     assert response_dict[0]["project_url"] == SampleValues.project_url
     assert response_dict[0]["pr_id"] == SampleValues.pr_id
     assert response_dict[0]["branch_name"] is None  # trigger was PR, not branch push
-    assert response_dict[0]["build_submitted_time"] is not None
+    assert response_dict[0]["submitted_time"] is not None
 
 
 def test_srpm_build_info(
@@ -258,7 +258,7 @@ def test_srpm_build_info(
     response_dict = response.json
 
     assert response_dict["status"] == "success"
-    assert response_dict["build_submitted_time"] is not None
+    assert response_dict["submitted_time"] is not None
     assert "url" in response_dict
     assert response_dict["logs"] is not None
 
@@ -283,7 +283,7 @@ def test_srpm_build_in_copr_info(
     response_dict = response.json
 
     assert response_dict["status"] == "success"
-    assert response_dict["build_submitted_time"] is not None
+    assert response_dict["submitted_time"] is not None
     assert "url" in response_dict
     assert response_dict["logs"] is None
     assert response_dict["copr_build_id"] is not None


### PR DESCRIPTION
I don't think it's necessary, nor wise, to merge this immediately. Since it is change to API and could break integration.

But it would be good to have the PR ready when the time comes.

RELEASE NOTES BEGIN

The `build_submitted_time` of responses from following API endpoints has been renamed to `submitted_time`.

- copr-builds
- copr-builds/<int:id>
- koji-builds
- koji-builds/<int:id>
- srpm-builds
- srpm-builds/<int:id>

RELEASE NOTES END
