### PR TITLE
Filter running jobs by project event instead of commit SHA

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -2176,15 +2176,20 @@ class CoprBuildGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             return session.query(CoprBuildGroupModel).filter_by(id=group_id).first()
 
     @classmethod
-    def get_running(cls, commit_sha: str) -> Iterable[tuple["CoprBuildTargetModel"]]:
-        """Get list of currently running Copr builds matching the passed
-        arguments.
+    def get_running(
+        cls,
+        project_event_type: ProjectEventModelType,
+        event_id: int,
+    ) -> Iterable[tuple["CoprBuildTargetModel"]]:
+        """Get list of currently running Copr builds for a given project object
+        (e.g. a PR or branch).
 
         Args:
-            commit_sha: Commit hash that is used for filtering the running jobs.
+            project_event_type: Type of the project event (e.g. pull_request).
+            event_id: ID of the project object (e.g. PullRequestModel.id).
 
         Returns:
-            An iterable over Copr target models that are curently in queue
+            An iterable over Copr target models that are currently in queue
             (running) or waiting for an SRPM.
         """
         q = (
@@ -2193,7 +2198,8 @@ class CoprBuildGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             .join(PipelineModel)
             .join(ProjectEventModel)
             .filter(
-                ProjectEventModel.commit_sha == commit_sha,
+                ProjectEventModel.type == project_event_type,
+                ProjectEventModel.event_id == event_id,
                 CoprBuildTargetModel.status.in_(
                     (BuildStatus.pending, BuildStatus.waiting_for_srpm)
                 ),
@@ -3622,12 +3628,18 @@ class TFTTestRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             return session.query(TFTTestRunGroupModel).filter_by(id=group_id).first()
 
     @classmethod
-    def get_running(cls, commit_sha: str, ranch: str) -> Iterable[tuple["TFTTestRunTargetModel"]]:
-        """Get list of currently running Testing Farm runs matching the passed
-        arguments.
+    def get_running(
+        cls,
+        project_event_type: ProjectEventModelType,
+        event_id: int,
+        ranch: str,
+    ) -> Iterable[tuple["TFTTestRunTargetModel"]]:
+        """Get list of currently running Testing Farm runs for a given project
+        object (e.g. a PR or branch).
 
         Args:
-            commit_sha: Commit hash that is used for filtering the running jobs.
+            project_event_type: Type of the project event (e.g. pull_request).
+            event_id: ID of the project object (e.g. PullRequestModel.id).
             ranch: Testing Farm ranch where the tests are supposed to be run.
 
         Returns:
@@ -3641,7 +3653,8 @@ class TFTTestRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             .join(PipelineModel)
             .join(ProjectEventModel)
             .filter(
-                ProjectEventModel.commit_sha == commit_sha,
+                ProjectEventModel.type == project_event_type,
+                ProjectEventModel.event_id == event_id,
                 TFTTestRunGroupModel.ranch == ranch,
                 TFTTestRunTargetModel.status.in_(
                     (
@@ -4932,12 +4945,17 @@ class LogDetectiveRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             return session.query(LogDetectiveRunGroupModel).filter_by(id=group_id).first()
 
     @classmethod
-    def get_running(cls, commit_sha: str) -> Iterable[tuple[LogDetectiveRunModel]]:
-        """Get list of currently running Log Detective runs matching the passed
-        arguments.
+    def get_running(
+        cls,
+        project_event_type: ProjectEventModelType,
+        event_id: int,
+    ) -> Iterable[tuple[LogDetectiveRunModel]]:
+        """Get list of currently running Log Detective runs for a given project
+        object (e.g. a PR or branch).
 
         Args:
-            commit_sha: Commit hash that is used for filtering the running jobs.
+            project_event_type: Type of the project event (e.g. pull_request).
+            event_id: ID of the project object (e.g. PullRequestModel.id).
 
         Returns:
             An iterable over Log Detective run models representing Log Detective runs
@@ -4949,7 +4967,8 @@ class LogDetectiveRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             .join(PipelineModel)
             .join(ProjectEventModel)
             .filter(
-                ProjectEventModel.commit_sha == commit_sha,
+                ProjectEventModel.type == project_event_type,
+                ProjectEventModel.event_id == event_id,
                 LogDetectiveRunModel.status == LogDetectiveResult.running,
             )
         )

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -1024,10 +1024,10 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
     def get_running_jobs(
         self,
     ) -> Union[Iterable[tuple["CoprBuildTargetModel"]], Iterable[tuple["TFTTestRunTargetModel"]]]:
-        if sha := self.metadata.commit_sha_before:
-            yield from CoprBuildGroupModel.get_running(commit_sha=sha)
-
-        # [SAFETY] When there's no previous commit hash, yields nothing
+        yield from CoprBuildGroupModel.get_running(
+            project_event_type=self.db_project_event.type,
+            event_id=self.db_project_event.event_id,
+        )
 
     def cancel_running_builds(self):
         running_builds = list(self.get_running_jobs())

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1233,12 +1233,11 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         )
 
     def get_running_jobs(self) -> Iterable[tuple["TFTTestRunTargetModel"]]:
-        if sha := self.metadata.commit_sha_before:
-            yield from TFTTestRunGroupModel.get_running(
-                commit_sha=sha, ranch=self.tft_client.default_ranch
-            )
-
-        # [SAFETY] When there's no previous commit hash, yields nothing
+        yield from TFTTestRunGroupModel.get_running(
+            project_event_type=self.db_project_event.type,
+            event_id=self.db_project_event.event_id,
+            ranch=self.tft_client.default_ranch,
+        )
 
     def cancel_running_tests(self):
         running_tests = list(self.get_running_jobs())

--- a/tests_openshift/database/test_models.py
+++ b/tests_openshift/database/test_models.py
@@ -1274,7 +1274,12 @@ def test_create_koji_tag_request(clean_before_and_after, a_koji_tag_request):
     assert a_koji_tag_request.get_project().project_url == SampleValues.project_url
 
 
-def test_copr_get_running(clean_before_and_after, pr_model, srpm_build_model_with_new_run_for_pr):
+def test_copr_get_running(
+    clean_before_and_after,
+    pr_model,
+    pr_project_event_model,
+    srpm_build_model_with_new_run_for_pr,
+):
     _, run_model = srpm_build_model_with_new_run_for_pr
     group, _ = CoprBuildGroupModel.create(run_model=run_model)
 
@@ -1294,7 +1299,12 @@ def test_copr_get_running(clean_before_and_after, pr_model, srpm_build_model_wit
             copr_build_group=group,
         )
 
-    running = list(CoprBuildGroupModel.get_running(commit_sha=SampleValues.commit_sha))
+    running = list(
+        CoprBuildGroupModel.get_running(
+            project_event_type=pr_project_event_model.type,
+            event_id=pr_project_event_model.event_id,
+        )
+    )
     assert running, "There are some running builds present"
     assert len(running) == 3, "There are exactly 3 builds running"
     assert {build.build_id for (build,) in running} == {"1", "2"}, (
@@ -1302,7 +1312,12 @@ def test_copr_get_running(clean_before_and_after, pr_model, srpm_build_model_wit
     )
 
 
-def test_tmt_get_running(clean_before_and_after, pr_model, srpm_build_model_with_new_run_for_pr):
+def test_tmt_get_running(
+    clean_before_and_after,
+    pr_model,
+    pr_project_event_model,
+    srpm_build_model_with_new_run_for_pr,
+):
     _, run_model = srpm_build_model_with_new_run_for_pr
     group = TFTTestRunGroupModel.create(run_model, ranch="public")
 
@@ -1320,7 +1335,11 @@ def test_tmt_get_running(clean_before_and_after, pr_model, srpm_build_model_with
         )
 
     running = list(
-        TFTTestRunGroupModel.get_running(commit_sha=SampleValues.commit_sha, ranch="public")
+        TFTTestRunGroupModel.get_running(
+            project_event_type=pr_project_event_model.type,
+            event_id=pr_project_event_model.event_id,
+            ranch="public",
+        )
     )
     assert running, "There are some running tests present"
     assert len(running) == 2, "There are exactly 2 tests running"
@@ -1330,7 +1349,10 @@ def test_tmt_get_running(clean_before_and_after, pr_model, srpm_build_model_with
 
 
 def test_tmt_get_running_different_ranches(
-    clean_before_and_after, pr_model, srpm_build_model_with_new_run_for_pr
+    clean_before_and_after,
+    pr_model,
+    pr_project_event_model,
+    srpm_build_model_with_new_run_for_pr,
 ):
     _, run_model = srpm_build_model_with_new_run_for_pr
 
@@ -1359,7 +1381,11 @@ def test_tmt_get_running_different_ranches(
         )
 
     running = list(
-        TFTTestRunGroupModel.get_running(commit_sha=SampleValues.commit_sha, ranch="public")
+        TFTTestRunGroupModel.get_running(
+            project_event_type=pr_project_event_model.type,
+            event_id=pr_project_event_model.event_id,
+            ranch="public",
+        )
     )
     assert running, "There are some running tests present"
     assert len(running) == 2, "There are exactly 2 tests running in the public ranch"
@@ -1368,7 +1394,11 @@ def test_tmt_get_running_different_ranches(
     )
 
     running = list(
-        TFTTestRunGroupModel.get_running(commit_sha=SampleValues.commit_sha, ranch="redhat")
+        TFTTestRunGroupModel.get_running(
+            project_event_type=pr_project_event_model.type,
+            event_id=pr_project_event_model.event_id,
+            ranch="redhat",
+        )
     )
     assert running, "There are some running tests present"
     assert len(running) == 2, "There are exactly 2 tests running in the redhat ranch"
@@ -1508,7 +1538,9 @@ def test_log_detective_run_group_targets(
     assert group.grouped_targets[0] == run_target
 
 
-def test_log_detective_get_running(clean_before_and_after, srpm_build_model_with_new_run_for_pr):
+def test_log_detective_get_running(
+    clean_before_and_after, pr_project_event_model, srpm_build_model_with_new_run_for_pr
+):
     _, run_model = srpm_build_model_with_new_run_for_pr
     group = LogDetectiveRunGroupModel.create([run_model])
 
@@ -1542,8 +1574,12 @@ def test_log_detective_get_running(clean_before_and_after, srpm_build_model_with
         target="",
     )
 
-    # The fixture uses SampleValues.commit_sha ("80201a74d96c")
-    running = list(LogDetectiveRunGroupModel.get_running(SampleValues.commit_sha))
+    running = list(
+        LogDetectiveRunGroupModel.get_running(
+            project_event_type=pr_project_event_model.type,
+            event_id=pr_project_event_model.event_id,
+        )
+    )
 
     assert running, "There should be running analysis present"
     assert len(running) == 1, "There is exactly 1 analysis running"


### PR DESCRIPTION
Not all events carry `commit_sha_before` value (e.g. github.pr.Comment, gitlab.mr.Comment, github.check.Rerun), so cancellation silently does nothing on retriggers.

Resolve this similarly to what Koji builds cancellation does by querying currently running jobs via ProjectEventModel.type + ProjectEventModel.event_id (project object identity — e.g. a specific PR or branch), which works for all event types regardless of forge or trigger method.

Resolves: https://github.com/packit/packit-service/issues/3005