### PR TITLE
Add --version argument to pull-from-upstream comment command

### DIFF
--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -307,6 +307,10 @@ def get_comment_parser(
         action="store_true",
         help="Use the configuration file from this dist-git pull request",
     )
+    pull_from_upstream_parser.add_argument(
+        "--version",
+        help="Version to use for the pull-from-upstream job",
+    )
 
     subparsers.add_parser(
         "koji-build",

--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -288,7 +288,9 @@ class AbstractSyncReleaseHandler(
             }
             if not self.packit_api.non_git_upstream:
                 kwargs["tag"] = self.tag
-            elif version := self.data.event_dict.get("version"):
+            elif (version := self.data.event_dict.get("version")) or (
+                version := self.get_version_from_comment()
+            ):
                 kwargs["versions"] = [version]
             # check if there is a Koji build job that should trigger on PR merge
             kwargs["warn_about_koji_build_triggering_bug"] = False

--- a/packit_service/worker/mixin.py
+++ b/packit_service/worker/mixin.py
@@ -21,6 +21,7 @@ from packit_service.constants import (
     SANDCASTLE_LOCAL_PROJECT_DIR,
 )
 from packit_service.events.event_data import EventData
+from packit_service.utils import get_packit_commands_from_comment
 from packit_service.worker.helpers.job_helper import BaseJobHelper
 from packit_service.worker.reporting import BaseCommitStatus
 
@@ -199,13 +200,36 @@ class PackitAPIWithUpstreamMixin(PackitAPIProtocol):
 class GetSyncReleaseTagMixin(PackitAPIWithUpstreamMixin):
     _tag: Optional[str] = None
 
+    def get_version_from_comment(self) -> Optional[str]:
+        """
+        Extract the --version argument from the PR comment if present.
+        The format in the comment should be:
+        /packit pull-from-upstream --version 1.2.3
+        """
+        comment = self.data.event_dict.get("comment")
+        if not comment:
+            return None
+
+        commands = get_packit_commands_from_comment(
+            comment,
+            self.service_config.comment_command_prefix,
+        )
+        args = commands[1:] if len(commands) > 1 else []
+        version_keyword = "--version"
+        if version_keyword not in args:
+            return None
+
+        idx = args.index(version_keyword)
+        return args[idx + 1] if idx < len(args) - 1 else None
+
     @property
     def tag(self) -> Optional[str]:
         self._tag = self.data.tag_name
         if not self._tag and not self.non_git_upstream:
             # there is no tag information when retriggering pull-from-upstream
-            # from dist-git PR
-            self._tag = self.packit_api.up.get_last_tag()
+            # from dist-git PR, use the version from the comment if provided,
+            # otherwise fall back to the last tag
+            self._tag = self.get_version_from_comment() or self.packit_api.up.get_last_tag()
         return self._tag
 
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -3235,6 +3235,242 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment_non_git(
     assert first_dict_value(results["job"])["success"]
 
 
+def _run_pull_from_upstream_with_version(
+    pagure_pr_comment_added,
+    packit_yaml,
+    sync_release_version_kwargs,
+    git_upstream_project=None,
+):
+    """
+    Shared setup for --version tests. Pass git_upstream_project for a git upstream
+    (tag=), or leave it as None for a non-git upstream (versions=).
+    """
+    pagure_pr_comment_added["pullrequest"]["comments"][0]["comment"] = (
+        "/packit pull-from-upstream --version 2.0.0"
+    )
+    sync_release_pr_model = flexmock(sync_release_targets=[flexmock(), flexmock()])
+    model = flexmock(status="queued", id=1234, branch="main")
+    flexmock(SyncReleaseTargetModel).should_receive("create").with_args(
+        status=SyncReleaseTargetStatus.queued,
+        branch="main",
+    ).and_return(model)
+    flexmock(SyncReleasePullRequestModel).should_receive("get_or_create").with_args(
+        pr_id=21,
+        namespace="downstream-namespace",
+        repo_name="downstream-repo",
+        project_url="https://src.fedoraproject.org/rpms/downstream-repo",
+        target_branch=str,
+        url=str,
+    ).and_return(sync_release_pr_model)
+
+    pr_mock = (
+        flexmock()
+        .should_receive("comment")
+        .with_args(
+            "The task was accepted. You can check the recent runs of pull from upstream jobs in "
+            "[Packit dashboard](/jobs/pull-from-upstreams)"
+            f"{DistgitAnnouncement.get_comment_footer_with_announcement_if_present()}",
+        )
+        .mock()
+    )
+    distgit_project = flexmock(
+        get_files=lambda ref, recursive: [".packit.yaml"],
+        get_file_content=lambda path, ref, headers: packit_yaml,
+        full_repo_name=pagure_pr_comment_added["pullrequest"]["project"]["fullname"],
+        repo=pagure_pr_comment_added["pullrequest"]["project"]["name"],
+        namespace=pagure_pr_comment_added["pullrequest"]["project"]["namespace"],
+        is_private=lambda: False,
+        default_branch="main",
+        service=flexmock(get_project=lambda **_: None),
+        get_pr=lambda pr_id: pr_mock,
+    )
+
+    lp = flexmock(LocalProject, refresh_the_arguments=lambda: None)
+    flexmock(LocalProjectBuilder, _refresh_the_state=lambda *args: lp)
+    lp.working_dir = ""
+    flexmock(DistGit).should_receive("local_project").and_return(lp)
+
+    if git_upstream_project:
+        flexmock(Github, get_repo=lambda full_name_or_id: None)
+        lp.git_project = git_upstream_project
+        flexmock(LocalProject).should_receive("git_repo").and_return(
+            flexmock(
+                head=flexmock()
+                .should_receive("reset")
+                .with_args("HEAD", index=True, working_tree=True)
+                .once()
+                .mock(),
+                git=flexmock(clear_cache=lambda: None),
+                submodules=[
+                    flexmock()
+                    .should_receive("update")
+                    .with_args(init=True, recursive=True, force=True)
+                    .once()
+                    .mock()
+                ],
+            ),
+        )
+        # get_version_from_comment() returns "2.0.0" so get_last_tag() must never be called
+        flexmock(GitUpstream).should_receive("get_last_tag").never()
+
+    flexmock(GithubService).should_receive("set_auth_method").with_args(
+        AuthMethod.token,
+    ).once()
+    flexmock(Allowlist, check_and_report=True)
+    flexmock(PackitAPIWithDownstreamMixin).should_receive("is_packager").and_return(True)
+
+    def _get_project(url, *_, **__):
+        if url == pagure_pr_comment_added["pullrequest"]["project"]["full_url"]:
+            return distgit_project
+        return git_upstream_project
+
+    service_config = ServiceConfig().get_service_config()
+    flexmock(service_config).should_receive("get_project").replace_with(_get_project)
+    target_project = (
+        flexmock(namespace="downstream-namespace", repo="downstream-repo")
+        .should_receive("get_web_url")
+        .and_return("https://src.fedoraproject.org/rpms/downstream-repo")
+        .mock()
+    )
+    pr = (
+        flexmock(id=21, url="some_url", target_project=target_project, description="")
+        .should_receive("comment")
+        .mock()
+    )
+    flexmock(PackitAPI).should_receive("sync_release").with_args(
+        dist_git_branch="main",
+        **sync_release_version_kwargs,
+        create_pr=True,
+        local_pr_branch_suffix="update-pull_from_upstream",
+        use_downstream_specfile=True,
+        add_pr_instructions=True,
+        resolved_bugs=[],
+        release_monitoring_project_id=None,
+        sync_acls=True,
+        pr_description_footer=DistgitAnnouncement.get_announcement(),
+        add_new_sources=True,
+        fast_forward_merge_branches=set(),
+        warn_about_koji_build_triggering_bug=False,
+    ).and_return((pr, {})).once()
+    flexmock(PackitAPI).should_receive("clean")
+
+    flexmock(model).should_receive("set_status").with_args(
+        status=SyncReleaseTargetStatus.running,
+    ).once()
+    flexmock(model).should_receive("set_downstream_pr_url").with_args(
+        downstream_pr_url="some_url",
+    ).once()
+    flexmock(model).should_receive("set_downstream_prs").with_args(
+        downstream_prs=[sync_release_pr_model],
+    ).once()
+    flexmock(model).should_receive("set_status").with_args(
+        status=SyncReleaseTargetStatus.submitted,
+    ).once()
+    flexmock(model).should_receive("set_start_time").once()
+    flexmock(model).should_receive("set_finished_time").once()
+    flexmock(model).should_receive("set_logs").once()
+
+    db_project_object = flexmock(
+        id=12,
+        project_event_model_type=ProjectEventModelType.pull_request,
+        job_config_trigger_type=JobConfigTriggerType.pull_request,
+    )
+    db_project_event = (
+        flexmock().should_receive("get_project_event_object").and_return(db_project_object).mock()
+    )
+    run_model = flexmock(PipelineModel)
+    flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
+        type=ProjectEventModelType.pull_request,
+        event_id=12,
+        commit_sha="beaf90bcecc51968a46663f8d6f092bfdc92e682",
+    ).and_return(db_project_event)
+    flexmock(PullRequestModel).should_receive("get_or_create").with_args(
+        pr_id=pagure_pr_comment_added["pullrequest"]["id"],
+        namespace=pagure_pr_comment_added["pullrequest"]["project"]["namespace"],
+        repo_name=pagure_pr_comment_added["pullrequest"]["project"]["name"],
+        project_url=pagure_pr_comment_added["pullrequest"]["project"]["full_url"],
+    ).and_return(db_project_object)
+    sync_release_model = flexmock(id=123, sync_release_targets=[])
+    flexmock(SyncReleaseModel).should_receive("create_with_new_run").with_args(
+        status=SyncReleaseStatus.running,
+        project_event_model=db_project_event,
+        job_type=SyncReleaseJobType.pull_from_upstream,
+        package_name="python-teamcity-messages",
+    ).and_return(sync_release_model, run_model).once()
+    flexmock(sync_release_model).should_receive("set_status").with_args(
+        status=SyncReleaseStatus.finished,
+    ).once()
+
+    flexmock(IsRunConditionSatisfied).should_receive("pre_check").and_return(True)
+
+    flexmock(AddPullRequestEventToDb).should_receive("db_project_object").and_return(
+        flexmock(
+            job_config_trigger_type=JobConfigTriggerType.pull_request,
+            id=123,
+            project=flexmock(project_url=None),
+            project_event_model_type=ProjectEventModelType.pull_request,
+        ),
+    )
+    flexmock(celery_group).should_receive("apply_async").once()
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+    flexmock(shutil).should_receive("rmtree").with_args("")
+    flexmock(pagure.pr.Comment).should_receive(
+        "get_base_project",
+    ).once().and_return(distgit_project)
+
+    processing_results = SteveJobs().process_message(pagure_pr_comment_added)
+    event_dict, _, job_config, package_config = get_parameters_from_results(
+        processing_results,
+    )
+    assert json.dumps(event_dict)
+
+    results = run_pull_from_upstream_handler(
+        package_config=package_config,
+        event=event_dict,
+        job_config=job_config,
+    )
+    assert first_dict_value(results["job"])["success"]
+
+
+def test_pull_from_upstream_retrigger_via_dist_git_pr_comment_with_version(
+    pagure_pr_comment_added,
+):
+    """--version overrides get_last_tag() for a git upstream."""
+    _run_pull_from_upstream_with_version(
+        pagure_pr_comment_added,
+        packit_yaml=(
+            "{'specfile_path': 'hello-world.spec', 'upstream_project_url': "
+            "'https://github.com/packit-service/hello-world'"
+            ", jobs: [{trigger: release, job: pull_from_upstream}]}"
+        ),
+        sync_release_version_kwargs={"tag": "2.0.0"},
+        git_upstream_project=flexmock(
+            full_repo_name="packit-service/hello-world",
+            repo="hello-world",
+            namespace="packit-service",
+            get_files=lambda ref, filter_regex: [],
+            get_sha_from_tag=lambda tag_name: "123456",
+            get_web_url=lambda: "https://github.com/packit/hello-world",
+            is_private=lambda: False,
+            default_branch="main",
+        ),
+    )
+
+
+def test_pull_from_upstream_retrigger_via_dist_git_pr_comment_non_git_with_version(
+    pagure_pr_comment_added,
+):
+    """--version is passed as versions= to sync_release for a non-git upstream."""
+    _run_pull_from_upstream_with_version(
+        pagure_pr_comment_added,
+        packit_yaml=(
+            "{'specfile_path': 'hello-world.spec', "
+            "jobs: [{trigger: release, job: pull_from_upstream}]}"
+        ),
+        sync_release_version_kwargs={"versions": ["2.0.0"]},
+    )
+
+
 @pytest.mark.parametrize(
     "all_branches",
     [False, True],


### PR DESCRIPTION
Allow users to specify a version string when retriggering via a dist-git PR comment.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- TODO list -->

TODO:

- [ x] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.

Fixes #3033

<!-- release notes footer -->

RELEASE NOTES BEGIN

Users can now specify a version string when retriggering `pull-from-upstream`  via a dist-git PR comment:
```
/packit pull-from-upstream --version 1.2.3
```
This overrides the version that Packit would otherwise resolve automatically.

RELEASE NOTES END
