### PR TITLE
Fix GitCommentHelpHandler not responding in monorepositories

### DIFF
--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -450,9 +450,7 @@ class JobHandler(Handler):
         return job_results
 
     @classmethod
-    def get_signature(
-        cls, event: Event, job: Optional[JobConfig], package_config_required: Optional[bool] = True
-    ) -> Signature:
+    def get_signature(cls, event: Event, job: Optional[JobConfig]) -> Signature:
         """
         Get the signature of a Celery task which will run the handler.
         https://docs.celeryq.dev/en/stable/userguide/canvas.html#signatures
@@ -466,7 +464,7 @@ class JobHandler(Handler):
                 "package_config": dump_package_config(
                     (
                         event.packages_config.get_package_config_for(job)
-                        if package_config_required and event.packages_config
+                        if job and event.packages_config
                         else None
                     ),
                 ),

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -377,19 +377,7 @@ class SteveJobs:
             handler.get_signature(
                 event=self.event,
                 job=None,
-                package_config_required=False,
             ).apply_async()
-
-            processing_results = [
-                TaskResults.create_from(
-                    success=True,
-                    msg="Job created.",
-                    job_config=None,
-                    event=self.event,
-                    package_config_required=False,
-                ),
-            ]
-
         else:
             if (
                 isinstance(

--- a/packit_service/worker/result.py
+++ b/packit_service/worker/result.py
@@ -34,11 +34,10 @@ class TaskResults(dict):
         msg: str,
         event: Event,
         job_config: JobConfig = None,
-        package_config_required: Optional[bool] = True,
     ):
         package_config = (
             event.packages_config.get_package_config_for(job_config)
-            if event.packages_config and package_config_required
+            if job_config and event.packages_config
             else None
         )
         details = {


### PR DESCRIPTION
This is a simple fix of the issue below. The two edited methods attempt to retrieve package configs, which aren't needed for the help handler. There may be a more elegant solution.

Also, if there is a possibility that `GithubAppInstallationHandler` and `GithubFasVerificationHandler` are ever run in a monorepository, they would possibly be affected by the same issue.

This has been tested locally on a generated Fedora Messaging message generated from a comment, so it should hopefully work.

Fixes [#3045](https://github.com/packit/packit-service/issues/3045)