### PR TITLE
Renaming logdetective_secret to logdetective_token

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -113,7 +113,7 @@ class ServiceConfig(Config):
         rate_limit_threshold: Optional[int] = None,
         logdetective_enabled: bool = False,
         logdetective_url: str = LOGDETECTIVE_PACKIT_SERVER_URL,
-        logdetective_secret: str = "",
+        logdetective_token: str = "",
         **kwargs,
     ):
         if "authentication" in kwargs:
@@ -213,7 +213,7 @@ class ServiceConfig(Config):
         # Default URL of the Log Detective interface server
         self.logdetective_url = logdetective_url
         # Token to be used with Log Detective interface server
-        self.logdetective_secret = logdetective_secret
+        self.logdetective_token = logdetective_token
 
     service_config = None
 

--- a/packit_service/schema.py
+++ b/packit_service/schema.py
@@ -89,7 +89,7 @@ class ServiceConfigSchema(UserConfigSchema):
     disabled_projects_for_fedora_ci = fields.List(fields.String())
     logdetective_enabled = fields.Bool(missing=False, default=False)
     logdetective_url = fields.String()
-    logdetective_secret = fields.String()
+    logdetective_token = fields.String()
 
     @post_load
     def make_instance(self, data, **kwargs):

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -391,7 +391,7 @@ class KojiTaskReportDownstreamHandler(AbstractKojiTaskReportHandler, FedoraCIJob
             self.koji_task_event,
             self.pushgateway,
             self.service_config.logdetective_url,
-            self.service_config.logdetective_secret,
+            self.service_config.logdetective_token,
         )
         trigger_success = log_detective_trigger.trigger_log_detective_analysis()
         if not trigger_success:

--- a/tests/integration/test_logdetective_koji.py
+++ b/tests/integration/test_logdetective_koji.py
@@ -52,7 +52,7 @@ def test_logdetective_koji_build_scratch_downstream(
         logdetective_url=LOGDETECTIVE_PACKIT_SERVER_URL,
         koji_logs_url="https://kojipkgs.fedoraproject.org",
         deployment=Deployment.prod,
-        logdetective_secret="secret-123",
+        logdetective_token="secret-123",
     )
 
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(service_config)


### PR DESCRIPTION
Deployment has different name in the template.

