### PR TITLE
Trigger LD for the correct buildArch taskID

### DIFF
--- a/packit_service/events/koji/result.py
+++ b/packit_service/events/koji/result.py
@@ -153,6 +153,7 @@ class Task(KojiEvent):
         state: KojiTaskState,
         old_state: Optional[KojiTaskState] = None,
         rpm_build_task_ids: Optional[dict[str, int]] = None,
+        rpm_build_failed_arch_list: Optional[list[str]] = None,
         start_time: Optional[Union[int, float, str]] = None,
         completion_time: Optional[Union[int, float, str]] = None,
     ):
@@ -162,6 +163,7 @@ class Task(KojiEvent):
             start_time=start_time,
             completion_time=completion_time,
         )
+        self.rpm_build_failed_arch_list = rpm_build_failed_arch_list
         self.state = state
         self.old_state = old_state
 
@@ -224,6 +226,7 @@ class Task(KojiEvent):
             state=KojiTaskState(event.get("state")) if event.get("state") else None,
             old_state=(KojiTaskState(event.get("old_state")) if event.get("old_state") else None),
             rpm_build_task_ids=event.get("rpm_build_task_ids"),
+            rpm_build_failed_arch_list=event.get("rpm_build_failed_arch_list"),
             start_time=event.get("start_time"),
             completion_time=event.get("completion_time"),
         )

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -4699,9 +4699,16 @@ class LogDetectiveRunModel(GroupAndTargetModelConnector, Base):
     status = Column(Enum(LogDetectiveResult), nullable=False)
     # From job configuration
     identifier = Column(String, nullable=True)
+
     # Set from `target_build` field of the message created by logdetective-packit
+    # either copr build ID or koji task ID
     target_build = Column(String)
-    # Target architecture
+
+    # For copr, this is chroot "fedora-VERSION-ARCH", for koji, this is "TARGET-ARCH", where:
+    # - VERSION = rawhide, 44 ...
+    # - TARGET = rawhide, fc44 ... ~ in downstream Koji, this refers to the branch name
+    # - ARCH = x86_64 aarch64 ... (we could possibly also include srpm here)
+    # We use this for human-distinguishable labels of different LD analyses
     target = Column(String)
     log_detective_response = Column(JSON)
     # Derived from `log_detective_analysis_start` field of the event
@@ -4823,7 +4830,7 @@ class LogDetectiveRunModel(GroupAndTargetModelConnector, Base):
         Args:
             status: state of Log Detective analysis
             target_build: identifier of the target build
-            target: build architecture
+            target: build architecture -- chroot (copr) or target-arch (koji)
             build_system: system providing the build
             log_detective_analysis_id: unique identifier of Log Detective analysis
             log_detective_run_group: "LogDetectiveRunGroupModel"

--- a/packit_service/worker/handlers/koji.py
+++ b/packit_service/worker/handlers/koji.py
@@ -271,6 +271,9 @@ class AbstractKojiTaskReportHandler(
             self.build.set_web_url(koji_web_url)
 
             if self.koji_task_event.state == KojiTaskState.failed:
+                logger.info(
+                    f"Failed Koji scratch build (parent taskID = {self.koji_task_event.task_id})"
+                )
                 self.trigger_log_detective_if_configured()
                 # Convert dict of logs URLs to a string representation
                 logs_url_str = ", ".join(koji_build_logs.values()) if koji_build_logs else ""
@@ -380,25 +383,38 @@ class KojiTaskReportDownstreamHandler(AbstractKojiTaskReportHandler, FedoraCIJob
 
     def trigger_log_detective_if_configured(self):
         """
-        Try triggering Log Detective analysis for a failed downstream Koji build.
+        Try triggering Log Detective analysis for all failed downstream Koji buildArch tasks.
         Since the analysis is not crucial for the build task itself, we only log
-        when the LD trigger failed, and not return a failed TaskResult
+        when the LD trigger failed, and not return a failed TaskResult.
         """
         if not self.project or not FedoraCIConfig.get_config().is_logdetective_enabled(
             self.project.get_web_url()
         ):
             return
-        logger.info("Triggering Log Detective Helper for a failed Koji build")
+
+        if not self.koji_task_event.rpm_build_task_ids:
+            logger.error("Koji scratch build failed, but cannot access buildArch subtask IDs")
+            return
+
+        if not self.koji_task_event.rpm_build_failed_arch_list:
+            logger.info(
+                "Koji scratch build failed, but no failed buildArch tasks found. "
+                "Likely an SRPM build failure."
+            )
+            return
+
         log_detective_trigger = LogDetectiveKojiTriggerHelper(
             self.koji_task_event,
             self.data,
             self.pushgateway,
+            self.service_config.koji_logs_url,
             self.service_config.logdetective_url,
             self.service_config.logdetective_token,
         )
-        trigger_success = log_detective_trigger.trigger_log_detective_analysis()
-        if not trigger_success:
-            logger.error("Log Detective was not properly triggered for a failed Koji build")
+        trigger_results = log_detective_trigger.trigger_log_detective_analysis()
+
+        if not all(trigger_results):
+            logger.error("Log Detective was not properly triggered for some failed Koji buildArch")
 
     def push_metrics(self) -> None:
         """Track Fedora CI Koji build metrics."""

--- a/packit_service/worker/handlers/logdetective.py
+++ b/packit_service/worker/handlers/logdetective.py
@@ -43,7 +43,7 @@ class DownstreamLogDetectiveResultsHandler(
 ):
     __test__ = False
     task_name = TaskName.downstream_log_detective_results
-    check_name = "Log Detective Analysis"
+    _check_name = "Log Detective analysis"
 
     def __init__(self, package_config: PackageConfig, job_config: JobConfig, event: dict):
         super().__init__(package_config, job_config, event)
@@ -132,8 +132,17 @@ class DownstreamLogDetectiveResultsHandler(
             self.branch_name = build.get_branch_name()
 
         url = build.web_url or ""
+        # LDRunModel.target is "target-arch" for Koji (i.e. rawhide-x86_64),
+        # for Copr it would be chroot which also includes arch information
+        self._ci_helper = FedoraCIHelper(
+            project=self.project,
+            metadata=self.data,
+            target_branch=log_detective_run_model.target or self.branch_name,
+        )
         self.report(
-            state=status, description=f"Log Detective analysis status: {self.status.value}", url=url
+            state=status,
+            description=f"Log Detective analysis status: {self.status.value}",
+            url=url,
         )
 
         if self.log_detective_response:
@@ -147,17 +156,12 @@ class DownstreamLogDetectiveResultsHandler(
 
         return TaskResults(success=True, details={})
 
-    def report(
-        self,
-        state: BaseCommitStatus,
-        description: str,
-        url: str,
-    ):
+    def report(self, state: BaseCommitStatus, description: str, url: str):
         self.ci_helper.report(
             state=state,
             description=description,
             url=url,
-            check_name="Log Detective Analysis",
+            check_name=self.check_name,
         )
 
     @property

--- a/packit_service/worker/helpers/logdetective.py
+++ b/packit_service/worker/helpers/logdetective.py
@@ -6,6 +6,7 @@ Helper class for triggering Log Detective from within the koji task handler.
 """
 
 import logging
+from typing import Optional
 
 import requests
 
@@ -25,6 +26,14 @@ logger = logging.getLogger(__name__)
 class LogDetectiveKojiTriggerHelper:
     """
     Trigger Log Detective interface server for an analysis of a failed Downstream Koji build.
+
+    We pass the full downstream build Task (with taskID of the parent) to __init__().
+    This task contains information about architectures, for which the build failed.
+    Arch is then used to look up the subtask ID for the buildArch,
+    where the proper failed build logs can be located.
+    KojiBuildTargetModel refers to the parent task -- there can be multiple
+    Log Detective runs for one BuildTarget (i.e. fedora 44 build can fail
+    for x86_64 and aarch64...).
     """
 
     __test__ = False
@@ -34,23 +43,39 @@ class LogDetectiveKojiTriggerHelper:
         koji_event: koji.result.Task,
         data: EventData,
         pushgateway: Pushgateway,
+        koji_logs_url: str,
         url: str,
         logdetective_token: str,
     ):
         self.koji_event = koji_event
         self.data = data
-        # NOTE: LD analysis currently (Feb 2026) only works for one log file.
-        # Specifically "build.log" for Koji ("builder-live.log" for Copr).
-        # A multi-log analysis support is planned, in which case this will need to be expanded
-        # to include other files, like "mock_output.log", "root.log", etc.
-        self.artifacts = {
-            "build.log": self.koji_event.get_koji_build_logs_url(self.koji_event.task_id),
-        }
+        self.koji_logs_url = koji_logs_url
         self.url = url
         self.pushgateway = pushgateway
         self.token = logdetective_token
+        # run_group created after 1st succcessful trigger, right before creating RunModel
+        self.run_group: Optional[LogDetectiveRunGroupModel] = None
 
-    def trigger_log_detective_analysis(self) -> bool:
+    def trigger_log_detective_analysis(self) -> list[bool]:
+        """
+        Run a trigger over all arches for which we have a failed buildArch task.
+
+        Return a list of booleans signaling if the triggers were successful.
+        """
+
+        trigger_results = []
+        for arch in self.koji_event.rpm_build_failed_arch_list:
+            success = self.trigger_log_detective_analysis_for_arch(arch)
+            logger.info(
+                f"Triggered Log Detective for a failed Koji build ("
+                f"child taskID = {self.koji_event.rpm_build_task_ids[arch]}, "
+                f"arch = {arch}, "
+                f"trigger = {'success' if success else 'fail'})"
+            )
+            trigger_results.append(success)
+        return trigger_results
+
+    def trigger_log_detective_analysis_for_arch(self, arch: str) -> bool:
         """
         Gather relevant data and send a request to LogDetective for the failed Koji build.
         This function assumes that the `self.koji_event` is already in the failed state,
@@ -60,10 +85,18 @@ class LogDetectiveKojiTriggerHelper:
         we just return a boolean signaling whether or not the trigger succeeded.
         """
 
+        build_arch_task_id = self.koji_event.rpm_build_task_ids[arch]
+        artifacts = {
+            "build.log": koji.result.KojiEvent.get_koji_build_logs_url(
+                build_arch_task_id,
+                self.koji_logs_url,
+            )
+        }
+
         endpoint_url = f"{self.url}/analyze"
         request_json = {
-            "artifacts": self.artifacts,
-            "target_build": str(self.koji_event.task_id),
+            "artifacts": artifacts,
+            "target_build": str(build_arch_task_id),
             "build_system": LogDetectiveBuildSystem.koji.value,
             "commit_sha": self.data.commit_sha,
             "project_url": self.data.project_url,
@@ -74,7 +107,7 @@ class LogDetectiveKojiTriggerHelper:
 
         try:
             response = requests.post(
-                endpoint_url,
+                url=endpoint_url,
                 json=request_json,
                 timeout=30,
                 headers={"Authorization": f"Bearer {self.token}"},
@@ -104,22 +137,23 @@ class LogDetectiveKojiTriggerHelper:
 
         build_target = self.koji_event.build_model
 
-        pipelines = build_target.group_of_targets.runs
-        group_run = LogDetectiveRunGroupModel.create(pipelines)
+        if self.run_group is None:
+            self.run_group = LogDetectiveRunGroupModel.create(
+                build_target.group_of_targets.runs  # pipelines
+            )
 
+        # "target" field in LDRunModel refers to:
+        # - "target-arch" for Koji builds (e.g. fc44-aarch64)
+        # - "chroot" for Copr builds (e.g. fedora-rawhide-x86_64)
         LogDetectiveRunModel.create(
             LogDetectiveResult.running,
-            str(self.koji_event.task_id),
-            self.koji_event.target,
+            str(build_arch_task_id),
+            f"{self.koji_event.target}-{arch}",
             LogDetectiveBuildSystem.koji,
             analysis_id,
-            group_run,
+            self.run_group,
         )
 
         build_target.add_log_detective_run(analysis_id)
 
-        logger.info(
-            f"Successfully triggered Log Detective at {analysis_start}"
-            f" for a failed Koji build {self.koji_event.task_id}"
-        )
         return True

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1445,9 +1445,15 @@ class Parser:
         completion_time = nested_get(event, "info", "completion_time")
 
         rpm_build_task_ids = {}
+        rpm_build_failed_arch_list: list[str] = []
         for children in nested_get(event, "info", "children", default=[]):
+            arch = children.get("arch")
+            subtask_id = children.get("id")
+            subtask_state = children.get("state")
             if children.get("method") == "buildArch":
-                rpm_build_task_ids[children.get("arch")] = children.get("id")
+                rpm_build_task_ids[arch] = subtask_id
+                if KojiTaskState.from_number(subtask_state) == KojiTaskState.failed:
+                    rpm_build_failed_arch_list.append(arch)
 
         return koji.result.Task(
             task_id=task_id,
@@ -1456,6 +1462,7 @@ class Parser:
             start_time=start_time,
             completion_time=completion_time,
             rpm_build_task_ids=rpm_build_task_ids,
+            rpm_build_failed_arch_list=rpm_build_failed_arch_list,
         )
 
     @staticmethod

--- a/tests/integration/test_logdetective_koji.py
+++ b/tests/integration/test_logdetective_koji.py
@@ -15,6 +15,8 @@ from packit_service.constants import LOGDETECTIVE_PACKIT_SERVER_URL
 from packit_service.events import koji
 from packit_service.models import (
     KojiBuildTargetModel,
+    LogDetectiveBuildSystem,
+    LogDetectiveResult,
     LogDetectiveRunGroupModel,
     LogDetectiveRunModel,
 )
@@ -25,21 +27,27 @@ from tests.spellbook import first_dict_value
 
 
 @pytest.fixture
-def koji_scratch_build_fixture(build_successful):
+def koji_scratch_build_fixture(failed_builds: int):
+    arches = []
+    if failed_builds > 0:
+        arches.append("x86_64")
+    if failed_builds > 1:
+        arches.append("noarch")
     return {
         "task_id": 12345,
-        "state": "CLOSED" if build_successful else "FAILED",
+        "state": "FAILED" if failed_builds > 0 else "CLOSED",
         "old_state": "OPEN",
         "rpm_build_task_ids": {"x86_64": 123456, "noarch": 123457},
+        "rpm_build_failed_arch_list": arches,
         "start_time": 1767225600,
         "completion_time": 1767225600 + 7200,
         "project_url": "https://src.fedoraproject.org/rpms/packit",
     }
 
 
-@pytest.mark.parametrize("build_successful", [True, False])
+@pytest.mark.parametrize("failed_builds", [0, 1, 2], indirect=False)
 def test_logdetective_koji_build_scratch_downstream(
-    build_successful,
+    failed_builds,
     koji_scratch_build_fixture,
     koji_build_pr_downstream: Mock,
 ):
@@ -72,30 +80,50 @@ def test_logdetective_koji_build_scratch_downstream(
     koji_build_pr_downstream.should_receive("set_build_start_time").once()
     koji_build_pr_downstream.should_receive("set_build_finished_time").once()
     koji_build_pr_downstream.should_receive("set_status").with_args(
-        "success" if build_successful else "failure"
+        "failure" if failed_builds else "success"
     ).once()
     koji_build_pr_downstream.should_receive("set_build_logs_urls").once()
     koji_build_pr_downstream.should_receive("set_web_url").once()
 
     flexmock(StatusReporter).should_receive("set_status").and_return().once()
 
-    if not build_successful:
+    if failed_builds > 0:
         mock_ld_response = flexmock(status_code=200)
         mock_ld_response.should_receive("raise_for_status")
         mock_ld_response.should_receive("json").and_return(
             {
                 "log_detective_analysis_id": "test-analysis-id-123",
                 "creation_time": "2026-01-01T12:00:00Z",
-            }
-        )
+            },
+            {
+                "log_detective_analysis_id": "test-analysis-id-456",
+                "creation_time": "2026-01-01T12:00:05Z",
+            },
+        ).one_by_one()
         flexmock(requests).should_receive("post").and_return(mock_ld_response)
 
-    ld_calls = 0 if build_successful else 1
     mock_group_run = flexmock(id=1)
-    flexmock(LogDetectiveRunGroupModel).should_receive("create").times(ld_calls).and_return(
-        mock_group_run
-    )
-    flexmock(LogDetectiveRunModel).should_receive("create").times(ld_calls)
+    flexmock(LogDetectiveRunGroupModel).should_receive("create").times(
+        int(failed_builds > 0)
+    ).and_return(mock_group_run)
+    if failed_builds > 0:
+        flexmock(LogDetectiveRunModel).should_receive("create").with_args(
+            LogDetectiveResult.running,
+            "123456",
+            "rawhide-x86_64",
+            LogDetectiveBuildSystem.koji,
+            "test-analysis-id-123",
+            mock_group_run,
+        )
+    if failed_builds > 1:
+        flexmock(LogDetectiveRunModel).should_receive("create").with_args(
+            LogDetectiveResult.running,
+            "123457",
+            "rawhide-noarch",
+            LogDetectiveBuildSystem.koji,
+            "test-analysis-id-456",
+            mock_group_run,
+        )
 
     pushgateway = flexmock(
         log_detective_runs_started=flexmock(),
@@ -103,12 +131,12 @@ def test_logdetective_koji_build_scratch_downstream(
         fedora_ci_koji_builds_finished=flexmock(),
         fedora_ci_koji_build_finished_time=flexmock(),
     )
-    pushgateway.log_detective_runs_started.should_receive("inc").times(ld_calls).and_return()
+    pushgateway.log_detective_runs_started.should_receive("inc").times(failed_builds).and_return()
     pushgateway.fedora_ci_koji_builds_finished.should_receive("inc").once().and_return()
     pushgateway.should_receive("push").and_return()
     flexmock(Pushgateway).new_instances(pushgateway)
 
-    koji_build_pr_downstream.should_receive("add_log_detective_run").times(ld_calls)
+    koji_build_pr_downstream.should_receive("add_log_detective_run").times(failed_builds)
 
     results = run_downstream_koji_scratch_build_report_handler(
         koji_scratch_build_fixture, None, None
@@ -128,6 +156,7 @@ def test_logdetective_skipped_when_project_disabled(
         "state": "FAILED",
         "old_state": "OPEN",
         "rpm_build_task_ids": {"x86_64": 123456, "noarch": 123457},
+        "rpm_build_failed_arch_list": ["noarch"],
         "start_time": 1767225600,
         "completion_time": 1767225600 + 7200,
         "project_url": "https://src.fedoraproject.org/rpms/packit",

--- a/tests/unit/events/test_logdetective.py
+++ b/tests/unit/events/test_logdetective.py
@@ -184,6 +184,7 @@ def test_logdetective_run_success(
             submitted_time=datetime.now(timezone.utc),
             copr_build_target_id=999,
             koji_build_target_id=999,
+            target="fedora-44-x86_64" if build_system == "copr" else "fc44-x86_64",
         )
     else:
         run_model = flexmock(
@@ -191,6 +192,7 @@ def test_logdetective_run_success(
             submitted_time=datetime.now(timezone.utc),
             copr_build_target_id=999,
             koji_build_target_id=999,
+            target="fedora-44-x86_64" if build_system == "copr" else "fc44-x86_64",
         )
     flexmock(LogDetectiveRunModel).should_receive("get_by_log_detective_analysis_id").with_args(
         analysis_id="123456"
@@ -221,7 +223,7 @@ def test_logdetective_run_success(
         state=expected_status,
         description=f"Log Detective analysis status: {status_str}",
         url="https://build.url",
-        check_name="Log Detective Analysis",
+        check_name="Packit - Log Detective analysis",
     ).once()
 
     # Mock Metrics
@@ -312,6 +314,7 @@ def test_logdetective_run_empty_url_fallback(handler_and_models):
         status=LogDetectiveResult.running,
         submitted_time=datetime.now(timezone.utc),
         copr_build_target_id=10,
+        target="fedora-rawhide-x86_64",
     )
     run_model.should_receive("set_status")
     flexmock(LogDetectiveRunModel).should_receive("get_by_log_detective_analysis_id").and_return(
@@ -327,7 +330,7 @@ def test_logdetective_run_empty_url_fallback(handler_and_models):
         state=BaseCommitStatus.success,
         description="Log Detective analysis status: complete",
         url="",
-        check_name="Log Detective Analysis",
+        check_name="Packit - Log Detective analysis",
     ).once()
 
     result = handler.run()

--- a/tests/unit/test_logdetective_koji_helper.py
+++ b/tests/unit/test_logdetective_koji_helper.py
@@ -54,36 +54,57 @@ def mock_koji_task_failed_event():
     mock_group = flexmock(runs=[flexmock()])
     mock_build_model = flexmock(group_of_targets=mock_group)
 
-    event = flexmock(
-        task_id=12345,
+    return flexmock(
+        task_id=12340,
         state=KojiTaskState.failed,
         old_state=KojiTaskState.open,
-        target="fedora-rawhide-x86_64",
+        target="rawhide",
         build_model=mock_build_model,
+        rpm_build_task_ids={"x86_64": 12345},
+        rpm_build_failed_arch_list=["x86_64"],
     )
 
-    event.should_receive("get_koji_build_logs_url").with_args(12345).and_return(
-        "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/build.log"
-    )
-    return event
 
-
-def test_logdetective_koji_init_sets_artifacts_correctly(
-    mock_koji_task_failed_event, mock_event_data
-):
+def test_logdetective_koji_set_payload(mock_koji_task_failed_event, mock_event_data):
+    """
+    Build and send the correct payload, then connection error happens ->
+    check proper handling and logging
+    """
     helper = LogDetectiveKojiTriggerHelper(
         mock_koji_task_failed_event,
         mock_event_data,
         flexmock(),
+        "https://kojipkgs.fedoraproject.org",
         LOGDETECTIVE_PACKIT_SERVER_URL,
         "secret-123",
     )
 
-    assert "build.log" in helper.artifacts
-    assert (
-        helper.artifacts["build.log"]
-        == "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/build.log"
+    request_json = {
+        "artifacts": {
+            "build.log": "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/build.log",
+        },
+        "target_build": "12345",
+        "build_system": "koji",
+        "commit_sha": "abc123",
+        "project_url": "https://github.com/test/repo",
+        "pr_id": 42,
+    }
+
+    flexmock(requests).should_receive("post").with_args(
+        "https://logdetective01.fedorainfracloud.org/analyze",
+        json=request_json,
+        timeout=30,
+        headers={"Authorization": "Bearer secret-123"},
+    ).once().and_raise(requests.exceptions.ConnectionError)
+
+    flexmock(LogDetectiveRunGroupModel).should_receive("create").never()
+    flexmock(logger).should_receive("info").with_args(
+        "Triggered Log Detective for a failed Koji build "
+        "(child taskID = 12345, arch = x86_64, trigger = fail)"
     )
+
+    trigger_success_list = helper.trigger_log_detective_analysis()
+    assert not all(trigger_success_list)
 
 
 def test_logdetective_koji_success(
@@ -119,7 +140,7 @@ def test_logdetective_koji_success(
     flexmock(LogDetectiveRunModel).should_receive("create").with_args(
         LogDetectiveResult.running,
         "12345",
-        "fedora-rawhide-x86_64",
+        "rawhide-x86_64",
         LogDetectiveBuildSystem.koji,
         "test-uuid-123",
         mock_group_run,
@@ -130,8 +151,9 @@ def test_logdetective_koji_success(
     ).once()
 
     flexmock(logger).should_receive("info").with_args(
-        "Successfully triggered Log Detective at 2026-01-01T12:00:00 for a failed Koji build 12345"
-    ).once()
+        "Triggered Log Detective for a failed Koji build "
+        "(child taskID = 12345, arch = x86_64, trigger = success)"
+    )
     flexmock(logger).should_call("warning").never()
     flexmock(logger).should_call("error").never()
 
@@ -139,12 +161,13 @@ def test_logdetective_koji_success(
         mock_koji_task_failed_event,
         mock_event_data,
         mock_pushgateway_log_detective_inc,
+        "https://kojipkgs.fedoraproject.org",
         LOGDETECTIVE_PACKIT_SERVER_URL,
         "secret-123",
     )
-    trigger_success = helper.trigger_log_detective_analysis()
+    trigger_success_list = helper.trigger_log_detective_analysis()
 
-    assert trigger_success
+    assert all(trigger_success_list)
 
 
 def test_logdetective_koji_http_error(
@@ -166,12 +189,13 @@ def test_logdetective_koji_http_error(
         mock_koji_task_failed_event,
         mock_event_data,
         mock_pushgateway_log_detective_no_inc,
+        "https://kojipkgs.fedoraproject.org",
         LOGDETECTIVE_PACKIT_SERVER_URL,
         "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
-    assert not trigger_success
+    assert not all(trigger_success)
 
 
 def test_logdetective_koji_connection_error(
@@ -189,12 +213,13 @@ def test_logdetective_koji_connection_error(
         mock_koji_task_failed_event,
         mock_event_data,
         mock_pushgateway_log_detective_no_inc,
+        "https://kojipkgs.fedoraproject.org",
         LOGDETECTIVE_PACKIT_SERVER_URL,
         "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
-    assert not trigger_success
+    assert not all(trigger_success)
 
 
 def test_logdetective_koji_json_decode_error(
@@ -215,12 +240,13 @@ def test_logdetective_koji_json_decode_error(
         mock_koji_task_failed_event,
         mock_event_data,
         mock_pushgateway_log_detective_no_inc,
+        "https://kojipkgs.fedoraproject.org",
         LOGDETECTIVE_PACKIT_SERVER_URL,
         "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
-    assert not trigger_success
+    assert not all(trigger_success)
 
 
 def test_logdetective_koji_timeout(
@@ -238,12 +264,13 @@ def test_logdetective_koji_timeout(
         mock_koji_task_failed_event,
         mock_event_data,
         mock_pushgateway_log_detective_no_inc,
+        "https://kojipkgs.fedoraproject.org",
         LOGDETECTIVE_PACKIT_SERVER_URL,
         "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
-    assert not trigger_success
+    assert not all(trigger_success)
 
 
 def test_logdetective_koji_missing_id(
@@ -265,12 +292,13 @@ def test_logdetective_koji_missing_id(
         mock_koji_task_failed_event,
         mock_event_data,
         mock_pushgateway_log_detective_no_inc,
+        "https://kojipkgs.fedoraproject.org",
         LOGDETECTIVE_PACKIT_SERVER_URL,
         "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
-    assert not trigger_success
+    assert not all(trigger_success)
 
 
 def test_logdetective_koji_missing_time(
@@ -292,9 +320,10 @@ def test_logdetective_koji_missing_time(
         mock_koji_task_failed_event,
         mock_event_data,
         mock_pushgateway_log_detective_no_inc,
+        "https://kojipkgs.fedoraproject.org",
         LOGDETECTIVE_PACKIT_SERVER_URL,
         "secret-123",
     )
     trigger_success = helper.trigger_log_detective_analysis()
 
-    assert not trigger_success
+    assert not all(trigger_success)

--- a/tests_openshift/service/test_logdetective.py
+++ b/tests_openshift/service/test_logdetective.py
@@ -83,7 +83,7 @@ def test_logdetective_process_message(
             task_id=logdetective_analysis_success_event["target_build"],
             scratch=False,
             web_url="https://copr.fedorainfracloud.org/coprs/packit/packit-123/build/123456/",
-            target="fedora-rawhide-x86_64",
+            target="rawhide-x86_64",
             status=BuildStatus.failure,
             koji_build_group=build_group,
         )
@@ -97,7 +97,7 @@ def test_logdetective_process_message(
         build_system=build_system,
         log_detective_analysis_id=logdetective_analysis_success_event["log_detective_analysis_id"],
         log_detective_run_group=ld_group,
-        target="fedora-rawhide-x86_64",
+        target="fedora-rawhide-x86_64" if build_system == "copr" else "rawhide-x86_64",
         identifier=logdetective_analysis_success_event["identifier"],
     )
 
@@ -145,7 +145,7 @@ def test_logdetective_process_message(
         state=BaseCommitStatus.success,
         description="Log Detective analysis status: complete",
         url="https://copr.fedorainfracloud.org/coprs/packit/packit-123/build/123456/",
-        check_name="Log Detective Analysis",
+        check_name="Packit - Log Detective analysis",
     ).once()
 
     result = process_message.apply(
@@ -297,7 +297,7 @@ def test_logdetective_process_message_error(
         state=BaseCommitStatus.error,
         description="Log Detective analysis status: error",
         url="https://copr.fedorainfracloud.org/coprs/packit/packit-123/build/123456/",
-        check_name="Log Detective Analysis",
+        check_name="Packit - Log Detective analysis",
     ).once()
 
     result = process_message.apply(


### PR DESCRIPTION
Instead of the parent task ID, we now pass the failed buildArch child task IDs.
This should prevent 404 errors when accessing logs at `https://kojipkgs.fedoraproject.org/work/tasks/YYYY/XXXXYYYY/build.log`.

Additionally, the CI reports are now consistent with other tasks, they include deployment and target-arch / chroot information.

TODO:

- [X] Write new tests or update the old ones to cover new functionality.
- [X] Update doc-strings where appropriate.

<!-- notes for reviewers -->

- added `rpm_build_task_states` dictionary for arch -> task state lookup
- we only trigger LD for failed buildArch subtasks
- there might be an edge case possible, where the parent task (scratch build) fails, but no failed buildArch task is found -> this happens for a failed SRPM build
- we might consider adding a fallback mechanism for this case where we would search for an SRPM build (the change is fairly simple -> we could add a 'srpm' to the `rpm_build_task_ids` and `rpm_build_task_states`)
- hopefully the LDRunModel and LDRunGroupModel are correctly used
- "target" field in the LDRunModel now contains not only build target, but also arch -> for distinguishing (perhaps this also needs a change into separate fields)

Fixes https://github.com/packit/packit-service/issues/3067

Related to https://github.com/packit/packit-service/pull/2971

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now triggers LogDetective with the correct artifact URLs for failed downstream Koji scratch builds.
LogDetective CI jobs are now properly reported.

RELEASE NOTES END
