### PR TITLE
Process Log Detective message only if the Log Detective integration is enabled

### DIFF
--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1888,6 +1888,13 @@ class Parser:
         commit_sha = event.get("commit_sha")
         pr_id = event.get("pr_id")
 
+        if not ServiceConfig.get_service_config().logdetective_enabled:
+            logger.info(
+                f"Log Detective analysis event {analysis_id} received "
+                "but Log Detective integration is disabled. Dropping the message."
+            )
+            return None
+
         try:
             log_detective_analysis_start = datetime.fromisoformat(log_detective_analysis_start)
         except (TypeError, ValueError):

--- a/tests/unit/events/conftest.py
+++ b/tests/unit/events/conftest.py
@@ -19,6 +19,7 @@ def mock_config():
         PagureService(instance_url="https://src.fedoraproject.org", token="1234"),
     }
     service_config.github_requests_log_path = "/path"
+    service_config.logdetective_enabled = True
     ServiceConfig.service_config = service_config
 
 

--- a/tests/unit/events/test_logdetective.py
+++ b/tests/unit/events/test_logdetective.py
@@ -71,6 +71,7 @@ def test_parse_logdetective_analysis_result(
     logdetective_analysis_result,
     log_detective_result_event_creation,
     log_detective_run_model_get_by_identifier,
+    mock_config,
     build_system,
     status,
 ):
@@ -98,6 +99,7 @@ def test_parse_logdetective_analysis_result_error(
     logdetective_analysis_result_error,
     log_detective_result_event_creation,
     log_detective_run_model_get_by_identifier,
+    mock_config,
     build_system,
 ):
     """When analysis returns `error` result, the `log_detective_response`

--- a/tests_openshift/service/test_logdetective.py
+++ b/tests_openshift/service/test_logdetective.py
@@ -121,6 +121,7 @@ def test_logdetective_process_message(
 
     service_config = ServiceConfig().get_service_config()
     service_config.fedora_ci.enabled_projects = {logdetective_analysis_success_event["project_url"]}
+    service_config.logdetective_enabled = True
 
     # Set deployment to prod to disable guppy memory profiling logic
     # which causes UnboundLocalError when guppy is missing.
@@ -177,6 +178,44 @@ def test_logdetective_process_message(
     # database stores timestamp as UTC, but without timezone information
     # we need to remove timezone information here, to get a match
     assert run_model_after.submitted_time == expected_time.replace(tzinfo=None)
+
+
+@pytest.mark.parametrize(
+    "build_system", [LogDetectiveBuildSystem.copr, LogDetectiveBuildSystem.koji]
+)
+def test_logdetective_process_message_logdetective_disabled(
+    build_system,
+    clean_before_and_after,
+    logdetective_analysis_success_event,
+    mock_metrics_counters,
+    eager_celery_tasks,
+):
+    """Test that the processing of a Log Detective event
+    via the main Celery task `process_message` does not occur if the integration is disabled.
+    """
+
+    logdetective_analysis_success_event["build_system"] = build_system
+
+    service_config = ServiceConfig().get_service_config()
+    service_config.fedora_ci.enabled_projects = {logdetective_analysis_success_event["project_url"]}
+    service_config.logdetective_enabled = False
+
+    # Set deployment to prod to disable guppy memory profiling logic
+    # which causes UnboundLocalError when guppy is missing.
+    service_config.deployment = Deployment.prod
+    flexmock(ServiceConfig).should_receive("get_service_config").and_return(service_config)
+
+    # Ensure FedoraCIHelper.report is never called when LD is disabled
+    flexmock(FedoraCIHelper).should_receive("report").never()
+
+    result = process_message.apply(
+        args=[logdetective_analysis_success_event],
+        kwargs={"source": "fedora-messaging", "event_type": "logdetective.analysis"},
+        throw=True,
+    )
+    result = result.get()
+    # Parser returns None when LD is disabled, so no handlers run
+    assert result == []
 
 
 @pytest.mark.parametrize(
@@ -273,6 +312,7 @@ def test_logdetective_process_message_error(
 
     service_config = ServiceConfig().get_service_config()
     service_config.fedora_ci.enabled_projects = {logdetective_analysis_error_event["project_url"]}
+    service_config.logdetective_enabled = True
 
     # Set deployment to prod to disable guppy memory profiling logic
     # which causes UnboundLocalError when guppy is missing.


### PR DESCRIPTION
Messages from Log Detective may arrive even if the Log Detective integration is disabled.
In such a case, there are most likely no records in the database to link results to, and error ensues.

With this change no attempt at using database is made.

In order to provide at least reference to the dropped analysis response in logs, the message is parsed and id is retrieved.
But this is very fast operation and shouldn't tax resources in a noticeable way.

RELEASE NOTES BEGIN

Log Detective messages are not processed unless the `logdetective_enabled` is set to `True`.

RELEASE NOTES END
