### PR TITLE
Move copr_build_handler to short running queue

### DIFF
--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -279,7 +279,7 @@ def run_copr_build_end_handler(event: dict, package_config: dict, job_config: di
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(bind=True, name=TaskName.copr_build, base=TaskWithRetry, queue="long-running")
+@celery_app.task(bind=True, name=TaskName.copr_build, base=TaskWithRetry)
 def run_copr_build_handler(
     self,
     event: dict,


### PR DESCRIPTION
Looking at Grafana, the copr build handler tasks take less time than the copr build start/end handler tasks. The latter already are in the short running queue.
Also the highest peaks, around 12 minutes, all come from the copr build start/end handlers; the highest peak I saw for the copr build handler in the last 30 days was 4 minutes.

So I think this change is safe.

Fix #2995