### PR TITLE
Check build in sidetags when retriggering update from sidetags

### DIFF
--- a/packit_service/worker/checker/bodhi.py
+++ b/packit_service/worker/checker/bodhi.py
@@ -199,3 +199,31 @@ class IsAuthorAPackager(ActorChecker, PackitAPIWithDownstreamMixin):
             comment_to_existing=msg,
         )
         return False
+
+
+class IsSidetagGroupNotConfigured(Checker):
+    """Check that sidetag_group is NOT configured.
+    Used to ensure RetriggerBodhiUpdateHandler only runs for non-sidetag updates.
+    """
+
+    def pre_check(self) -> bool:
+        if self.job_config.sidetag_group:
+            logger.debug(
+                "Sidetag group is configured. Use RetriggerBodhiUpdateFromSidetagHandler instead."
+            )
+            return False
+        return True
+
+
+class IsSidetagGroupConfigured(Checker):
+    """Check that sidetag_group IS configured.
+    Used to ensure RetriggerBodhiUpdateFromSidetagHandler only runs for sidetag updates.
+    """
+
+    def pre_check(self) -> bool:
+        if not self.job_config.sidetag_group:
+            logger.debug(
+                "Sidetag group is not configured. Use RetriggerBodhiUpdateHandler instead."
+            )
+            return False
+        return True

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -289,6 +289,7 @@ class TaskName(str, enum.Enum):
     bodhi_update = "task.bodhi_update"
     bodhi_update_from_sidetag = "task.bodhi_update_from_sidetag"
     retrigger_bodhi_update = "task.retrigger_bodhi_update"
+    retrigger_bodhi_update_from_sidetag = "task.retrigger_bodhi_update_from_sidetag"
     issue_comment_retrigger_bodhi_update = "task.issue_comment_retrigger_bodhi_update"
     github_fas_verification = "task.github_fas_verification"
     vm_image_build = "task.run_vm_image_build_handler"

--- a/packit_service/worker/handlers/bodhi.py
+++ b/packit_service/worker/handlers/bodhi.py
@@ -44,6 +44,8 @@ from packit_service.worker.checker.bodhi import (
     IsKojiBuildCompleteAndBranchConfiguredCheckService,
     IsKojiBuildCompleteAndBranchConfiguredCheckSidetag,
     IsKojiBuildOwnerMatchingConfiguration,
+    IsSidetagGroupConfigured,
+    IsSidetagGroupNotConfigured,
 )
 from packit_service.worker.checker.run_condition import IsRunConditionSatisfied
 from packit_service.worker.handlers.abstract import (
@@ -60,6 +62,7 @@ from packit_service.worker.handlers.mixin import (
     GetKojiBuildDataFromKojiServiceMixin,
     GetKojiBuildDataFromKojiServiceMultipleBranches,
     GetKojiBuildEventMixin,
+    GetSidetagKojiBuildDataFromKojiServiceMixin,
 )
 from packit_service.worker.helpers.sidetag import SidetagHelper
 from packit_service.worker.mixin import (
@@ -422,7 +425,7 @@ class RetriggerBodhiUpdateHandler(
     GetKojiBuildDataFromKojiServiceMixin,
 ):
     """
-    This handler can re-trigger a bodhi update if any successful Koji build.
+    This handler can re-trigger a bodhi update for successful Koji build.
     """
 
     task_name = TaskName.retrigger_bodhi_update
@@ -430,12 +433,13 @@ class RetriggerBodhiUpdateHandler(
     @staticmethod
     def get_checkers() -> tuple[type[Checker], ...]:
         """We react only on finished builds (=KojiBuildState.complete)
-        and configured branches.
+        and configured branches, when sidetag_group is NOT configured.
         """
         logger.debug("Bodhi update will be re-triggered via dist-git PR comment.")
         return (
             IsAuthorAPackager,
             HasIssueCommenterRetriggeringPermissions,
+            IsSidetagGroupNotConfigured,
             IsKojiBuildCompleteAndBranchConfiguredCheckService,
             IsRunConditionSatisfied,
         )
@@ -443,6 +447,37 @@ class RetriggerBodhiUpdateHandler(
     def get_trigger_type_description(self) -> str:
         return (
             f"Fedora Bodhi update was re-triggered "
+            f"by comment in dist-git PR with id {self.data.pr_id}."
+        )
+
+
+@configured_as(job_type=JobType.bodhi_update)
+@reacts_to(event=pagure.pr.Comment)
+@run_for_comment(command="create-update")
+class RetriggerBodhiUpdateFromSidetagHandler(
+    BodhiUpdateHandler,
+    GetSidetagKojiBuildDataFromKojiServiceMixin,
+):
+    """
+    This handler can re-trigger a bodhi update for builds in a sidetag.
+    """
+
+    task_name = TaskName.retrigger_bodhi_update_from_sidetag
+
+    @staticmethod
+    def get_checkers() -> tuple[type[Checker], ...]:
+        """We react only when sidetag_group IS configured."""
+        logger.debug("Bodhi update from sidetag will be re-triggered via dist-git PR comment.")
+        return (
+            IsAuthorAPackager,
+            HasIssueCommenterRetriggeringPermissions,
+            IsSidetagGroupConfigured,
+            IsRunConditionSatisfied,
+        )
+
+    def get_trigger_type_description(self) -> str:
+        return (
+            f"Fedora Bodhi update from sidetag was re-triggered "
             f"by comment in dist-git PR with id {self.data.pr_id}."
         )
 

--- a/packit_service/worker/handlers/mixin.py
+++ b/packit_service/worker/handlers/mixin.py
@@ -45,6 +45,11 @@ from packit_service.worker.monitoring import Pushgateway
 logger = logging.getLogger(__name__)
 
 
+def normalize_branch_for_koji(branch: str) -> str:
+    """Normalize branch name for Koji (main -> rawhide)."""
+    return "rawhide" if branch == "main" else branch
+
+
 class GetKojiBuildEvent(Protocol):
     data: EventData
 
@@ -299,10 +304,9 @@ class GetKojiBuildDataFromKojiBuildTagEventMixin(
 
     @property
     def _dist_git_branch(self) -> str:
-        if self.sidetag.dist_git_branch == "main":
-            # Koji doesn't recognize main, only rawhide
-            return "rawhide"
-        return self.sidetag.dist_git_branch
+        if not self.sidetag:
+            raise PackitException("Sidetag not found for build tag event")
+        return normalize_branch_for_koji(self.sidetag.dist_git_branch)
 
     @property
     def _state(self) -> KojiBuildState:
@@ -373,14 +377,72 @@ class GetKojiBuildDataFromKojiServiceMixin(
 ):
     @property
     def _dist_git_branch(self) -> str:
-        if (branch := self.project.get_pr(self.data.pr_id).target_branch) == "main":
-            # Koji doesn't recognize main, only rawhide
-            return "rawhide"
-        return branch
+        branch = self.project.get_pr(self.data.pr_id).target_branch
+        return normalize_branch_for_koji(branch)
 
     @property
     def num_of_branches(self):
         return 1  # just a branch in the event
+
+
+class GetSidetagKojiBuildDataFromKojiServiceMixin(
+    GetKojiBuildDataFromKojiServiceMixin,
+):
+    """
+    Get Koji build data from a sidetag for retrigger scenarios.
+    Used when retriggering bodhi updates from sidetags via PR comments.
+    Inherits _dist_git_branch and num_of_branches from parent.
+    """
+
+    _sidetag: Optional[Sidetag] = None
+    _build: Optional[dict] = None
+    job_config: JobConfig
+
+    @property
+    def sidetag(self) -> Sidetag:
+        if not self._sidetag:
+            self._sidetag = SidetagHelper.get_sidetag(
+                self.job_config.sidetag_group,
+                self._dist_git_branch,
+            )
+        return self._sidetag
+
+    @property
+    def build(self) -> dict:
+        if not self._build:
+            latest_build = max(
+                (
+                    b
+                    for b in self.sidetag.get_builds()
+                    if b.name == self.job_config.downstream_package_name
+                ),
+                default=None,
+            )
+            if not latest_build or not (
+                build_info := self.koji_helper.get_build_info(str(latest_build))
+            ):
+                raise PackitException(
+                    f"No build found for package={self.job_config.downstream_package_name} "
+                    f"in sidetag={self.sidetag.koji_name}",
+                )
+            self._build = build_info
+        return self._build
+
+    @property
+    def _nvr(self) -> str:
+        return self.build["nvr"]
+
+    @property
+    def _build_id(self) -> int:
+        return self.build["build_id"]
+
+    @property
+    def _state(self) -> KojiBuildState:
+        return KojiBuildState.from_number(self.build["state"])
+
+    @property
+    def _task_id(self) -> int:
+        return self.build["task_id"]
 
 
 class GetKojiBuildDataFromKojiServiceMultipleBranches(

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -76,6 +76,7 @@ from packit_service.worker.handlers.bodhi import (
     BodhiUpdateFromSidetagHandler,
     CreateBodhiUpdateHandler,
     IssueCommentRetriggerBodhiUpdateHandler,
+    RetriggerBodhiUpdateFromSidetagHandler,
     RetriggerBodhiUpdateHandler,
 )
 from packit_service.worker.handlers.distgit import (
@@ -708,6 +709,29 @@ def run_retrigger_bodhi_update(
     bodhi_update_group_model_id: Optional[int] = None,
 ):
     handler = RetriggerBodhiUpdateHandler(
+        package_config=load_package_config(package_config),
+        job_config=load_job_config(job_config),
+        event=event,
+        celery_task=self,
+        bodhi_update_group_model_id=bodhi_update_group_model_id,
+    )
+    return get_handlers_task_results(handler.run_job(), event)
+
+
+@celery_app.task(
+    bind=True,
+    name=TaskName.retrigger_bodhi_update_from_sidetag,
+    base=TaskWithRetry,
+    queue="long-running",
+)
+def run_retrigger_bodhi_update_from_sidetag(
+    self,
+    event: dict,
+    package_config: dict,
+    job_config: dict,
+    bodhi_update_group_model_id: Optional[int] = None,
+):
+    handler = RetriggerBodhiUpdateFromSidetagHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         event=event,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,19 +1,32 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+from typing import Optional
+
 import pytest
 from flexmock import flexmock
 from github.MainClass import Github
 from ogr.services.github import GithubProject
+from ogr.services.pagure import PagureProject
 from packit.config import JobConfigTriggerType
 from packit.local_project import LocalProject
+from packit.utils.koji_helper import KojiHelper
 
+from packit_service.config import ServiceConfig
 from packit_service.models import (
+    BodhiUpdateGroupModel,
+    BodhiUpdateTargetModel,
     GitBranchModel,
+    KojiBuildTargetModel,
+    PipelineModel,
     ProjectEventModel,
+    ProjectEventModelType,
     ProjectReleaseModel,
     PullRequestModel,
+    SidetagGroupModel,
 )
+from packit_service.service.db_project_events import AddPullRequestEventToDb
+from packit_service.worker.reporting.news import DistgitAnnouncement
 
 
 @pytest.fixture
@@ -151,3 +164,217 @@ def mock_release_functionality(request):
         project_url="https://github.com/packit/hello-world",
         commit_hash="0e5d8b51fd5dfa460605e1497d22a76d65c6d7fd",
     ).and_return(release_model)
+
+
+@pytest.fixture
+def bodhi_update_db_mocks():
+    """Fixture factory for database model mocks used in bodhi update tests."""
+
+    def _setup(package_name: str, project_url: str):
+        project_event = flexmock(
+            job_config_trigger_type=JobConfigTriggerType.pull_request,
+            project=flexmock(project_url=None),
+            id=123,
+        )
+        flexmock(AddPullRequestEventToDb).should_receive("db_project_object").and_return(
+            project_event,
+        )
+        flexmock(PullRequestModel).should_receive("get_by_id").with_args(123).and_return(
+            project_event,
+        )
+        run_model_flexmock = flexmock()
+        db_project_object = flexmock(
+            id=12,
+            project_event_model_type=ProjectEventModelType.pull_request,
+            job_config_trigger_type=JobConfigTriggerType.pull_request,
+        )
+        flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
+            79721403,
+        ).and_return(None)
+        flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
+            type=ProjectEventModelType.pull_request,
+            event_id=12,
+            commit_sha="beaf90bcecc51968a46663f8d6f092bfdc92e682",
+        ).and_return(project_event)
+        flexmock(PullRequestModel).should_receive("get_or_create").with_args(
+            pr_id=36,
+            namespace="rpms",
+            repo_name=package_name,
+            project_url=project_url,
+        ).and_return(db_project_object)
+        flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
+
+    return _setup
+
+
+@pytest.fixture
+def bodhi_update_target_mocks():
+    """Fixture factory for bodhi update group and target model mocks.
+    Can be used for both regular and sidetag bodhi updates."""
+
+    def _setup(target: str, nvr: str, sidetag: Optional[str] = None):
+        group_model = flexmock(
+            id=23,
+            grouped_targets=[
+                flexmock(
+                    id=456,
+                    target=target,
+                    koji_nvrs=nvr,
+                    sidetag=sidetag,
+                    set_status=lambda x: None,
+                    set_data=lambda x: None,
+                    set_web_url=lambda x: None,
+                    set_alias=lambda x: None,
+                    set_update_creation_time=lambda x: None,
+                ),
+            ],
+        )
+        flexmock(BodhiUpdateGroupModel).should_receive("create").and_return(group_model)
+
+        if sidetag:
+            flexmock(BodhiUpdateTargetModel).should_receive(
+                "get_last_successful_by_sidetag",
+            ).with_args(sidetag).and_return(None)
+
+        flexmock(BodhiUpdateTargetModel).should_receive(
+            "get_all_successful_or_in_progress_by_nvrs",
+        ).with_args(nvr).and_return(set())
+        flexmock(BodhiUpdateTargetModel).should_receive("create").with_args(
+            target=target,
+            koji_nvrs=nvr,
+            sidetag=sidetag,
+            status="queued",
+            bodhi_update_group=group_model,
+        ).and_return()
+        return group_model
+
+    return _setup
+
+
+@pytest.fixture
+def sidetag_koji_mocks():
+    """Fixture factory for sidetag-specific Koji mocks."""
+
+    def _setup(
+        sidetag_group_name: str,
+        target: str,
+        sidetag_koji_name: str,
+        package_name: str,
+        nvr: str,
+        build_id: int,
+        task_id: int,
+    ):
+        sidetag_model = flexmock(
+            koji_name=sidetag_koji_name,
+            target=target,
+            sidetag_group=flexmock(name=sidetag_group_name),
+        )
+        sidetag_group = flexmock(name=sidetag_group_name)
+        flexmock(SidetagGroupModel).should_receive("get_or_create").with_args(
+            sidetag_group_name,
+        ).and_return(sidetag_group)
+        flexmock(sidetag_group).should_receive("get_sidetag_by_target").with_args(
+            target,
+        ).and_return(sidetag_model)
+        flexmock(KojiHelper).should_receive("get_tag_info").with_args(
+            sidetag_koji_name,
+        ).and_return(flexmock())
+
+        flexmock(KojiHelper).should_receive("get_builds_in_tag").with_args(
+            sidetag_koji_name,
+        ).and_return(
+            [
+                {
+                    "name": package_name,
+                    "nvr": nvr,
+                    "build_id": build_id,
+                    "state": 1,
+                    "task_id": task_id,
+                },
+            ],
+        )
+
+        flexmock(KojiHelper).should_receive("get_latest_stable_nvr").with_args(
+            package_name,
+            target,
+        ).and_return(None)
+
+        flexmock(KojiHelper).should_receive("get_build_info").with_args(nvr).and_return(
+            {
+                "name": package_name,
+                "nvr": nvr,
+                "build_id": build_id,
+                "state": 1,
+                "task_id": task_id,
+            }
+        )
+
+    return _setup
+
+
+@pytest.fixture
+def bodhi_update_pagure_project():
+    """Fixture factory for pagure project mocks in bodhi update tests.
+    Can be used for both regular and sidetag bodhi updates."""
+
+    def _setup(package_name: str, project_url: str, target_branch: str, packit_yaml: str):
+        pr_mock = (
+            flexmock(target_branch=target_branch)
+            .should_receive("comment")
+            .with_args(
+                "The task was accepted. You can check the recent Bodhi update submissions "
+                "of Packit in [Packit dashboard](/jobs/bodhi-updates). "
+                "You can also check the recent Bodhi update activity of `packit` in "
+                "[the Bodhi interface](https://bodhi.fedoraproject.org/users/packit)."
+                f"{DistgitAnnouncement.get_comment_footer_with_announcement_if_present()}",
+            )
+            .mock()
+        )
+
+        pagure_service = flexmock()
+        pagure_service.should_receive("get_project").and_return(flexmock(default_branch="main"))
+
+        pagure_project = flexmock(
+            PagureProject,
+            full_repo_name=f"rpms/{package_name}",
+            get_web_url=lambda: project_url,
+            default_branch="main",
+            get_pr=lambda id: pr_mock,
+        )
+        pagure_project.service = pagure_service
+
+        pagure_project.should_receive("get_files").with_args(
+            ref="main",
+            filter_regex=r".+\.spec$",
+        ).and_return([f"{package_name}.spec"])
+        pagure_project.should_receive("get_file_content").with_args(
+            path=".packit.yaml",
+            ref="main",
+            headers=dict,
+        ).and_return(packit_yaml)
+        pagure_project.should_receive("get_files").with_args(
+            ref="main",
+            recursive=False,
+        ).and_return([f"{package_name}.spec", ".packit.yaml"])
+
+        # Mock for ServiceConfig.get_project (used by sidetag handler)
+        project_mock = flexmock(
+            repo=package_name,
+            namespace="rpms",
+            full_repo_name=f"rpms/{package_name}",
+            get_pr=lambda id: pr_mock,
+            is_private=lambda: False,
+            default_branch="main",
+            get_file_content=lambda path, ref, headers: packit_yaml,
+            get_files=lambda ref, recursive=False, filter_regex=None: (
+                [f"{package_name}.spec"]
+                if filter_regex
+                else [f"{package_name}.spec", ".packit.yaml"]
+            ),
+        )
+        project_mock.service = pagure_service
+        flexmock(ServiceConfig).should_receive("get_project").and_return(project_mock)
+
+        return pagure_project
+
+    return _setup

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -43,8 +43,6 @@ from packit_service.constants import (
 )
 from packit_service.events import abstract, pagure
 from packit_service.models import (
-    BodhiUpdateGroupModel,
-    BodhiUpdateTargetModel,
     BuildStatus,
     CoprBuildTargetModel,
     KojiBuildGroupModel,
@@ -77,6 +75,7 @@ from packit_service.worker.celery_task import CeleryTask
 from packit_service.worker.checker.run_condition import IsRunConditionSatisfied
 from packit_service.worker.handlers import distgit
 from packit_service.worker.handlers.bodhi import (
+    RetriggerBodhiUpdateFromSidetagHandler,
     RetriggerBodhiUpdateHandler,
 )
 from packit_service.worker.handlers.distgit import (
@@ -111,6 +110,7 @@ from packit_service.worker.tasks import (
     run_koji_build_handler,
     run_pull_from_upstream_handler,
     run_retrigger_bodhi_update,
+    run_retrigger_bodhi_update_from_sidetag,
     run_tag_into_sidetag_handler,
     run_testing_farm_handler,
 )
@@ -2710,7 +2710,13 @@ def test_downstream_koji_scratch_build_retrigger_via_dist_git_pr_comment(
     assert first_dict_value(results["job"])["success"]
 
 
-def test_bodhi_update_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added):
+def test_bodhi_update_retrigger_via_dist_git_pr_comment(
+    pagure_pr_comment_added,
+    bodhi_update_db_mocks,
+    bodhi_update_target_mocks,
+    bodhi_update_pagure_project,
+):
+    """Test retrigger bodhi update for builds in candidate tags."""
     pagure_pr_comment_added["pullrequest"]["comments"][0]["comment"] = "/packit create-update"
     project = pagure_pr_comment_added["pullrequest"]["project"]
     project["full_url"] = "https://src.fedoraproject.org/rpms/jouduv-dort"
@@ -2724,108 +2730,31 @@ def test_bodhi_update_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added)
         "'downstream_package_name': 'jouduv-dort'}"
     )
 
-    project_event = flexmock(
-        job_config_trigger_type=JobConfigTriggerType.pull_request,
-        project=flexmock(project_url=None),
-        id=123,
-    )
-    flexmock(AddPullRequestEventToDb).should_receive("db_project_object").and_return(
-        project_event,
-    )
-    flexmock(PullRequestModel).should_receive("get_by_id").with_args(123).and_return(
-        project_event,
-    )
-    run_model_flexmock = flexmock()
-    db_project_object = flexmock(
-        id=12,
-        project_event_model_type=ProjectEventModelType.pull_request,
-        job_config_trigger_type=JobConfigTriggerType.pull_request,
-    )
-    flexmock(KojiBuildTargetModel).should_receive("get_by_task_id").with_args(
-        79721403,
-    ).and_return(None)
-    flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
-        type=ProjectEventModelType.pull_request,
-        event_id=12,
-        commit_sha="beaf90bcecc51968a46663f8d6f092bfdc92e682",
-    ).and_return(project_event)
-    flexmock(PullRequestModel).should_receive("get_or_create").with_args(
-        pr_id=36,
-        namespace="rpms",
-        repo_name="jouduv-dort",
-        project_url="https://src.fedoraproject.org/rpms/jouduv-dort",
-    ).and_return(db_project_object)
-    flexmock(PipelineModel).should_receive("create").and_return(run_model_flexmock)
-    group_model = flexmock(
-        id=23,
-        grouped_targets=[
-            flexmock(
-                target="the_distgit_branch",
-                koji_nvrs="123",
-                sidetag=None,
-                set_status=lambda x: None,
-                set_data=lambda x: None,
-                set_web_url=lambda x: None,
-                set_alias=lambda x: None,
-                set_update_creation_time=lambda x: None,
-            ),
-        ],
-    )
-    flexmock(BodhiUpdateGroupModel).should_receive("create").and_return(group_model)
-    flexmock(BodhiUpdateTargetModel).should_receive(
-        "get_all_successful_or_in_progress_by_nvrs",
-    ).with_args("123").and_return(set())
-    flexmock(BodhiUpdateTargetModel).should_receive("create").with_args(
-        target="the_distgit_branch",
-        koji_nvrs="123",
-        sidetag=None,
-        status="queued",
-        bodhi_update_group=group_model,
-    ).and_return()
+    # Setup database mocks using fixture
+    bodhi_update_db_mocks("jouduv-dort", "https://src.fedoraproject.org/rpms/jouduv-dort")
 
-    pr_mock = (
-        flexmock(target_branch="the_distgit_branch")
-        .should_receive("comment")
-        .with_args(
-            "The task was accepted. You can check the recent Bodhi update submissions of Packit "
-            "in [Packit dashboard](/jobs/bodhi-updates). "
-            "You can also check the recent Bodhi update activity of `packit` in "
-            "[the Bodhi interface](https://bodhi.fedoraproject.org/users/packit)."
-            f"{DistgitAnnouncement.get_comment_footer_with_announcement_if_present()}",
-        )
-        .mock()
+    # Setup bodhi update target mocks using fixture
+    bodhi_update_target_mocks("the_distgit_branch", "123", sidetag=None)
+
+    # Setup pagure project mocks using fixture
+    bodhi_update_pagure_project(
+        "jouduv-dort",
+        "https://src.fedoraproject.org/rpms/jouduv-dort",
+        "the_distgit_branch",
+        packit_yaml,
     )
 
-    pagure_project = flexmock(
-        PagureProject,
-        full_repo_name="rpms/jouduv-dort",
-        get_web_url=lambda: "https://src.fedoraproject.org/rpms/jouduv-dort",
-        default_branch="main",
-        get_pr=lambda id: pr_mock,
-    )
-
+    # Mock Koji candidate build (specific to non-sidetag updates)
     flexmock(KojiHelper).should_receive("get_latest_candidate_build").and_return(
         {"nvr": "123", "build_id": 321, "state": 0, "task_id": 123},
     )
 
-    pagure_project.should_receive("get_files").with_args(
-        ref="main",
-        filter_regex=r".+\.spec$",
-    ).and_return(["jouduv-dort.spec"])
-    pagure_project.should_receive("get_file_content").with_args(
-        path=".packit.yaml",
-        ref="main",
-        headers=dict,
-    ).and_return(packit_yaml)
-    pagure_project.should_receive("get_files").with_args(
-        ref="main",
-        recursive=False,
-    ).and_return(["jouduv-dort.spec", ".packit.yaml"])
-
+    # Handler pre-checks
     flexmock(RetriggerBodhiUpdateHandler).should_receive("pre_check").and_return(True)
+    flexmock(RetriggerBodhiUpdateFromSidetagHandler).should_receive("pre_check").and_return(False)
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(celery_group).should_receive("apply_async").once()
+    flexmock(celery_group).should_receive("apply_async").twice()
     flexmock(PackitAPI).should_receive("create_update").with_args(
         dist_git_branch="the_distgit_branch",
         update_type="enhancement",
@@ -2837,11 +2766,92 @@ def test_bodhi_update_retrigger_via_dist_git_pr_comment(pagure_pr_comment_added)
     flexmock(Pushgateway).should_receive("push").times(2).and_return()
 
     processing_results = SteveJobs().process_message(pagure_pr_comment_added)
-    event_dict, _, job_config, package_config = get_parameters_from_results(
-        processing_results,
-    )
+    event_dict, _, job_config, package_config = get_parameters_from_results(processing_results)
     assert json.dumps(event_dict)
+
     results = run_retrigger_bodhi_update(
+        event=event_dict,
+        package_config=package_config,
+        job_config=job_config,
+    )
+
+    assert first_dict_value(results["job"])["success"]
+
+
+def test_bodhi_update_retrigger_via_dist_git_pr_comment_with_sidetag(
+    pagure_pr_comment_added,
+    bodhi_update_db_mocks,
+    bodhi_update_target_mocks,
+    sidetag_koji_mocks,
+    bodhi_update_pagure_project,
+):
+    """
+    Test retrigger bodhi update from sidetag.
+    This simulates the EPEL 10 side tag scenario from issue #3053.
+    """
+    pagure_pr_comment_added["pullrequest"]["comments"][0]["comment"] = "/packit create-update"
+    project = pagure_pr_comment_added["pullrequest"]["project"]
+    project["full_url"] = "https://src.fedoraproject.org/rpms/packit"
+    project["fullname"] = "rpms/packit"
+    project["name"] = "packit"
+    project["url_path"] = "rpms/packit"
+
+    packit_yaml = (
+        "{'specfile_path': 'packit.spec',"
+        "'jobs': [{'trigger': 'commit', 'job': 'bodhi_update', 'sidetag_group': 'epel10-side'}],"
+        "'downstream_package_name': 'packit'}"
+    )
+
+    # Setup database mocks using fixture
+    bodhi_update_db_mocks("packit", "https://src.fedoraproject.org/rpms/packit")
+
+    # Setup sidetag-specific Koji mocks using fixture
+    sidetag_koji_mocks(
+        sidetag_group_name="epel10-side",
+        target="epel10",
+        sidetag_koji_name="epel10-build-side-12345",
+        package_name="packit",
+        nvr="packit-0.100.0-1.el10",
+        build_id=456,
+        task_id=789,
+    )
+
+    # Setup bodhi update target mocks using fixture (with sidetag)
+    bodhi_update_target_mocks(
+        target="epel10",
+        nvr="packit-0.100.0-1.el10",
+        sidetag="epel10-build-side-12345",
+    )
+
+    # Setup pagure project mocks using fixture
+    bodhi_update_pagure_project(
+        "packit",
+        "https://src.fedoraproject.org/rpms/packit",
+        "epel10",
+        packit_yaml,
+    )
+
+    # Handler pre-checks
+    flexmock(RetriggerBodhiUpdateHandler).should_receive("pre_check").and_return(False)
+    flexmock(RetriggerBodhiUpdateFromSidetagHandler).should_receive("pre_check").and_return(True)
+
+    flexmock(LocalProject, refresh_the_arguments=lambda: None)
+    flexmock(celery_group).should_receive("apply_async").twice()
+    flexmock(PackitAPI).should_receive("create_update").with_args(
+        dist_git_branch="epel10",
+        update_type="enhancement",
+        koji_builds=["packit-0.100.0-1.el10"],
+        sidetag="epel10-build-side-12345",
+        alias=None,
+    ).once().and_return(("alias", "url"))
+
+    flexmock(Pushgateway).should_receive("push").times(2).and_return()
+
+    processing_results = SteveJobs().process_message(pagure_pr_comment_added)
+    event_dict, _, job_config, package_config = get_parameters_from_results(processing_results)
+    assert json.dumps(event_dict)
+
+    results = run_retrigger_bodhi_update_from_sidetag(
         event=event_dict,
         package_config=package_config,
         job_config=job_config,


### PR DESCRIPTION
Should fix #3053 

RELEASE NOTES BEGIN

We have fixed a bug that prevented a bodhi update to be triggered from sidetags when the koji build was missing in a release candidate tag.

RELEASE NOTES END
