### PR TITLE
Add fedora ci checks using the shared repo

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1510,6 +1510,24 @@ class DownstreamTestingFarmJobHelper:
         }
         return payload
 
+    # TODO: this placeholder would no longer be needed if all the other tests
+    #  are defined in it. It requires splitting the check status for each plan
+    #  and restarting individual plans (either from this shared or custom)
+    @implements_fedora_ci_test("shared")
+    def _payload_shared(self, distro: str, compose: str) -> dict:
+        git_repo = "https://forge.fedoraproject.org/ci/shared-tests"
+        git_ref = "main"
+        # The shared plans will define their own provision steps, requiring
+        # compose to be turned off.
+        payload = self._get_tf_base_payload(distro, None)
+        payload["test"] = {
+            "tmt": {
+                "url": git_repo,
+                "ref": git_ref,
+            },
+        }
+        return payload
+
     @staticmethod
     def is_fmf_configured(project: GitProject, metadata: EventData) -> bool:
         try:


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Allow the shared checks to be empty (no plans run, which will happen on `prod` until we switch the sources of the tests)

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to #2914 

<!-- release notes footer -->

RELEASE NOTES BEGIN

Added the plans from [forge.fp.o/ci/shared-tests](https://forge.fedoraproject.org/ci/shared-tests). These plans
are currently only run in the `stg` deployment, and additional tests will appear first gated by the `stg` deployment.

RELEASE NOTES END
