### PR TITLE
Add `rmdepcheck` and `fedora-review` tests

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1603,6 +1603,41 @@ class DownstreamTestingFarmJobHelper:
         }
         return payload
 
+    def _get_fedora_ci_payload(self, distro: str, plan: str) -> dict:
+        # TODO: Gradually move the other tests to use the shared-tests repo
+        # TODO: Installability migration is blocked because it needs specific compose
+        #  Maybe we can define a specific context that can expand to the appropriate container image
+        # TODO: Remove the need for specific plan needed here
+        #  https://github.com/packit/packit-service/issues/2915
+        # TODO: `distro` context can eventually be dropped once the tests migrate to using
+        #  `dist-git-branch`
+        git_repo = "https://forge.fedoraproject.org/ci/shared-tests"
+        git_ref = "main" if self.service_config.deployment == Deployment.prod else "stg"
+        # All tests in ci/shared-tests define their own provision hence `compose=None`
+        payload = self._get_tf_base_payload(distro, None)
+        payload["test"] = {
+            "tmt": {
+                "url": git_repo,
+                "ref": git_ref,
+                "name": plan,
+            },
+        }
+        return payload
+
+    @implements_fedora_ci_test(
+        "rmdepcheck",
+        checkers=[IsProjectOutsideOfTestsNamespace],
+    )
+    def _payload_rmdepcheck(self, distro: str, compose: str) -> dict:
+        return self._get_fedora_ci_payload(distro, "/rmdepcheck")
+
+    @implements_fedora_ci_test(
+        "license-validate",
+        checkers=[IsProjectOutsideOfTestsNamespace],
+    )
+    def _payload_fedora_review(self, distro: str, compose: str) -> dict:
+        return self._get_fedora_ci_payload(distro, "/license-validate")
+
     @implements_fedora_ci_test(
         "custom",
         checkers=[IsFMFConfigPresent],

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -2765,6 +2765,30 @@ def test_koji_build_end_downstream(
         **common_payload_no_compose,
     }
 
+    shared_tests_repo = "https://forge.fedoraproject.org/ci/shared-tests"
+
+    payload_rmdepcheck = {
+        "test": {
+            "tmt": {
+                "url": shared_tests_repo,
+                "ref": "stg",
+                "name": "/rmdepcheck",
+            },
+        },
+        **common_payload_no_compose,
+    }
+
+    payload_license_validate = {
+        "test": {
+            "tmt": {
+                "url": shared_tests_repo,
+                "ref": "stg",
+                "name": "/license-validate",
+            },
+        },
+        **common_payload_no_compose,
+    }
+
     payload_custom = {
         "test": {
             "tmt": {
@@ -2851,6 +2875,26 @@ def test_koji_build_end_downstream(
     ).once()
     flexmock(TestingFarmClient).should_receive(
         "send_testing_farm_request",
+    ).with_args(endpoint="requests", method="POST", data=payload_rmdepcheck).and_return(
+        RequestResponse(
+            status_code=200,
+            ok=True,
+            content=json.dumps({"id": pipeline_id}).encode(),
+            json={"id": pipeline_id},
+        ),
+    ).once()
+    flexmock(TestingFarmClient).should_receive(
+        "send_testing_farm_request",
+    ).with_args(endpoint="requests", method="POST", data=payload_license_validate).and_return(
+        RequestResponse(
+            status_code=200,
+            ok=True,
+            content=json.dumps({"id": pipeline_id}).encode(),
+            json={"id": pipeline_id},
+        ),
+    ).once()
+    flexmock(TestingFarmClient).should_receive(
+        "send_testing_farm_request",
     ).with_args(endpoint="requests", method="POST", data=payload_custom).and_return(
         RequestResponse(
             status_code=200,
@@ -2928,12 +2972,48 @@ def test_koji_build_end_downstream(
         .once()
         .mock()
     )
+    tft_test_run_model_rmdepcheck = (
+        flexmock(
+            id=9,
+            koji_builds=[koji_build_pr_downstream],
+            status=TestingFarmResult.new,
+            target=distro,
+            data={"fedora_ci_test": "rmdepcheck"},
+        )
+        .should_receive("set_pipeline_id")
+        .with_args(pipeline_id)
+        .once()
+        .mock()
+        .should_receive("set_status")
+        .with_args(TestingFarmResult.queued)
+        .once()
+        .mock()
+    )
+    tft_test_run_model_license_validate = (
+        flexmock(
+            id=10,
+            koji_builds=[koji_build_pr_downstream],
+            status=TestingFarmResult.new,
+            target=distro,
+            data={"fedora_ci_test": "license-validate"},
+        )
+        .should_receive("set_pipeline_id")
+        .with_args(pipeline_id)
+        .once()
+        .mock()
+        .should_receive("set_status")
+        .with_args(TestingFarmResult.queued)
+        .once()
+        .mock()
+    )
     group = flexmock(
         grouped_targets=[
             tft_test_run_model_installability,
             tft_test_run_model_custom,
             tft_test_run_model_rpminspect,
             tft_test_run_model_rpmlint,
+            tft_test_run_model_rmdepcheck,
+            tft_test_run_model_license_validate,
         ]
     )
     flexmock(TFTTestRunGroupModel).should_receive("create").with_args(
@@ -2992,6 +3072,32 @@ def test_koji_build_end_downstream(
             "fedora_ci_test": "rpmlint",
         },
     ).and_return(tft_test_run_model_rpmlint).once()
+    flexmock(TFTTestRunTargetModel).should_receive("create").with_args(
+        pipeline_id=None,
+        identifier=None,
+        status=TestingFarmResult.new,
+        target=distro,
+        web_url=None,
+        test_run_group=group,
+        koji_build_targets=[koji_build_pr_downstream],
+        data={
+            "base_project_url": "https://src.fedoraproject.org/rpms/packit",
+            "fedora_ci_test": "rmdepcheck",
+        },
+    ).and_return(tft_test_run_model_rmdepcheck).once()
+    flexmock(TFTTestRunTargetModel).should_receive("create").with_args(
+        pipeline_id=None,
+        identifier=None,
+        status=TestingFarmResult.new,
+        target=distro,
+        web_url=None,
+        test_run_group=group,
+        koji_build_targets=[koji_build_pr_downstream],
+        data={
+            "base_project_url": "https://src.fedoraproject.org/rpms/packit",
+            "fedora_ci_test": "license-validate",
+        },
+    ).and_return(tft_test_run_model_license_validate).once()
 
     # check if packit-service set correct PR statuses
     flexmock(StatusReporter).should_receive("set_status").with_args(
@@ -3055,6 +3161,34 @@ def test_koji_build_end_downstream(
         description="Tests have been submitted ...",
         url="https://dashboard.localhost/jobs/testing-farm/8",
         check_name="Packit-stg - rpmlint",
+        target_branch=koji_target,
+    ).once()
+    flexmock(StatusReporter).should_receive("set_status").with_args(
+        state=BaseCommitStatus.running,
+        description="Submitting the tests ...",
+        url="https://dashboard.localhost/jobs/testing-farm/9",
+        check_name="Packit-stg - rmdepcheck",
+        target_branch=koji_target,
+    ).once()
+    flexmock(StatusReporter).should_receive("set_status").with_args(
+        state=BaseCommitStatus.running,
+        description="Tests have been submitted ...",
+        url="https://dashboard.localhost/jobs/testing-farm/9",
+        check_name="Packit-stg - rmdepcheck",
+        target_branch=koji_target,
+    ).once()
+    flexmock(StatusReporter).should_receive("set_status").with_args(
+        state=BaseCommitStatus.running,
+        description="Submitting the tests ...",
+        url="https://dashboard.localhost/jobs/testing-farm/10",
+        check_name="Packit-stg - license-validate",
+        target_branch=koji_target,
+    ).once()
+    flexmock(StatusReporter).should_receive("set_status").with_args(
+        state=BaseCommitStatus.running,
+        description="Tests have been submitted ...",
+        url="https://dashboard.localhost/jobs/testing-farm/10",
+        check_name="Packit-stg - license-validate",
         target_branch=koji_target,
     ).once()
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -3872,6 +3872,14 @@ def _test_downstream_tf_retrigger_common(
                     "cafe8a3fb7c24f7534a6157514dda0f3",
                     "Packit-stg - rpmlint - rawhide [beaf90b]",
                 ),
+                (
+                    "88ac5f0f7dc0c684f988ec9157fff5b2",
+                    "Packit-stg - rmdepcheck - rawhide [beaf90b]",
+                ),
+                (
+                    "325199098ce9f37cc790405f4fa300cf",
+                    "Packit-stg - license-validate - rawhide [beaf90b]",
+                ),
             ],
             id="rawhide target branch",
         ),
@@ -3884,6 +3892,11 @@ def _test_downstream_tf_retrigger_common(
                 ),
                 ("d6df09a49152552c196c4d06f286abef", "Packit-stg - rpminspect - f42 [beaf90b]"),
                 ("6901e099dadbb89822e6a64c411ceb8c", "Packit-stg - rpmlint - f42 [beaf90b]"),
+                ("ea75be809952ac2c43a139e80d2cedc1", "Packit-stg - rmdepcheck - f42 [beaf90b]"),
+                (
+                    "e3cceaaad50a791b999c00aba2973653",
+                    "Packit-stg - license-validate - f42 [beaf90b]",
+                ),
             ],
             id="f42 target branch",
         ),
@@ -3899,7 +3912,7 @@ def test_downstream_testing_farm_retrigger_via_dist_git_pr_comment(
         target_branch,
         flags,
         "/packit-ci test",
-        tests=3,
+        tests=5,
     )
 
 
@@ -3971,8 +3984,13 @@ def test_downstream_testing_farm_retrigger_specific_plan_via_dist_git_pr_comment
                 ("Packit-stg - installability - eln [beaf90b]", "ca546b82b2aeb2fcef8bf12746f0bd06"),
                 ("Packit-stg - rpminspect - eln [beaf90b]", "bb18abcfd81c6e8f66320513e432b4cd"),
                 ("Packit-stg - rpmlint - eln [beaf90b]", "de24b7b63bf38420bdfea804d3bf56d7"),
+                ("Packit-stg - rmdepcheck - eln [beaf90b]", "8ad85bf19e686070b8c8105956ec273a"),
+                (
+                    "Packit-stg - license-validate - eln [beaf90b]",
+                    "54f936fa395a5b11c0595cde0de3571d",
+                ),
             },
-            3,
+            5,
             "eln",
             id="rpminspect - rawhide branch, eln target",
         ),


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Make the related tests compatible with packit's contexts
  - [x] `rmdepcheck`
  - [x] ~~`fedora-review`~~ ready but postponing the enablement
  - [x] `license-validate`

Merge after https://github.com/fedora-ci/rmdepcheck-pipeline/pull/12

Also not sure how this would behave when run in `prod` when the corresponding tests are not yet enabled.

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit Fedora-CI now runs `rmdepcheck` and `license-validate` tests on PRs. 

RELEASE NOTES END
