### PR TITLE
Simplify fedora-ci jobs

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -10,8 +10,8 @@ from typing import Any, Callable, Optional, Union
 from ogr.abstract import GitProject, PullRequest
 from ogr.utils import RequestResponse
 from packit.config import JobConfig, PackageConfig
-from packit.exceptions import PackitConfigException, PackitException
-from packit.utils import commands, nested_get
+from packit.exceptions import PackitConfigException
+from packit.utils import nested_get
 from packit.utils.koji_helper import KojiHelper
 
 from packit_service.config import Deployment, ServiceConfig
@@ -1459,49 +1459,15 @@ class DownstreamTestingFarmJobHelper:
     @implements_fedora_ci_test("installability")
     def _payload_installability(self, distro: str, compose: str) -> dict:
         git_repo = "https://github.com/fedora-ci/installability-pipeline.git"
-        git_ref = (
-            commands.run_command(["git", "ls-remote", git_repo, "HEAD"], output=True)
-            .stdout.strip()
-            .split()[0]
-        )
-
-        if distro == "fedora-rawhide":
-            # profile names are in "fedora-N" format
-            # extract current rawhide version number from its candidate tag
-            if not (candidate_tag := self.koji_helper.get_candidate_tag("rawhide")):
-                raise PackitException(f"Failed to get test profile for {distro}")
-            profile = re.sub(r"f(\d+)(-.*)?", r"fedora-\1", candidate_tag)
-        else:
-            profile = distro
-
-        # installability test requires a Koji build
-        # (it should be guaranteed by the `HasEventSuccessfulScratchBuild` checker)
-        assert self.koji_build
-
-        return {
-            "test": {
-                "tmt": {
-                    "url": git_repo,
-                    "ref": git_ref,
-                },
-            },
-            "environments": [
-                {
-                    "arch": "x86_64",
-                    "os": {"compose": compose},
-                    "variables": {
-                        "PROFILE_NAME": profile,
-                        "TASK_ID": self.koji_build.task_id,
-                    },
-                },
-            ],
-            "notification": {
-                "webhook": {
-                    "url": f"{self.api_url}/testing-farm/results",
-                    "token": self.service_config.testing_farm_secret,
-                },
+        git_ref = "master"
+        payload = self._get_tf_base_payload(distro, compose)
+        payload["test"] = {
+            "tmt": {
+                "url": git_repo,
+                "ref": git_ref,
             },
         }
+        return payload
 
     @implements_fedora_ci_test("rpminspect")
     def _payload_rpminspect(self, distro: str, compose: str) -> dict:

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -10,8 +10,8 @@ from typing import Any, Callable, Optional, Union
 from ogr.abstract import GitProject, PullRequest
 from ogr.utils import RequestResponse
 from packit.config import JobConfig, PackageConfig
-from packit.exceptions import PackitConfigException, PackitException
-from packit.utils import commands, nested_get
+from packit.exceptions import PackitConfigException
+from packit.utils import nested_get
 from packit.utils.koji_helper import KojiHelper
 
 from packit_service.config import Deployment, ServiceConfig
@@ -1525,49 +1525,15 @@ class DownstreamTestingFarmJobHelper:
     )
     def _payload_installability(self, distro: str, compose: str) -> dict:
         git_repo = "https://github.com/fedora-ci/installability-pipeline.git"
-        git_ref = (
-            commands.run_command(["git", "ls-remote", git_repo, "HEAD"], output=True)
-            .stdout.strip()
-            .split()[0]
-        )
-
-        if distro == "fedora-rawhide":
-            # profile names are in "fedora-N" format
-            # extract current rawhide version number from its candidate tag
-            if not (candidate_tag := self.koji_helper.get_candidate_tag("rawhide")):
-                raise PackitException(f"Failed to get test profile for {distro}")
-            profile = re.sub(r"f(\d+)(-.*)?", r"fedora-\1", candidate_tag)
-        else:
-            profile = distro
-
-        # installability test requires a Koji build
-        # (it should be guaranteed by the `HasEventSuccessfulScratchBuild` checker)
-        assert self.koji_build
-
-        return {
-            "test": {
-                "tmt": {
-                    "url": git_repo,
-                    "ref": git_ref,
-                },
-            },
-            "environments": [
-                {
-                    "arch": "x86_64",
-                    "os": {"compose": compose},
-                    "variables": {
-                        "PROFILE_NAME": profile,
-                        "TASK_ID": self.koji_build.task_id,
-                    },
-                },
-            ],
-            "notification": {
-                "webhook": {
-                    "url": f"{self.api_url}/testing-farm/results",
-                    "token": self.service_config.testing_farm_secret,
-                },
+        git_ref = "master"
+        payload = self._get_tf_base_payload(distro, compose)
+        payload["test"] = {
+            "tmt": {
+                "url": git_repo,
+                "ref": git_ref,
             },
         }
+        return payload
 
     @implements_fedora_ci_test(
         "rpminspect",

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1526,7 +1526,7 @@ class DownstreamTestingFarmJobHelper:
     def _payload_installability(self, distro: str, compose: str) -> dict:
         git_repo = "https://github.com/fedora-ci/installability-pipeline.git"
         git_ref = "master"
-        payload = self._get_tf_base_payload(distro, compose)
+        payload = self._get_tf_base_payload(distro, compose, with_artifacts=False)
         payload["test"] = {
             "tmt": {
                 "url": git_repo,
@@ -1544,7 +1544,7 @@ class DownstreamTestingFarmJobHelper:
         git_ref = "master"
         # rpminspect defines its own container in the tmt plan file,
         # hence `compose=None`
-        payload = self._get_tf_base_payload(distro, None)
+        payload = self._get_tf_base_payload(distro, None, with_artifacts=False)
         payload["test"] = {
             "tmt": {
                 "url": git_repo,
@@ -1562,7 +1562,7 @@ class DownstreamTestingFarmJobHelper:
         git_ref = "main"
         # rpmlint defines its own container in the tmt plan file,
         # hence `compose=None`
-        payload = self._get_tf_base_payload(distro, None)
+        payload = self._get_tf_base_payload(distro, None, with_artifacts=False)
         payload["test"] = {
             "tmt": {
                 "url": git_repo,
@@ -1583,7 +1583,7 @@ class DownstreamTestingFarmJobHelper:
         git_repo = "https://forge.fedoraproject.org/ci/shared-tests"
         git_ref = "main" if self.service_config.deployment == Deployment.prod else "stg"
         # All tests in ci/shared-tests define their own provision hence `compose=None`
-        payload = self._get_tf_base_payload(distro, None)
+        payload = self._get_tf_base_payload(distro, None, with_artifacts=False)
         payload["test"] = {
             "tmt": {
                 "url": git_repo,
@@ -1621,7 +1621,9 @@ class DownstreamTestingFarmJobHelper:
         }
         return payload
 
-    def _get_tf_base_payload(self, distro: str, compose: Optional[str]) -> dict:
+    def _get_tf_base_payload(
+        self, distro: str, compose: Optional[str], with_artifacts: bool = True
+    ) -> dict:
         """
         Common payload for all fedora-ci testing-farm jobs.
 
@@ -1655,7 +1657,7 @@ class DownstreamTestingFarmJobHelper:
                     "arch": "x86_64",
                     **os_params,
                     "variables": variables,
-                    "artifacts": artifacts,
+                    "artifacts": (with_artifacts and artifacts) or [],
                     "tmt": {
                         "context": context,
                     },

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -2676,38 +2676,46 @@ def test_koji_build_end_downstream(
     koji_build_pr_downstream.should_receive("set_status").with_args("success").once()
     koji_build_pr_downstream.should_receive("set_build_logs_urls")
     koji_build_pr_downstream.should_receive("set_web_url")
-    common_payload_no_compose = {
-        "environments": [
-            {
-                "arch": "x86_64",
-                "variables": {
-                    "KOJI_TASK_ID": "1",
-                },
-                "artifacts": [
-                    {
-                        "id": "1",
-                        "type": "fedora-koji-build",
+
+    def _common_payload(*, with_compose: bool, with_artifact: bool):
+        _payload = {
+            "environments": [
+                {
+                    "arch": "x86_64",
+                    "variables": {
+                        "KOJI_TASK_ID": "1",
                     },
-                ],
-                "tmt": {
-                    "context": {
-                        "distro": distro,
-                        "arch": "x86_64",
-                        "trigger": "commit",
-                        "initiator": "fedora-ci",
-                        "dist-git-branch": "rawhide",
-                        **extra_context,
+                    "artifacts": [],
+                    "tmt": {
+                        "context": {
+                            "distro": distro,
+                            "arch": "x86_64",
+                            "trigger": "commit",
+                            "initiator": "fedora-ci",
+                            "dist-git-branch": "rawhide",
+                            **extra_context,
+                        },
                     },
                 },
+            ],
+            "notification": {
+                "webhook": {
+                    "url": "https://stg.packit.dev/api/testing-farm/results",
+                    "token": "secret token",
+                },
             },
-        ],
-        "notification": {
-            "webhook": {
-                "url": "https://stg.packit.dev/api/testing-farm/results",
-                "token": "secret token",
-            },
-        },
-    }
+        }
+        assert isinstance(_payload["environments"], list)  # narrow type
+        if with_artifact:
+            _payload["environments"][0]["artifacts"] = [
+                {
+                    "id": "1",
+                    "type": "fedora-koji-build",
+                }
+            ]
+        if with_compose:
+            _payload["environments"][0]["os"] = {"compose": compose}
+        return _payload
 
     installability_repo = "https://github.com/fedora-ci/installability-pipeline.git"
     payload_installability = {
@@ -2717,10 +2725,8 @@ def test_koji_build_end_downstream(
                 "ref": "master",
             },
         },
-        **common_payload_no_compose,
+        **_common_payload(with_compose=True, with_artifact=False),
     }
-    payload_installability = copy.deepcopy(payload_installability)
-    payload_installability["environments"][0]["os"] = {"compose": compose}
 
     rpminspect_repo = "https://github.com/fedora-ci/rpminspect-pipeline.git"
     payload_rpminspect = {
@@ -2730,7 +2736,7 @@ def test_koji_build_end_downstream(
                 "ref": "master",
             },
         },
-        **common_payload_no_compose,
+        **_common_payload(with_compose=False, with_artifact=False),
     }
 
     rpmlint_repo = "https://github.com/packit/tmt-plans.git"
@@ -2743,7 +2749,7 @@ def test_koji_build_end_downstream(
                 "name": "/plans/rpmlint",
             },
         },
-        **common_payload_no_compose,
+        **_common_payload(with_compose=False, with_artifact=False),
     }
 
     shared_tests_repo = "https://forge.fedoraproject.org/ci/shared-tests"
@@ -2756,7 +2762,7 @@ def test_koji_build_end_downstream(
                 "name": "/rmdepcheck",
             },
         },
-        **common_payload_no_compose,
+        **_common_payload(with_compose=False, with_artifact=False),
     }
 
     payload_license_validate = {
@@ -2767,7 +2773,7 @@ def test_koji_build_end_downstream(
                 "name": "/license-validate",
             },
         },
-        **common_payload_no_compose,
+        **_common_payload(with_compose=False, with_artifact=False),
     }
 
     payload_custom = {
@@ -2777,37 +2783,7 @@ def test_koji_build_end_downstream(
                 "ref": "0011223344",
             },
         },
-        "environments": [
-            {
-                "arch": "x86_64",
-                "os": {"compose": compose},
-                "variables": {
-                    "KOJI_TASK_ID": "1",
-                },
-                "artifacts": [
-                    {
-                        "id": "1",
-                        "type": "fedora-koji-build",
-                    },
-                ],
-                "tmt": {
-                    "context": {
-                        "distro": distro,
-                        "arch": "x86_64",
-                        "trigger": "commit",
-                        "initiator": "fedora-ci",
-                        "dist-git-branch": "rawhide",
-                        **extra_context,
-                    },
-                },
-            },
-        ],
-        "notification": {
-            "webhook": {
-                "url": "https://stg.packit.dev/api/testing-farm/results",
-                "token": "secret token",
-            },
-        },
+        **_common_payload(with_compose=True, with_artifact=True),
     }
 
     flexmock(aliases).should_receive("get_aliases").and_return({"fedora-all": [], "epel-all": []})

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -26,6 +26,7 @@ from packit.config import (
 from packit.config.requirements import LabelRequirementsConfig, RequirementsConfig
 from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject, LocalProjectBuilder
+from packit.utils import commands
 from packit.utils.koji_helper import KojiHelper
 
 import packit_service.service.urls as urls
@@ -65,7 +66,6 @@ from packit_service.worker.helpers.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.helpers.testing_farm import (
     TestingFarmClient,
     TestingFarmJobHelper,
-    commands,
 )
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.monitoring import Pushgateway
@@ -2676,40 +2676,6 @@ def test_koji_build_end_downstream(
     koji_build_pr_downstream.should_receive("set_status").with_args("success").once()
     koji_build_pr_downstream.should_receive("set_build_logs_urls")
     koji_build_pr_downstream.should_receive("set_web_url")
-
-    installability_repo = "https://github.com/fedora-ci/installability-pipeline.git"
-    installability_hash = "f6cd4a50476d9c8ffa36472c5ab2d2c8aad6cee1"
-
-    flexmock(commands).should_receive("run_command").with_args(
-        ["git", "ls-remote", installability_repo, "HEAD"], output=True
-    ).and_return(flexmock(stdout=f"{installability_hash}\tHEAD"))
-
-    payload_installability = {
-        "test": {
-            "tmt": {
-                "url": installability_repo,
-                "ref": installability_hash,
-            },
-        },
-        "environments": [
-            {
-                "arch": "x86_64",
-                "os": {"compose": compose},
-                "variables": {
-                    "PROFILE_NAME": profile,
-                    "TASK_ID": "1",
-                },
-            },
-        ],
-        "notification": {
-            "webhook": {
-                "url": "https://stg.packit.dev/api/testing-farm/results",
-                "token": "secret token",
-            },
-        },
-    }
-
-    rpminspect_repo = "https://github.com/fedora-ci/rpminspect-pipeline.git"
     common_payload_no_compose = {
         "environments": [
             {
@@ -2743,6 +2709,20 @@ def test_koji_build_end_downstream(
         },
     }
 
+    installability_repo = "https://github.com/fedora-ci/installability-pipeline.git"
+    payload_installability = {
+        "test": {
+            "tmt": {
+                "url": installability_repo,
+                "ref": "master",
+            },
+        },
+        **common_payload_no_compose,
+    }
+    payload_installability = copy.deepcopy(payload_installability)
+    payload_installability["environments"][0]["os"] = {"compose": compose}
+
+    rpminspect_repo = "https://github.com/fedora-ci/rpminspect-pipeline.git"
     payload_rpminspect = {
         "test": {
             "tmt": {
@@ -2838,10 +2818,6 @@ def test_koji_build_end_downstream(
     flexmock(TestingFarmClient).should_receive("distro2compose").with_args(
         distro,
     ).and_return(compose)
-
-    flexmock(KojiHelper).should_receive("get_candidate_tag").with_args("rawhide").and_return(
-        "f43-updates-candidate"
-    )
 
     pipeline_id = "5e8079d8-f181-41cf-af96-28e99774eb68"
     flexmock(TestingFarmClient).should_receive(


### PR DESCRIPTION
As part of the cleanup of the current fedora-ci jobs https://forge.fedoraproject.org/ci/tickets/issues/553, the interface for all of these jobs would converge to that from packit, simplifying how the jobs are handled here.

TODO:

- [x] Wait for installability to be compatible https://github.com/fedora-ci/installability-pipeline/pull/63
