### PR TITLE
Cleanup: get_running() methods return query

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -42,7 +42,6 @@ from sqlalchemy import (
     func,
     null,
     or_,
-    select,
 )
 from sqlalchemy.dialects.postgresql import array as psql_array
 from sqlalchemy.ext.declarative import declarative_base
@@ -2176,7 +2175,7 @@ class CoprBuildGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             return session.query(CoprBuildGroupModel).filter_by(id=group_id).first()
 
     @classmethod
-    def get_running(cls, commit_sha: str) -> Iterable[tuple["CoprBuildTargetModel"]]:
+    def get_running(cls, commit_sha: str) -> Iterable["CoprBuildTargetModel"]:
         """Get list of currently running Copr builds matching the passed
         arguments.
 
@@ -2187,20 +2186,19 @@ class CoprBuildGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             An iterable over Copr target models that are curently in queue
             (running) or waiting for an SRPM.
         """
-        q = (
-            select(CoprBuildTargetModel)
-            .join(CoprBuildGroupModel)
-            .join(PipelineModel)
-            .join(ProjectEventModel)
-            .filter(
-                ProjectEventModel.commit_sha == commit_sha,
-                CoprBuildTargetModel.status.in_(
-                    (BuildStatus.pending, BuildStatus.waiting_for_srpm)
-                ),
-            )
-        )
         with sa_session_transaction() as session:
-            return session.execute(q)
+            return (
+                session.query(CoprBuildTargetModel)
+                .join(CoprBuildGroupModel)
+                .join(PipelineModel)
+                .join(ProjectEventModel)
+                .filter(
+                    ProjectEventModel.commit_sha == commit_sha,
+                    CoprBuildTargetModel.status.in_(
+                        (BuildStatus.pending, BuildStatus.waiting_for_srpm)
+                    ),
+                )
+            )
 
 
 class BuildStatus(str, enum.Enum):
@@ -3622,7 +3620,7 @@ class TFTTestRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             return session.query(TFTTestRunGroupModel).filter_by(id=group_id).first()
 
     @classmethod
-    def get_running(cls, commit_sha: str, ranch: str) -> Iterable[tuple["TFTTestRunTargetModel"]]:
+    def get_running(cls, commit_sha: str, ranch: str) -> Iterable["TFTTestRunTargetModel"]:
         """Get list of currently running Testing Farm runs matching the passed
         arguments.
 
@@ -3632,27 +3630,25 @@ class TFTTestRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
 
         Returns:
             An iterable over TFT target models that reprepresent matching TF
-            runs that are _new_ (to be triggered), _queued_ (already submitted
-            to the TF), or _running_.
+            runs that are _queued_ (already submitted to the TF) or _running_.
         """
-        q = (
-            select(TFTTestRunTargetModel)
-            .join(TFTTestRunGroupModel)
-            .join(PipelineModel)
-            .join(ProjectEventModel)
-            .filter(
-                ProjectEventModel.commit_sha == commit_sha,
-                TFTTestRunGroupModel.ranch == ranch,
-                TFTTestRunTargetModel.status.in_(
-                    (
-                        TestingFarmResult.queued,
-                        TestingFarmResult.running,
-                    )
-                ),
-            )
-        )
         with sa_session_transaction() as session:
-            return session.execute(q)
+            return (
+                session.query(TFTTestRunTargetModel)
+                .join(TFTTestRunGroupModel)
+                .join(PipelineModel)
+                .join(ProjectEventModel)
+                .filter(
+                    ProjectEventModel.commit_sha == commit_sha,
+                    TFTTestRunGroupModel.ranch == ranch,
+                    TFTTestRunTargetModel.status.in_(
+                        (
+                            TestingFarmResult.queued,
+                            TestingFarmResult.running,
+                        )
+                    ),
+                )
+            )
 
 
 class TFTTestRunTargetModel(GroupAndTargetModelConnector, Base):
@@ -4932,7 +4928,7 @@ class LogDetectiveRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             return session.query(LogDetectiveRunGroupModel).filter_by(id=group_id).first()
 
     @classmethod
-    def get_running(cls, commit_sha: str) -> Iterable[tuple[LogDetectiveRunModel]]:
+    def get_running(cls, commit_sha: str) -> Iterable[LogDetectiveRunModel]:
         """Get list of currently running Log Detective runs matching the passed
         arguments.
 
@@ -4943,18 +4939,17 @@ class LogDetectiveRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             An iterable over Log Detective run models representing Log Detective runs
             runs that are running.
         """
-        q = (
-            select(LogDetectiveRunModel)
-            .join(LogDetectiveRunGroupModel)
-            .join(PipelineModel)
-            .join(ProjectEventModel)
-            .filter(
-                ProjectEventModel.commit_sha == commit_sha,
-                LogDetectiveRunModel.status == LogDetectiveResult.running,
-            )
-        )
         with sa_session_transaction() as session:
-            return session.execute(q)
+            return (
+                session.query(LogDetectiveRunModel)
+                .join(LogDetectiveRunGroupModel)
+                .join(PipelineModel)
+                .join(ProjectEventModel)
+                .filter(
+                    ProjectEventModel.commit_sha == commit_sha,
+                    LogDetectiveRunModel.status == LogDetectiveResult.running,
+                )
+            )
 
 
 @cached(cache=TTLCache(maxsize=2048, ttl=(60 * 60 * 24)))

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -1023,7 +1023,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
     # it clashes the type checking…
     def get_running_jobs(
         self,
-    ) -> Union[Iterable[tuple["CoprBuildTargetModel"]], Iterable[tuple["TFTTestRunTargetModel"]]]:
+    ) -> Union[Iterable["CoprBuildTargetModel"], Iterable["TFTTestRunTargetModel"]]:
         if sha := self.metadata.commit_sha_before:
             yield from CoprBuildGroupModel.get_running(commit_sha=sha)
 
@@ -1037,12 +1037,12 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
 
         # Cancel unique builds
         unique_builds = {
-            int(build.build_id) for (build,) in running_builds if build.build_id is not None
+            int(build.build_id) for build in running_builds if build.build_id is not None
         }
         for build_id in unique_builds:
             logger.debug("Cancelling Copr build #%s", build_id)
             self.api.copr_helper.cancel_build(build_id)
 
         # Mark them as canceled
-        for (target,) in running_builds:
+        for target in running_builds:
             target.set_status(BuildStatus.canceled)

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1233,7 +1233,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             update_feedback_time=update_feedback_time,
         )
 
-    def get_running_jobs(self) -> Iterable[tuple["TFTTestRunTargetModel"]]:
+    def get_running_jobs(self) -> Iterable["TFTTestRunTargetModel"]:
         if sha := self.metadata.commit_sha_before:
             yield from TFTTestRunGroupModel.get_running(
                 commit_sha=sha, ranch=self.tft_client.default_ranch
@@ -1247,7 +1247,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             logger.info("No running TF tests to cancel.")
             return
 
-        for (test_run,) in running_tests:
+        for test_run in running_tests:
             self.tft_client.cancel(test_run.pipeline_id)
             test_run.set_status(TestingFarmResult.cancel_requested)
 

--- a/tests_openshift/database/test_models.py
+++ b/tests_openshift/database/test_models.py
@@ -1297,7 +1297,7 @@ def test_copr_get_running(clean_before_and_after, pr_model, srpm_build_model_wit
     running = list(CoprBuildGroupModel.get_running(commit_sha=SampleValues.commit_sha))
     assert running, "There are some running builds present"
     assert len(running) == 3, "There are exactly 3 builds running"
-    assert {build.build_id for (build,) in running} == {"1", "2"}, (
+    assert {build.build_id for build in running} == {"1", "2"}, (
         "Exactly ‹1› and ‹2› are in the running state"
     )
 
@@ -1324,7 +1324,7 @@ def test_tmt_get_running(clean_before_and_after, pr_model, srpm_build_model_with
     )
     assert running, "There are some running tests present"
     assert len(running) == 2, "There are exactly 2 tests running"
-    assert {test_run.pipeline_id for (test_run,) in running} == {"cafe", "42"}, (
+    assert {test_run.pipeline_id for test_run in running} == {"cafe", "42"}, (
         "Test runs created by the test are in the running state"
     )
 
@@ -1363,7 +1363,7 @@ def test_tmt_get_running_different_ranches(
     )
     assert running, "There are some running tests present"
     assert len(running) == 2, "There are exactly 2 tests running in the public ranch"
-    assert {test_run.pipeline_id for (test_run,) in running} == {"cafe", "42"}, (
+    assert {test_run.pipeline_id for test_run in running} == {"cafe", "42"}, (
         "Test runs created by the test are in the running state"
     )
 
@@ -1372,7 +1372,7 @@ def test_tmt_get_running_different_ranches(
     )
     assert running, "There are some running tests present"
     assert len(running) == 2, "There are exactly 2 tests running in the redhat ranch"
-    assert {test_run.pipeline_id for (test_run,) in running} == {"cafe-internal", "42-internal"}, (
+    assert {test_run.pipeline_id for test_run in running} == {"cafe-internal", "42-internal"}, (
         "Test runs created by the test are in the running state"
     )
 
@@ -1548,8 +1548,7 @@ def test_log_detective_get_running(clean_before_and_after, srpm_build_model_with
     assert running, "There should be running analysis present"
     assert len(running) == 1, "There is exactly 1 analysis running"
 
-    # get_running returns a list of tuples (LogDetectiveRunModel, )
-    run_model = running[0][0]
+    run_model = running[0]
     assert isinstance(run_model, LogDetectiveRunModel)
     assert run_model.analysis_id == "uuid-1"
 


### PR DESCRIPTION
Makes *.get_running() methods consistent with other model methods that
already return a query. Returns model instances directly instead of
single-element tuples, removing awkward (obj,) unpacking in
all callers.

Resolves: https://github.com/packit/packit-service/issues/3004