### PR TITLE
Revert "Check if `sync_release` PR should warn about `koji_build` triggering bug"

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -18,7 +18,7 @@ from celery import Task
 from ogr.abstract import AuthMethod, PullRequest
 from ogr.parsing import RepoUrl, parse_git_repo
 from ogr.services.github import GithubService
-from packit.config import Deployment, JobConfig, JobConfigTriggerType, JobType, aliases
+from packit.config import Deployment, JobConfig, JobType, aliases
 from packit.config.package_config import PackageConfig
 from packit.exceptions import (
     PackitCommandFailedError,
@@ -293,20 +293,6 @@ class AbstractSyncReleaseHandler(
                 version := self.get_version_from_comment()
             ):
                 kwargs["versions"] = [version]
-            # check if there is a Koji build job that should trigger on PR merge
-            kwargs["warn_about_koji_build_triggering_bug"] = False
-            for job in self.package_config.get_job_views():
-                if job.type != JobType.koji_build:
-                    continue
-                if job.trigger != JobConfigTriggerType.commit:
-                    continue
-                if branch not in aliases.get_branches(
-                    *job.dist_git_branches,
-                    default_dg_branch="rawhide",
-                ):
-                    continue
-                kwargs["warn_about_koji_build_triggering_bug"] = True
-                break
             downstream_pr, additional_prs = self.packit_api.sync_release(**kwargs)
         except PackitDownloadFailedException as ex:
             # the archive has not been uploaded to PyPI yet

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -232,7 +232,6 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-        warn_about_koji_build_triggering_bug=False,
     ).and_return((pr, {})).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -411,7 +410,6 @@ def test_new_hotness_update_non_git(new_hotness_update, sync_release_model_non_g
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-        warn_about_koji_build_triggering_bug=False,
     ).and_return((pr, {})).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -2977,7 +2977,6 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-        warn_about_koji_build_triggering_bug=False,
     ).and_return((pr, {})).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -3148,7 +3147,6 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment_non_git(
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-        warn_about_koji_build_triggering_bug=False,
     ).and_return((pr, {})).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -3345,7 +3343,6 @@ def _run_pull_from_upstream_with_version(
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-        warn_about_koji_build_triggering_bug=False,
     ).and_return((pr, {})).once()
     flexmock(PackitAPI).should_receive("clean")
 

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -233,7 +233,6 @@ def test_dist_git_push_release_handle(
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-        warn_about_koji_build_triggering_bug=False,
     ).and_return((pr, {})).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -390,7 +389,6 @@ def test_dist_git_push_release_handle_fast_forward_branches(
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-        warn_about_koji_build_triggering_bug=False,
     ).and_return((pr, {"rawhide": second_pr})).once()
     flexmock(PackitAPI).should_receive("clean")
 
@@ -538,7 +536,6 @@ def test_dist_git_push_release_handle_multiple_branches(
             pr_description_footer=DistgitAnnouncement.get_announcement(),
             add_new_sources=True,
             fast_forward_merge_branches=set(),
-            warn_about_koji_build_triggering_bug=False,
         ).and_return((pr, {})).once()
 
         flexmock(ProposeDownstreamJobHelper).should_receive(
@@ -694,7 +691,6 @@ def test_dist_git_push_release_handle_one_failed(
                 pr_description_footer=DistgitAnnouncement.get_announcement(),
                 add_new_sources=True,
                 fast_forward_merge_branches=set(),
-                warn_about_koji_build_triggering_bug=False,
             ).and_return((pr, {})).once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch",
@@ -718,7 +714,6 @@ def test_dist_git_push_release_handle_one_failed(
                 pr_description_footer=DistgitAnnouncement.get_announcement(),
                 add_new_sources=True,
                 fast_forward_merge_branches=set(),
-                warn_about_koji_build_triggering_bug=False,
             ).and_raise(Exception, f"Failed {model.branch}").once()
             flexmock(ProposeDownstreamJobHelper).should_receive(
                 "report_status_for_branch",
@@ -984,7 +979,6 @@ def test_retry_propose_downstream_task(
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-        warn_about_koji_build_triggering_bug=False,
     ).and_raise(
         PackitDownloadFailedException,
         "Failed to download source from example.com",
@@ -1099,7 +1093,6 @@ def test_dont_retry_propose_downstream_task(
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-        warn_about_koji_build_triggering_bug=False,
     ).and_raise(
         PackitDownloadFailedException,
         "Failed to download source from example.com",

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -201,7 +201,6 @@ def test_process_message(event, private, enabled_private_namespaces, success):
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-        warn_about_koji_build_triggering_bug=False,
     ).and_return((pr, {})).times(1 if success else 0)
     flexmock(shutil).should_receive("rmtree").with_args("")
 


### PR DESCRIPTION
This reverts commit c35b2380cc2ef923d9af790ca0231dede8ac38c3.

Fixes https://github.com/packit/packit-service/issues/2537.

Merge before https://github.com/packit/packit/pull/2708.