### PR TITLE
Return trigger information along with Log Detective run results

### DIFF
--- a/packit_service/service/api/logdetective.py
+++ b/packit_service/service/api/logdetective.py
@@ -109,6 +109,7 @@ class LogDetectiveResultList(Resource):
                 "run_ids": run_ids,
                 "submitted_time": optional_timestamp(log_detective_run_model.submitted_time),
             }
+            log_detective_result_dict.update(get_project_info_from_build(log_detective_run_model))
             result.append(log_detective_result_dict)
 
         resp = response_maker(

--- a/tests_openshift/service/test_api.py
+++ b/tests_openshift/service/test_api.py
@@ -1098,5 +1098,17 @@ def test_log_detective_list(client, clean_before_and_after, a_log_detective_resu
     response = client.get(
         url_for("api.log-detective_log_detective_result_list"),
     )
-    response_dict = response.json
-    assert len(response_dict) == 1
+    response_list = response.json
+    assert len(response_list) == 1
+
+    response_dict = response_list[0]
+    assert isinstance(response_dict, dict)
+    assert "pr_id" in response_dict
+    assert "issue_id" in response_dict
+    assert "branch_name" in response_dict
+    assert "release" in response_dict
+    assert "anitya_version" in response_dict
+    assert "project_url" in response_dict
+
+    assert response_dict["project_url"] == SampleValues.project_url
+    assert response_dict["branch_name"] == SampleValues.branch


### PR DESCRIPTION
RELEASE NOTES BEGIN

Log Detective list API endpoint now returns information about triggering event, if such are available. 

RELEASE NOTES END

Tests were expanded to account for the new datastructure. 
