### PR TITLE
Send token together with request for Log Detective analysis

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -113,6 +113,7 @@ class ServiceConfig(Config):
         rate_limit_threshold: Optional[int] = None,
         logdetective_enabled: bool = False,
         logdetective_url: str = LOGDETECTIVE_PACKIT_SERVER_URL,
+        logdetective_secret: str = "",
         **kwargs,
     ):
         if "authentication" in kwargs:
@@ -211,6 +212,8 @@ class ServiceConfig(Config):
         self.logdetective_enabled = logdetective_enabled
         # Default URL of the Log Detective interface server
         self.logdetective_url = logdetective_url
+        # Token to be used with Log Detective interface server
+        self.logdetective_secret = logdetective_secret
 
     service_config = None
 

--- a/packit_service/schema.py
+++ b/packit_service/schema.py
@@ -87,6 +87,9 @@ class ServiceConfigSchema(UserConfigSchema):
     rate_limit_threshold = fields.Integer(missing=None)
     fedora_ci_run_by_default = fields.Bool(missing=False)
     disabled_projects_for_fedora_ci = fields.List(fields.String())
+    logdetective_enabled = fields.Bool(missing=False, default=False)
+    logdetective_url = fields.String()
+    logdetective_secret = fields.String()
 
     @post_load
     def make_instance(self, data, **kwargs):

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -367,7 +367,10 @@ class KojiTaskReportDownstreamHandler(AbstractKojiTaskReportHandler, FedoraCIJob
             return
         logger.info("Triggering Log Detective Helper for a failed Koji build")
         log_detective_trigger = LogDetectiveKojiTriggerHelper(
-            self.koji_task_event, self.pushgateway, self.service_config.logdetective_url
+            self.koji_task_event,
+            self.pushgateway,
+            self.service_config.logdetective_url,
+            self.service_config.logdetective_secret,
         )
         trigger_success = log_detective_trigger.trigger_log_detective_analysis()
         if not trigger_success:

--- a/packit_service/worker/helpers/logdetective.py
+++ b/packit_service/worker/helpers/logdetective.py
@@ -28,7 +28,13 @@ class LogDetectiveKojiTriggerHelper:
 
     __test__ = False
 
-    def __init__(self, koji_event: koji.result.Task, pushgateway: Pushgateway, url: str):
+    def __init__(
+        self,
+        koji_event: koji.result.Task,
+        pushgateway: Pushgateway,
+        url: str,
+        logdetective_token: str,
+    ):
         self.koji_event = koji_event
         # NOTE: LD analysis currently (Feb 2026) only works for one log file.
         # Specifically "build.log" for Koji ("builder-live.log" for Copr).
@@ -39,6 +45,7 @@ class LogDetectiveKojiTriggerHelper:
         }
         self.url = url
         self.pushgateway = pushgateway
+        self.token = logdetective_token
 
     def trigger_log_detective_analysis(self) -> bool:
         """
@@ -61,7 +68,12 @@ class LogDetectiveKojiTriggerHelper:
         }
 
         try:
-            response = requests.post(endpoint_url, json=request_json, timeout=30)
+            response = requests.post(
+                endpoint_url,
+                json=request_json,
+                timeout=30,
+                headers={"Authorization": f"Bearer {self.token}"},
+            )
             response.raise_for_status()
         except (requests.exceptions.HTTPError, requests.exceptions.RequestException) as e:
             msg = f"Failed to get response from Log Detective: {e}"

--- a/tests/integration/test_logdetective_koji.py
+++ b/tests/integration/test_logdetective_koji.py
@@ -52,6 +52,7 @@ def test_logdetective_koji_build_scratch_downstream(
         logdetective_url=LOGDETECTIVE_PACKIT_SERVER_URL,
         koji_logs_url="https://kojipkgs.fedoraproject.org",
         deployment=Deployment.prod,
+        logdetective_secret="secret-123",
     )
 
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(service_config)

--- a/tests/unit/test_logdetective_koji_helper.py
+++ b/tests/unit/test_logdetective_koji_helper.py
@@ -67,6 +67,7 @@ def test_logdetective_koji_init_sets_artifacts_correctly(mock_koji_task_failed_e
         mock_koji_task_failed_event,
         flexmock(),
         LOGDETECTIVE_PACKIT_SERVER_URL,
+        "secret-123",
     )
 
     assert "build.log" in helper.artifacts
@@ -99,6 +100,7 @@ def test_logdetective_koji_success(mock_koji_task_failed_event, mock_pushgateway
             "pr_id": 42,
         },
         timeout=30,
+        headers={"Authorization": "Bearer secret-123"},
     ).once().and_return(mock_response)
 
     mock_group_run = flexmock()
@@ -126,6 +128,7 @@ def test_logdetective_koji_success(mock_koji_task_failed_event, mock_pushgateway
         mock_koji_task_failed_event,
         mock_pushgateway_log_detective_inc,
         LOGDETECTIVE_PACKIT_SERVER_URL,
+        "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
@@ -151,6 +154,7 @@ def test_logdetective_koji_http_error(
         mock_koji_task_failed_event,
         mock_pushgateway_log_detective_no_inc,
         LOGDETECTIVE_PACKIT_SERVER_URL,
+        "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
@@ -172,6 +176,7 @@ def test_logdetective_koji_connection_error(
         mock_koji_task_failed_event,
         mock_pushgateway_log_detective_no_inc,
         LOGDETECTIVE_PACKIT_SERVER_URL,
+        "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
@@ -196,6 +201,7 @@ def test_logdetective_koji_json_decode_error(
         mock_koji_task_failed_event,
         mock_pushgateway_log_detective_no_inc,
         LOGDETECTIVE_PACKIT_SERVER_URL,
+        "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
@@ -217,6 +223,7 @@ def test_logdetective_koji_timeout(
         mock_koji_task_failed_event,
         mock_pushgateway_log_detective_no_inc,
         LOGDETECTIVE_PACKIT_SERVER_URL,
+        "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
@@ -242,6 +249,7 @@ def test_logdetective_koji_missing_id(
         mock_koji_task_failed_event,
         mock_pushgateway_log_detective_no_inc,
         LOGDETECTIVE_PACKIT_SERVER_URL,
+        "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
@@ -267,6 +275,7 @@ def test_logdetective_koji_missing_time(
         mock_koji_task_failed_event,
         mock_pushgateway_log_detective_no_inc,
         LOGDETECTIVE_PACKIT_SERVER_URL,
+        "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 


### PR DESCRIPTION
RELEASE NOTES BEGIN

Requests for Log Detective analysis now use token defined in configuration.

RELEASE NOTES END
