### PR TITLE
Fix checking for job's retry state

### DIFF
--- a/packit_service/worker/celery_task.py
+++ b/packit_service/worker/celery_task.py
@@ -39,6 +39,19 @@ class CeleryTask:
         """
         return self.task.max_retries
 
+    def can_retry_for(self, exception: Exception) -> bool:
+        """
+        Check if an exception is retryable based on the task's autoretry_for list.
+
+        Args:
+            exception: The exception to check
+
+        Returns:
+            True if the exception type is in the task's autoretry_for list,
+            False otherwise
+        """
+        return isinstance(exception, tuple(self.task.autoretry_for))
+
     def retry(
         self,
         ex: Optional[Exception] = None,

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -1148,7 +1148,11 @@ class AbstractDownstreamKojiBuildHandler(
                     koji_build_model.set_web_url(web_url)
                     koji_build_model.set_build_submission_stdout(stdout)
             except PackitException as ex:
-                if self.celery_task and not self.celery_task.is_last_try():
+                if (
+                    self.celery_task
+                    and self.celery_task.can_retry_for(ex)
+                    and not self.celery_task.is_last_try()
+                ):
                     kargs = self.celery_task.task.request.kwargs.copy()
                     kargs["koji_group_model_id"] = group.id
                     for model in group.grouped_targets:

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -733,8 +733,10 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         forge_outage_exc = isinstance(ex, OgrNetworkError)
         forge_internal_error = isinstance(ex, GitForgeInternalError)
 
-        if not self.celery_task.is_last_try() and (
-            possible_copr_outage_exc or forge_outage_exc or forge_internal_error
+        if (
+            not self.celery_task.is_last_try()
+            and (possible_copr_outage_exc or forge_outage_exc or forge_internal_error)
+            and self.celery_task.can_retry_for(ex)
         ):
             what_failed = "Copr" if possible_copr_outage_exc else "Git forge"
             max_retries = None

--- a/tests/integration/test_dg_commit.py
+++ b/tests/integration/test_dg_commit.py
@@ -44,6 +44,7 @@ from packit_service.worker.handlers.distgit import DownstreamKojiBuildHandler
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.monitoring import Pushgateway
 from packit_service.worker.tasks import (
+    TaskWithRetry,
     run_downstream_koji_build,
     run_sync_from_downstream_handler,
 )
@@ -575,6 +576,7 @@ def test_downstream_koji_build_failure_issue_created():
         celery_task=flexmock(
             request=flexmock(retries=DEFAULT_RETRY_LIMIT),
             max_retries=DEFAULT_RETRY_LIMIT,
+            autoretry_for=TaskWithRetry.autoretry_for,
         ),
     ).run_job()
 
@@ -699,6 +701,7 @@ def test_downstream_koji_build_failure_issue_comment():
         celery_task=flexmock(
             request=flexmock(retries=DEFAULT_RETRY_LIMIT),
             max_retries=DEFAULT_RETRY_LIMIT,
+            autoretry_for=TaskWithRetry.autoretry_for,
         ),
     ).run_job()
 

--- a/tests/unit/test_bodhi_update_error_msgs.py
+++ b/tests/unit/test_bodhi_update_error_msgs.py
@@ -24,6 +24,7 @@ from packit_service.worker.handlers.bodhi import (
     RetriggerBodhiUpdateHandler,
 )
 from packit_service.worker.handlers.mixin import KojiBuildData
+from packit_service.worker.tasks import TaskWithRetry
 
 
 @pytest.fixture(scope="module")
@@ -146,6 +147,9 @@ def test_pull_request_retrigger_bodhi_update_with_koji_data(
     flexmock(BodhiUpdateTargetModel).should_receive(
         "get_all_successful_or_in_progress_by_nvrs",
     ).and_return(set())
+    task_mock = flexmock(
+        autoretry_for=TaskWithRetry.autoretry_for,
+    )
     flexmock(CeleryTask).should_receive("is_last_try").and_return(True)
-    handler = RetriggerBodhiUpdateHandler(package_config, job_config, data, flexmock())
+    handler = RetriggerBodhiUpdateHandler(package_config, job_config, data, task_mock)
     handler.run()


### PR DESCRIPTION
Since the rate limit related changes, a retryable task does not retry for every exception anymore. We should check if the handled exception is in the autoretry_for list.