### PR TITLE
fix: handle projects with multi-level namespaces

### DIFF
--- a/packit_service/service/api/projects.py
+++ b/packit_service/service/api/projects.py
@@ -50,7 +50,7 @@ class ProjectsList(Resource):
         return resp
 
 
-@ns.route("/<forge>/<namespace>/<repo_name>")
+@ns.route("/<forge>/<path:namespace>/<repo_name>")
 @ns.param("forge", "Git Forge")
 @ns.param("namespace", "Namespace")
 @ns.param("repo_name", "Repo Name")
@@ -108,7 +108,7 @@ class ProjectsForge(Resource):
         return resp
 
 
-@ns.route("/<forge>/<namespace>")
+@ns.route("/<forge>/<path:namespace>")
 @ns.param("forge", "Git Forge")
 @ns.param("namespace", "Namespace")
 class ProjectsNamespace(Resource):
@@ -144,7 +144,7 @@ class ProjectsNamespace(Resource):
         return resp
 
 
-@ns.route("/<forge>/<namespace>/<repo_name>/prs")
+@ns.route("/<forge>/<path:namespace>/<repo_name>/prs")
 @ns.param("forge", "Git Forge")
 @ns.param("namespace", "Namespace")
 @ns.param("repo_name", "Repo Name")
@@ -222,7 +222,7 @@ class ProjectsPRs(Resource):
         return resp
 
 
-@ns.route("/<forge>/<namespace>/<repo_name>/issues")
+@ns.route("/<forge>/<path:namespace>/<repo_name>/issues")
 @ns.param("forge", "Git Forge")
 @ns.param("namespace", "Namespace")
 @ns.param("repo_name", "Repo Name")
@@ -256,7 +256,7 @@ class ProjectIssues(Resource):
         return resp
 
 
-@ns.route("/<forge>/<namespace>/<repo_name>/releases")
+@ns.route("/<forge>/<path:namespace>/<repo_name>/releases")
 @ns.param("forge", "Git Forge")
 @ns.param("namespace", "Namespace")
 @ns.param("repo_name", "Repo Name")
@@ -293,7 +293,7 @@ class ProjectReleases(Resource):
         return resp
 
 
-@ns.route("/<forge>/<namespace>/<repo_name>/branches")
+@ns.route("/<forge>/<path:namespace>/<repo_name>/branches")
 @ns.param("forge", "Git Forge")
 @ns.param("namespace", "Namespace")
 @ns.param("repo_name", "Repo Name")

--- a/packit_service/service/api/usage.py
+++ b/packit_service/service/api/usage.py
@@ -70,7 +70,7 @@ class Usage(Resource):
         return response_maker(result)
 
 
-@usage_ns.route("/project/<forge>/<namespace>/<repo_name>")
+@usage_ns.route("/project/<forge>/<path:namespace>/<repo_name>")
 @usage_ns.param("forge", "Git Forge")
 @usage_ns.param("namespace", "Namespace")
 @usage_ns.param("repo_name", "Repo Name")


### PR DESCRIPTION
## Summary
This PR fixes an issue with handling projects that have multi-level namespaces.

## Problem
The API routes were using `<namespace>` which doesn't match multi-level namespaces like `organization/team` or `org/suborg/project`.

## Solution
Changed the route pattern from `<namespace>` to `<path:namespace>` which allows matching namespaces with slashes (multi-level namespaces).

## Changes
- Updated API routes in `projects.py` to use `<path:namespace>`
- Updated API routes in `usage.py` to use `<path:namespace>`

## Testing
- Tested with single-level namespaces (existing behavior preserved)
- Tested with multi-level namespaces (now works correctly)

## Example
Before: `/github/org/team/repo` would fail to match
After: `/github/org/team/repo` correctly matches with namespace=`org/team`