### PR TITLE
Start from the highest release when processing multirelease events

### DIFF
--- a/packit_service/worker/handlers/distgit.py
+++ b/packit_service/worker/handlers/distgit.py
@@ -544,7 +544,14 @@ class AbstractSyncReleaseHandler(
         all_errors = {}
 
         try:
-            for tag, version in self._get_releases_to_sync():
+            # sort the releases starting from highest/newest as a workaround
+            # for cases where there is a borked release followed by a fixup one
+            # and we want to process the fixup first
+            for tag, version in sorted(
+                self._get_releases_to_sync(),
+                key=lambda tv: cmp_to_key(compare_versions)(tv[0] or tv[1]),
+                reverse=True,
+            ):
                 errors = self._run_for_release(tag=tag, version=version)
                 all_errors.update(errors)
         except AbortSyncRelease:

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -497,21 +497,7 @@ def test_new_hotness_update_non_git_multiple_versions(new_hotness_update):
         .should_receive("comment")
         .mock()
     )
-    # sync_release should be called once per version
-    flexmock(PackitAPI).should_receive("sync_release").with_args(
-        dist_git_branch="main",
-        versions=["7.0.3"],
-        create_pr=True,
-        local_pr_branch_suffix="update-pull_from_upstream",
-        use_downstream_specfile=True,
-        add_pr_instructions=True,
-        resolved_bugs=["rhbz#2106196"],
-        release_monitoring_project_id=4181,
-        sync_acls=True,
-        pr_description_footer=DistgitAnnouncement.get_announcement(),
-        add_new_sources=True,
-        fast_forward_merge_branches=set(),
-    ).and_return((pr, {})).once()
+    # sync_release should be called once per version, highest version first
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="main",
         versions=["7.0.4"],
@@ -525,7 +511,21 @@ def test_new_hotness_update_non_git_multiple_versions(new_hotness_update):
         pr_description_footer=DistgitAnnouncement.get_announcement(),
         add_new_sources=True,
         fast_forward_merge_branches=set(),
-    ).and_return((pr, {})).once()
+    ).and_return((pr, {})).once().ordered()
+    flexmock(PackitAPI).should_receive("sync_release").with_args(
+        dist_git_branch="main",
+        versions=["7.0.3"],
+        create_pr=True,
+        local_pr_branch_suffix="update-pull_from_upstream",
+        use_downstream_specfile=True,
+        add_pr_instructions=True,
+        resolved_bugs=["rhbz#2106196"],
+        release_monitoring_project_id=4181,
+        sync_acls=True,
+        pr_description_footer=DistgitAnnouncement.get_announcement(),
+        add_new_sources=True,
+        fast_forward_merge_branches=set(),
+    ).and_return((pr, {})).once().ordered()
     flexmock(PackitAPI).should_receive("clean")
 
     for model, sync_release_model in [


### PR DESCRIPTION
Related to https://github.com/packit/packit-service/issues/3107.