### PR TITLE
Fix-copr-builds-race-condition

### DIFF
--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -579,7 +579,11 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 target.set_status(BuildStatus.waiting_for_srpm)
             return group
 
-        group = CoprBuildGroupModel.create(self.run_model)
+        # Fallback to job_config.package if get_package_name() returns None
+        handler_package_name = self.get_package_name() or self.job_config.package
+        group, self.run_model = CoprBuildGroupModel.create(
+            self.run_model, package_name=handler_package_name
+        )
         unprocessed_chroots = []
         for chroot in self.build_targets:
             if chroot not in self.available_chroots:

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -295,7 +295,7 @@ def test_run_copr_build_from_source_script(github_pr_event, srpm_build_deps):
     flexmock(build).should_receive("set_web_url")
     group = flexmock(id=1, grouped_targets=4 * [build])
     flexmock(CoprBuildTargetModel).should_receive("create").and_return(build)
-    flexmock(CoprBuildGroupModel).should_receive("create").and_return(group)
+    flexmock(CoprBuildGroupModel).should_receive("create").and_return((group, flexmock()))
     flexmock(CoprBuildTargetModel).should_receive("create").and_return(build).times(4)
     flexmock(github.pr.Action).should_receive("db_project_object").and_return(
         flexmock(),
@@ -447,7 +447,7 @@ def test_run_copr_build_from_source_script_github_outage_retry(
             BuildStatus.waiting_for_srpm,
         )
     else:
-        flexmock(CoprBuildGroupModel).should_receive("create").and_return(group)
+        flexmock(CoprBuildGroupModel).should_receive("create").and_return((group, flexmock()))
 
     if retry:
         flexmock(CeleryTask).should_receive("retry").with_args(

--- a/tests_openshift/conftest.py
+++ b/tests_openshift/conftest.py
@@ -670,7 +670,7 @@ def different_issue_model(different_issue_project_event_model):
 @pytest.fixture()
 def a_copr_build_for_pr(srpm_build_model_with_new_run_for_pr):
     _, run_model = srpm_build_model_with_new_run_for_pr
-    group = CoprBuildGroupModel.create(run_model)
+    group, _ = CoprBuildGroupModel.create(run_model)
     copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         project_name=SampleValues.project,
@@ -692,7 +692,7 @@ def a_copr_build_for_pr_different_commit(
     srpm_build_model_with_new_run_for_pr_different_commit,
 ):
     _, run_model = srpm_build_model_with_new_run_for_pr_different_commit
-    group = CoprBuildGroupModel.create(run_model)
+    group, _ = CoprBuildGroupModel.create(run_model)
     copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         project_name=SampleValues.project,
@@ -712,7 +712,7 @@ def a_copr_build_for_pr_different_commit(
 @pytest.fixture()
 def a_copr_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
     _, run_model = srpm_build_model_with_new_run_for_branch
-    group = CoprBuildGroupModel.create(run_model)
+    group, _ = CoprBuildGroupModel.create(run_model)
     copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         project_name=SampleValues.project,
@@ -731,7 +731,7 @@ def a_copr_build_for_branch_push(srpm_build_model_with_new_run_for_branch):
 @pytest.fixture()
 def a_copr_build_for_release(srpm_build_model_with_new_run_for_release):
     _, run_model = srpm_build_model_with_new_run_for_release
-    group = CoprBuildGroupModel.create(run_model)
+    group, _ = CoprBuildGroupModel.create(run_model)
     copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         project_name=SampleValues.project,
@@ -750,7 +750,7 @@ def a_copr_build_for_release(srpm_build_model_with_new_run_for_release):
 @pytest.fixture()
 def a_copr_build_waiting_for_srpm(srpm_build_in_copr_model):
     _, run_model = srpm_build_in_copr_model
-    group = CoprBuildGroupModel.create(run_model)
+    group, _ = CoprBuildGroupModel.create(run_model)
     copr_build_model = CoprBuildTargetModel.create(
         build_id=SampleValues.build_id,
         project_name=SampleValues.project,
@@ -772,15 +772,15 @@ def multiple_copr_builds(pr_project_event_model, different_pr_project_event_mode
     _, run_model_for_pr = SRPMBuildModel.create_with_new_run(
         project_event_model=pr_project_event_model,
     )
-    group_for_pr = CoprBuildGroupModel.create(run_model_for_pr)
+    group_for_pr, _ = CoprBuildGroupModel.create(run_model_for_pr)
     _, run_model_for_same_pr = SRPMBuildModel.create_with_new_run(
         project_event_model=pr_project_event_model,
     )
-    group_for_same_pr = CoprBuildGroupModel.create(run_model_for_same_pr)
+    group_for_same_pr, _ = CoprBuildGroupModel.create(run_model_for_same_pr)
     _, run_model_for_a_different_pr = SRPMBuildModel.create_with_new_run(
         project_event_model=different_pr_project_event_model,
     )
-    group_for_a_different_pr = CoprBuildGroupModel.create(run_model_for_a_different_pr)
+    group_for_a_different_pr, _ = CoprBuildGroupModel.create(run_model_for_a_different_pr)
 
     yield [
         # Two chroots for one run model
@@ -833,11 +833,11 @@ def too_many_copr_builds(pr_project_event_model, different_pr_project_event_mode
         _, run_model_for_pr = SRPMBuildModel.create_with_new_run(
             project_event_model=pr_project_event_model,
         )
-        group_for_pr = CoprBuildGroupModel.create(run_model_for_pr)
+        group_for_pr, _ = CoprBuildGroupModel.create(run_model_for_pr)
         _, run_model_for_same_pr = SRPMBuildModel.create_with_new_run(
             project_event_model=pr_project_event_model,
         )
-        group_for_same_pr = CoprBuildGroupModel.create(run_model_for_same_pr)
+        group_for_same_pr, _ = CoprBuildGroupModel.create(run_model_for_same_pr)
         _, run_model_for_a_different_pr = SRPMBuildModel.create_with_new_run(
             project_event_model=different_pr_project_event_model,
         )
@@ -895,7 +895,7 @@ def copr_builds_for_filtering(pr_project_event_model):
     _, run_model = SRPMBuildModel.create_with_new_run(
         project_event_model=pr_project_event_model,
     )
-    group = CoprBuildGroupModel.create(run_model)
+    group, _ = CoprBuildGroupModel.create(run_model)
     builds_list = []
 
     # Build without build_id - should be filtered out
@@ -988,9 +988,9 @@ def copr_builds_with_different_triggers(
     _, run_model_for_pr = srpm_build_model_with_new_run_for_pr
     _, run_model_for_branch = srpm_build_model_with_new_run_for_branch
     _, run_model_for_release = srpm_build_model_with_new_run_for_release
-    group_for_pr = CoprBuildGroupModel.create(run_model_for_pr)
-    group_for_branch = CoprBuildGroupModel.create(run_model_for_branch)
-    group_for_release = CoprBuildGroupModel.create(run_model_for_release)
+    group_for_pr, _ = CoprBuildGroupModel.create(run_model_for_pr)
+    group_for_branch, _ = CoprBuildGroupModel.create(run_model_for_branch)
+    group_for_release, _ = CoprBuildGroupModel.create(run_model_for_release)
 
     yield [
         # pull request trigger
@@ -1195,16 +1195,16 @@ def multiple_new_test_runs(pr_project_event_model, different_pr_project_event_mo
         project_event_model=pr_project_event_model,
     )
     test_group_for_pr = TFTTestRunGroupModel.create(run_model_for_pr, ranch="public")
-    build_group_for_pr = CoprBuildGroupModel.create(run_model_for_pr)
+    build_group_for_pr, _ = CoprBuildGroupModel.create(run_model_for_pr)
     _, run_model_for_same_pr = SRPMBuildModel.create_with_new_run(
         project_event_model=pr_project_event_model,
     )
     test_group_for_same_pr = TFTTestRunGroupModel.create(run_model_for_same_pr, ranch="public")
-    build_group_for_same_pr = CoprBuildGroupModel.create(run_model_for_same_pr)
+    build_group_for_same_pr, _ = CoprBuildGroupModel.create(run_model_for_same_pr)
     _, run_model_for_a_different_pr = SRPMBuildModel.create_with_new_run(
         project_event_model=different_pr_project_event_model,
     )
-    build_group_for_a_different_pr = CoprBuildGroupModel.create(
+    build_group_for_a_different_pr, _ = CoprBuildGroupModel.create(
         run_model_for_a_different_pr,
     )
     test_group_for_different_pr = TFTTestRunGroupModel.create(
@@ -2359,7 +2359,7 @@ def few_runs(pr_project_event_model, different_pr_project_event_model):
     _, run_model_for_pr = SRPMBuildModel.create_with_new_run(
         project_event_model=pr_project_event_model,
     )
-    build_group = CoprBuildGroupModel.create(run_model_for_pr)
+    build_group, _ = CoprBuildGroupModel.create(run_model_for_pr)
     TFTTestRunGroupModel.create(run_model_for_pr, ranch="public")
 
     for target in (SampleValues.target, SampleValues.different_target):
@@ -2385,7 +2385,7 @@ def few_runs(pr_project_event_model, different_pr_project_event_model):
         project_event_model=different_pr_project_event_model,
     )
     TFTTestRunGroupModel.create(run_model_for_different_pr, ranch="public")
-    build_group = CoprBuildGroupModel.create(run_model_for_different_pr)
+    build_group, _ = CoprBuildGroupModel.create(run_model_for_different_pr)
 
     runs = []
     for target in (SampleValues.target, SampleValues.different_target):

--- a/tests_openshift/database/test_models.py
+++ b/tests_openshift/database/test_models.py
@@ -427,7 +427,7 @@ def test_copr_get_all_by_ordering_by_id_desc(clean_before_and_after, pr_project_
     Ordering by id DESC ensures we get the latest build (highest id) first.
     """
     _, run_model_1 = SRPMBuildModel.create_with_new_run(project_event_model=pr_project_event_model)
-    group_1 = CoprBuildGroupModel.create(run_model_1)
+    group_1, _ = CoprBuildGroupModel.create(run_model_1)
     build_1 = CoprBuildTargetModel.create(
         build_id="9931733",  # Lower build_id, but created first (lower id)
         project_name=SampleValues.project,
@@ -439,7 +439,7 @@ def test_copr_get_all_by_ordering_by_id_desc(clean_before_and_after, pr_project_
     )
 
     _, run_model_2 = SRPMBuildModel.create_with_new_run(project_event_model=pr_project_event_model)
-    group_2 = CoprBuildGroupModel.create(run_model_2)
+    group_2, _ = CoprBuildGroupModel.create(run_model_2)
     build_2 = CoprBuildTargetModel.create(
         build_id="10020464",  # Higher build_id, created second (higher id)
         project_name=SampleValues.project,
@@ -520,7 +520,7 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
     srpm_build_for_copr, run_model_for_copr = SRPMBuildModel.create_with_new_run(
         project_event_model=project_event,
     )
-    copr_group = CoprBuildGroupModel.create(run_model_for_copr)
+    copr_group, _ = CoprBuildGroupModel.create(run_model_for_copr)
     srpm_build_for_copr.set_logs("asd\nqwe\n")
     srpm_build_for_copr.set_status(BuildStatus.success)
 
@@ -1276,7 +1276,7 @@ def test_create_koji_tag_request(clean_before_and_after, a_koji_tag_request):
 
 def test_copr_get_running(clean_before_and_after, pr_model, srpm_build_model_with_new_run_for_pr):
     _, run_model = srpm_build_model_with_new_run_for_pr
-    group = CoprBuildGroupModel.create(run_model=run_model)
+    group, _ = CoprBuildGroupModel.create(run_model=run_model)
 
     for build_id, target, status in (
         ("1", "fedora-rawhide-x86_64", BuildStatus.pending),

--- a/tests_openshift/database/test_tasks.py
+++ b/tests_openshift/database/test_tasks.py
@@ -85,7 +85,7 @@ def packit_build_752():
     srpm_build, run_model = SRPMBuildModel.create_with_new_run(
         project_event_model=pr_event,
     )
-    group = CoprBuildGroupModel.create(run_model)
+    group, _ = CoprBuildGroupModel.create(run_model)
     srpm_build.set_logs("asd\nqwe\n")
     srpm_build.set_status("success")
     yield CoprBuildTargetModel.create(
@@ -307,7 +307,7 @@ def test_testing_farm_race_condition_concurrent_identifiers(
     _, run_model = SRPMBuildModel.create_with_new_run(
         project_event_model=project_event,
     )
-    copr_build_group = CoprBuildGroupModel.create(run_model)
+    copr_build_group, _ = CoprBuildGroupModel.create(run_model)
 
     # Create copr build with specific build_id
     # The commit_sha is already set in the project_event we created above

--- a/tests_openshift/service/test_logdetective.py
+++ b/tests_openshift/service/test_logdetective.py
@@ -65,7 +65,7 @@ def test_logdetective_process_message(
 
     if build_system == LogDetectiveBuildSystem.copr:
         # The .create() method handles the logic of attaching to the pipeline
-        build_group = CoprBuildGroupModel.create(run_model=pipeline)
+        build_group, _ = CoprBuildGroupModel.create(run_model=pipeline)
 
         build = CoprBuildTargetModel.create(
             build_id=logdetective_analysis_success_event["target_build"],
@@ -218,7 +218,7 @@ def test_logdetective_process_message_error(
     # The .create() method handles the logic of attaching to the pipeline
     if build_system == LogDetectiveBuildSystem.copr:
         # The .create() method handles the logic of attaching to the pipeline
-        build_group = CoprBuildGroupModel.create(run_model=pipeline)
+        build_group, _ = CoprBuildGroupModel.create(run_model=pipeline)
 
         build = CoprBuildTargetModel.create(
             build_id=logdetective_analysis_error_event["target_build"],


### PR DESCRIPTION
It fixes the race condition triggered by the unit test created in the previous commit.

RELEASE NOTES BEGIN

We have fixed a race condition that prevented copr builds to being reported as complete.

RELEASE NOTES END
