### PR TITLE
Always honor `upstream_tag_include`/`upstream_tag_exclude`

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -7,6 +7,7 @@ This file defines classes for job handlers specific for distgit
 
 import abc
 import logging
+import re
 import shutil
 from collections import defaultdict
 from datetime import datetime
@@ -493,6 +494,22 @@ class AbstractSyncReleaseHandler(
         # no error occurred
         return None
 
+    def _filter_tags(self, tags: list[str]) -> list[str]:
+        """Filter the given tags using upstream_tag_include and
+        upstream_tag_exclude from the job config.
+        """
+        if upstream_tag_include := self.job_config.upstream_tag_include:
+            include_re = re.compile(upstream_tag_include)
+            tags = [tag for tag in tags if include_re.match(tag)]
+            logger.debug(f"Filtered tags after matching upstream_tag_include: {tags}")
+
+        if upstream_tag_exclude := self.job_config.upstream_tag_exclude:
+            exclude_re = re.compile(upstream_tag_exclude)
+            tags = [tag for tag in tags if not exclude_re.match(tag)]
+            logger.debug(f"Filtered tags after matching upstream_tag_exclude: {tags}")
+
+        return tags
+
     def _get_releases_to_sync(self) -> list[tuple[Optional[str], Optional[str]]]:
         """Get list of (tag, version) pairs to sync.
 
@@ -500,7 +517,7 @@ class AbstractSyncReleaseHandler(
         For non-git upstreams, returns (None, version) pairs.
         """
         if not self.packit_api.non_git_upstream:
-            return [(tag, None) for tag in self.tags]
+            return [(tag, None) for tag in self._filter_tags(self.tags)]
 
         versions = self.data.event_dict.get("versions") or []
         if not versions:

--- a/tests/unit/test_distgit.py
+++ b/tests/unit/test_distgit.py
@@ -186,3 +186,66 @@ def test__repo_url_with_git_ref(src, git_ref, expected):
         DownstreamKojiScratchBuildHandler._repo_url_with_git_ref(parse_git_repo(src), git_ref)
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    "tags, upstream_tag_include, upstream_tag_exclude, expected",
+    (
+        pytest.param(
+            ["2.1.1", "3.0.0"],
+            None,
+            None,
+            ["2.1.1", "3.0.0"],
+            id="no filters",
+        ),
+        pytest.param(
+            ["2.1.1", "3.0.0"],
+            r"^2\..+",
+            None,
+            ["2.1.1"],
+            id="include only",
+        ),
+        pytest.param(
+            ["2.1.1", "3.0.0"],
+            None,
+            r"^2\..+",
+            ["3.0.0"],
+            id="exclude only",
+        ),
+        pytest.param(
+            ["2.1.1", "2.2.0", "3.0.0"],
+            r"^2\..+",
+            r"^.+\.1\..+",
+            ["2.2.0"],
+            id="include and exclude",
+        ),
+        pytest.param(
+            ["3.0.0"],
+            r"^2\..+",
+            None,
+            [],
+            id="include filters out all",
+        ),
+    ),
+)
+def test_filter_tags(tags, upstream_tag_include, upstream_tag_exclude, expected):
+    flexmock(EventData).should_receive("from_event_dict").and_return(
+        flexmock(
+            event_type="unknown",
+            actor="an actor",
+            event_id=1,
+            project_url="a project url",
+            tag_name=None,
+        ),
+    )
+    handler = PullFromUpstreamHandler(
+        None,
+        flexmock(
+            upstream_project_url="url",
+            upstream_tag_include=upstream_tag_include,
+            upstream_tag_exclude=upstream_tag_exclude,
+        ),
+        {"event_type": "unknown"},
+        None,
+    )
+    assert handler._filter_tags(tags) == expected


### PR DESCRIPTION
Tag filtering doesn't happen when processing multi-release events and when retriggering pull-from-upstream. Fix that.