### PR TITLE
Handle exceptions in Pushgateway.push() gracefully

### DIFF
--- a/packit_service/worker/monitoring.py
+++ b/packit_service/worker/monitoring.py
@@ -271,8 +271,11 @@ class Pushgateway:
             return
 
         logger.info("Pushing the metrics to pushgateway.")
-        push_to_gateway(
-            self.pushgateway_address,
-            job=self.worker_name,
-            registry=self.registry,
-        )
+        try:
+            push_to_gateway(
+                self.pushgateway_address,
+                job=self.worker_name,
+                registry=self.registry,
+            )
+        except Exception as e:
+            logger.error(f"Failed to push metrics to pushgateway: {e}")

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -6,11 +6,13 @@ import datetime
 import pytest
 from flexmock import flexmock
 
+from packit_service.worker import monitoring
 from packit_service.worker.handlers import (
     CoprBuildHandler,
     TestingFarmHandler,
 )
 from packit_service.worker.jobs import SteveJobs
+from packit_service.worker.monitoring import Pushgateway
 
 
 @pytest.mark.parametrize(
@@ -71,3 +73,17 @@ def test_delayed():
     jobs.pushgateway = pushgateway
 
     jobs.push_statuses_metrics([created_at + datetime.timedelta(seconds=42)])
+
+
+def test_pushgateway_push_error_handled():
+    """Test that exceptions during push_to_gateway are handled gracefully."""
+    flexmock(monitoring).should_receive("push_to_gateway").and_raise(
+        Exception("Pushgateway error")
+    ).once()
+
+    pushgateway = Pushgateway()
+    pushgateway.pushgateway_address = "http://pushgateway"
+    pushgateway.worker_name = "test-worker"
+
+    # Should not raise an exception
+    pushgateway.push()


### PR DESCRIPTION
Catch all exceptions when pushing metrics to the pushgateway to prevent worker disruption. Metrics collection is important for observability but not critical for core functionality - a failing pushgateway should not crash workers or trigger retries that could saturate the system.

Fixes #2934


