### PR TITLE
Only cancel those running test jobs that will be retriggered

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -3671,6 +3671,8 @@ class TFTTestRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
         ranch: str,
         created_before: Optional[datetime] = None,
         has_copr_build: Optional[bool] = None,
+        identifier: Optional[str] = None,
+        targets: Optional[set[str]] = None,
     ) -> Iterable["TFTTestRunTargetModel"]:
         """Get list of currently running Testing Farm runs for a given project
         object (e.g. a PR or branch).
@@ -3685,6 +3687,13 @@ class TFTTestRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             has_copr_build: If set, filter by whether the test run's pipeline
                 is associated with a Copr build group. `True` returns only runs
                 linked to a Copr build, `False` returns only runs without one.
+            identifier: Only return test runs matching this identifier
+                (e.g. "full", "sanity"). When None, filters for test runs
+                with no identifier (IS NULL).
+            targets: If set, only return test runs whose target/chroot is
+                in this set (e.g. {"fedora-43-x86_64"}). Used to scope
+                cancellation to specific targets during check re-runs
+                or retest-failed.
 
         Returns:
             An iterable over TFT target models that reprepresent matching TF
@@ -3714,6 +3723,9 @@ class TFTTestRunGroupModel(ProjectAndEventsConnector, GroupModel, Base):
                 q = q.filter(PipelineModel.copr_build_group_id.isnot(None))
             elif has_copr_build is False:
                 q = q.filter(PipelineModel.copr_build_group_id.is_(None))
+            q = q.filter(TFTTestRunTargetModel.identifier == identifier)
+            if targets is not None:
+                q = q.filter(TFTTestRunTargetModel.target.in_(targets))
             return q
 
 

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -2204,6 +2204,8 @@ class CoprBuildGroupModel(ProjectAndEventsConnector, GroupModel, Base):
         project_event_type: ProjectEventModelType,
         event_id: int,
         created_before: Optional[datetime] = None,
+        identifier: Optional[str] = None,
+        targets: Optional[set[str]] = None,
     ) -> Iterable["CoprBuildTargetModel"]:
         """Get list of currently running Copr builds for a given project object
         (e.g. a PR or branch).
@@ -2214,6 +2216,11 @@ class CoprBuildGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             created_before: If set, only return builds whose pipeline was
                 created at or before this datetime (used to avoid cancelling
                 builds from the current trigger batch).
+            identifier: Only return builds matching this identifier.
+                When None, filters for builds with no identifier (IS NULL).
+            targets: If set, only return builds whose target/chroot is
+                in this set. Used to scope cancellation to specific
+                targets during check re-runs or rebuild-failed.
 
         Returns:
             An iterable over Copr target models that are currently in queue
@@ -2235,6 +2242,9 @@ class CoprBuildGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             )
             if created_before is not None:
                 q = q.filter(PipelineModel.datetime <= created_before)
+            q = q.filter(CoprBuildTargetModel.identifier == identifier)
+            if targets is not None:
+                q = q.filter(CoprBuildTargetModel.target.in_(targets))
             return q
 
 
@@ -2667,6 +2677,7 @@ class KojiBuildGroupModel(ProjectAndEventsConnector, GroupModel, Base):
         project_event_type: ProjectEventModelType,
         event_id: int,
         created_before: Optional[datetime] = None,
+        targets: Optional[set[str]] = None,
     ) -> Iterable["KojiBuildTargetModel"]:
         """Get running Koji builds for a given project object (e.g. a PR or branch).
 
@@ -2676,6 +2687,9 @@ class KojiBuildGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             created_before: If set, only return builds whose pipeline was
                 created at or before this datetime (used to avoid cancelling
                 builds from the current trigger batch).
+            targets: If set, only return builds whose target is in this set.
+                Used to scope cancellation to specific targets during
+                check re-runs.
 
         Returns:
             An iterable over KojiBuildTargetModels in non-final states.
@@ -2694,6 +2708,8 @@ class KojiBuildGroupModel(ProjectAndEventsConnector, GroupModel, Base):
             )
             if created_before is not None:
                 q = q.filter(PipelineModel.datetime <= created_before)
+            if targets is not None:
+                q = q.filter(KojiBuildTargetModel.target.in_(targets))
             return q
 
 

--- a/packit_service/worker/helpers/build/copr_build.py
+++ b/packit_service/worker/helpers/build/copr_build.py
@@ -1033,10 +1033,18 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 "to avoid canceling unrelated jobs."
             )
             return
+        targets = None
+        if self.build_targets_override is not None:
+            targets = {t for t, _ in self.build_targets_override}
+            if not targets:
+                return
+
         yield from CoprBuildGroupModel.get_running(
             project_event_type=self.db_project_event.type,
             event_id=self.db_project_event.event_id,
             created_before=self.metadata.cancel_cutoff_time,
+            identifier=self.job_config.identifier,
+            targets=targets,
         )
 
     def cancel_running_builds(self):

--- a/packit_service/worker/helpers/build/koji_build.py
+++ b/packit_service/worker/helpers/build/koji_build.py
@@ -238,10 +238,17 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
                 "to avoid canceling unrelated jobs."
             )
             return
+        targets = None
+        if self.build_targets_override is not None:
+            targets = {t for t, _ in self.build_targets_override}
+            if not targets:
+                return
+
         yield from KojiBuildGroupModel.get_running(
             project_event_type=self.db_project_event.type,
             event_id=self.db_project_event.event_id,
             created_before=self.metadata.cancel_cutoff_time,
+            targets=targets,
         )
 
     def cancel_running_builds(

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -1243,12 +1243,23 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
                 "to avoid canceling unrelated jobs."
             )
             return
+
+        targets = None
+        if self.tests_targets_override is not None:
+            targets = {
+                t for t, ident in self.tests_targets_override if ident == self.job_config.identifier
+            }
+            if not targets:
+                return
+
         yield from TFTTestRunGroupModel.get_running(
             project_event_type=self.db_project_event.type,
             event_id=self.db_project_event.event_id,
             ranch=self.tft_client.default_ranch,
             created_before=self.metadata.cancel_cutoff_time,
             has_copr_build=not self.skip_build,
+            identifier=self.job_config.identifier,
+            targets=targets,
         )
 
     def cancel_running_tests(self):

--- a/tests/integration/test_koji_build_cancel.py
+++ b/tests/integration/test_koji_build_cancel.py
@@ -496,6 +496,7 @@ def test_downstream_koji_build_cancel_uses_event_based_filtering(monkeypatch):
         project_event_type=ProjectEventModelType.branch_push,
         event_id=9,
         created_before=cutoff_time,
+        targets=None,
     ).and_return([]).once()
 
     distgit_commit = json.loads(

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -1039,3 +1039,73 @@ def test_check_if_actor_can_run_job_and_report(jobs, should_pass):
         )
         == should_pass
     )
+
+
+def test_get_running_jobs_check_rerun_passes_identifier_and_targets(github_pr_event):
+    """Check re-run on rpm-build:fedora-rawhide-x86_64 should pass
+    identifier and targets={'fedora-rawhide-x86_64'}."""
+    helper = build_helper(
+        event=github_pr_event,
+        build_targets_override={("fedora-rawhide-x86_64", None)},
+    )
+    helper.metadata.cancel_cutoff_time = flexmock()
+    helper.db_project_event = flexmock(
+        type="pull_request",
+        event_id=42,
+    )
+    sentinel = [flexmock()]
+    flexmock(CoprBuildGroupModel).should_receive("get_running").with_args(
+        project_event_type="pull_request",
+        event_id=42,
+        created_before=helper.metadata.cancel_cutoff_time,
+        identifier=None,
+        targets={"fedora-rawhide-x86_64"},
+    ).and_return(sentinel).once()
+    assert list(helper.get_running_jobs()) == sentinel
+
+
+def test_get_running_jobs_comment_trigger_no_targets(github_pr_event):
+    """/packit build should pass identifier and targets=None (cancel all)."""
+    helper = build_helper(
+        event=github_pr_event,
+        build_targets_override=None,
+    )
+    helper.metadata.cancel_cutoff_time = flexmock()
+    helper.db_project_event = flexmock(
+        type="pull_request",
+        event_id=42,
+    )
+    sentinel = [flexmock()]
+    flexmock(CoprBuildGroupModel).should_receive("get_running").with_args(
+        project_event_type="pull_request",
+        event_id=42,
+        created_before=helper.metadata.cancel_cutoff_time,
+        identifier=None,
+        targets=None,
+    ).and_return(sentinel).once()
+    assert list(helper.get_running_jobs()) == sentinel
+
+
+def test_get_running_jobs_rebuild_failed_passes_targets(github_pr_event):
+    """rebuild-failed with multiple failed targets should pass all targets."""
+    helper = build_helper(
+        event=github_pr_event,
+        build_targets_override={
+            ("fedora-rawhide-x86_64", None),
+            ("fedora-40-x86_64", None),
+        },
+    )
+    helper.metadata.cancel_cutoff_time = flexmock()
+    helper.db_project_event = flexmock(
+        type="pull_request",
+        event_id=42,
+    )
+    sentinel = [flexmock()]
+    flexmock(CoprBuildGroupModel).should_receive("get_running").with_args(
+        project_event_type="pull_request",
+        event_id=42,
+        created_before=helper.metadata.cancel_cutoff_time,
+        identifier=None,
+        targets={"fedora-rawhide-x86_64", "fedora-40-x86_64"},
+    ).and_return(sentinel).once()
+    assert list(helper.get_running_jobs()) == sentinel

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -605,6 +605,48 @@ def test_get_koji_rpm_build_web_url(id_, result):
     assert koji.result.Task.get_koji_rpm_build_web_url(rpm_build_task_id=id_) == result
 
 
+def test_get_running_jobs_check_rerun_passes_targets(github_pr_event):
+    """Check re-run on koji-build:f41 should pass targets={'f41'}."""
+    helper = build_helper(
+        event=github_pr_event,
+        build_targets_override={("f41", None)},
+    )
+    helper.metadata.cancel_cutoff_time = flexmock()
+    helper.db_project_event = flexmock(
+        type="pull_request",
+        event_id=42,
+    )
+    sentinel = [flexmock()]
+    flexmock(KojiBuildGroupModel).should_receive("get_running").with_args(
+        project_event_type="pull_request",
+        event_id=42,
+        created_before=helper.metadata.cancel_cutoff_time,
+        targets={"f41"},
+    ).and_return(sentinel).once()
+    assert list(helper.get_running_jobs()) == sentinel
+
+
+def test_get_running_jobs_comment_trigger_no_targets(github_pr_event):
+    """/packit build should pass targets=None (cancel all)."""
+    helper = build_helper(
+        event=github_pr_event,
+        build_targets_override=None,
+    )
+    helper.metadata.cancel_cutoff_time = flexmock()
+    helper.db_project_event = flexmock(
+        type="pull_request",
+        event_id=42,
+    )
+    sentinel = [flexmock()]
+    flexmock(KojiBuildGroupModel).should_receive("get_running").with_args(
+        project_event_type="pull_request",
+        event_id=42,
+        created_before=helper.metadata.cancel_cutoff_time,
+        targets=None,
+    ).and_return(sentinel).once()
+    assert list(helper.get_running_jobs()) == sentinel
+
+
 def test_cancel_running_builds():
     build1 = flexmock(task_id="111", id=1, target="f41")
     build2 = flexmock(task_id="222", id=2, target="f42")

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -2346,3 +2346,176 @@ def test_parse_comment_arguments(
     assert helper.comment_arguments.identifier == expected_identifier
     assert helper.comment_arguments.labels == expected_labels
     assert helper.comment_arguments.envs == expected_envs
+
+
+class TestGetRunningJobs:
+    """Tests for TFJobHelper.get_running_jobs() cancel-scoping logic."""
+
+    @staticmethod
+    def _make_helper(
+        identifier=None,
+        tests_targets_override=None,
+        skip_build=False,
+        cancel_cutoff_time=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    ):
+        job_config = JobConfig(
+            trigger=JobConfigTriggerType.pull_request,
+            type=JobType.tests,
+            packages={
+                "package": CommonPackageConfig(
+                    identifier=identifier,
+                    skip_build=skip_build,
+                    _targets=["fedora-42-x86_64", "fedora-43-x86_64"],
+                ),
+            },
+        )
+        metadata = flexmock(
+            cancel_cutoff_time=cancel_cutoff_time,
+            event_dict={"comment": "/packit test"},
+        )
+        db_project_event = (
+            flexmock(
+                type=ProjectEventModelType.pull_request,
+                event_id=42,
+            )
+            .should_receive("get_project_event_object")
+            .and_return(
+                flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request),
+            )
+            .mock()
+        )
+        helper = TFJobHelper(
+            service_config=flexmock(
+                comment_command_prefix="/packit",
+                deployment=Deployment.prod,
+            ),
+            package_config=flexmock(jobs=[]),
+            project=flexmock(),
+            metadata=metadata,
+            db_project_event=db_project_event,
+            job_config=job_config,
+            tests_targets_override=tests_targets_override,
+        )
+        helper._tft_client = flexmock(default_ranch="public")
+        return helper
+
+    def test_no_db_project_event(self):
+        helper = self._make_helper()
+        helper.db_project_event = None
+        assert list(helper.get_running_jobs()) == []
+
+    def test_no_cancel_cutoff_time(self):
+        helper = self._make_helper(cancel_cutoff_time=None)
+        assert list(helper.get_running_jobs()) == []
+
+    def test_check_rerun_passes_identifier_and_target(self):
+        """Re-running testing-farm:fedora-43-x86_64:full should pass both
+        identifier='full' and targets={'fedora-43-x86_64'}."""
+        helper = self._make_helper(
+            identifier="full",
+            tests_targets_override={("fedora-43-x86_64", "full")},
+        )
+        sentinel = [flexmock()]
+        flexmock(TFTTestRunGroupModel).should_receive("get_running").with_args(
+            project_event_type=ProjectEventModelType.pull_request,
+            event_id=42,
+            ranch="public",
+            created_before=helper.metadata.cancel_cutoff_time,
+            has_copr_build=True,
+            identifier="full",
+            targets={"fedora-43-x86_64"},
+        ).and_return(sentinel).once()
+        assert list(helper.get_running_jobs()) == sentinel
+
+    def test_retest_failed_passes_identifier_and_multiple_targets(self):
+        """retest-failed with multiple failed targets for the same identifier
+        should pass all of them in the targets set."""
+        helper = self._make_helper(
+            identifier="full",
+            tests_targets_override={
+                ("fedora-42-x86_64", "full"),
+                ("fedora-43-x86_64", "full"),
+            },
+        )
+        sentinel = [flexmock()]
+        flexmock(TFTTestRunGroupModel).should_receive("get_running").with_args(
+            project_event_type=ProjectEventModelType.pull_request,
+            event_id=42,
+            ranch="public",
+            created_before=helper.metadata.cancel_cutoff_time,
+            has_copr_build=True,
+            identifier="full",
+            targets={"fedora-42-x86_64", "fedora-43-x86_64"},
+        ).and_return(sentinel).once()
+        assert list(helper.get_running_jobs()) == sentinel
+
+    def test_comment_trigger_passes_identifier_only(self):
+        """/packit test --identifier full should pass identifier='full'
+        but targets=None (cancel all targets for that identifier)."""
+        helper = self._make_helper(
+            identifier="full",
+            tests_targets_override=None,
+        )
+        sentinel = [flexmock()]
+        flexmock(TFTTestRunGroupModel).should_receive("get_running").with_args(
+            project_event_type=ProjectEventModelType.pull_request,
+            event_id=42,
+            ranch="public",
+            created_before=helper.metadata.cancel_cutoff_time,
+            has_copr_build=True,
+            identifier="full",
+            targets=None,
+        ).and_return(sentinel).once()
+        assert list(helper.get_running_jobs()) == sentinel
+
+    def test_comment_trigger_no_identifier(self):
+        """/packit test (no identifier) should pass identifier=None
+        and targets=None."""
+        helper = self._make_helper(
+            identifier=None,
+            tests_targets_override=None,
+        )
+        sentinel = [flexmock()]
+        flexmock(TFTTestRunGroupModel).should_receive("get_running").with_args(
+            project_event_type=ProjectEventModelType.pull_request,
+            event_id=42,
+            ranch="public",
+            created_before=helper.metadata.cancel_cutoff_time,
+            has_copr_build=True,
+            identifier=None,
+            targets=None,
+        ).and_return(sentinel).once()
+        assert list(helper.get_running_jobs()) == sentinel
+
+    def test_override_with_different_identifier_returns_early(self):
+        """If tests_targets_override contains targets for a different identifier,
+        get_running_jobs should return early without querying."""
+        helper = self._make_helper(
+            identifier="full",
+            tests_targets_override={("fedora-43-x86_64", "sanity")},
+        )
+        flexmock(TFTTestRunGroupModel).should_receive("get_running").never()
+        assert list(helper.get_running_jobs()) == []
+
+    def test_cancel_running_tests_calls_cancel_and_sets_status(self):
+        run1 = flexmock(pipeline_id="abc-123")
+        run2 = flexmock(pipeline_id="def-456")
+        run1.should_receive("set_status").with_args(
+            TestingFarmResult.cancel_requested,
+        ).once()
+        run2.should_receive("set_status").with_args(
+            TestingFarmResult.cancel_requested,
+        ).once()
+
+        helper = self._make_helper(identifier="full")
+        flexmock(helper).should_receive("get_running_jobs").and_return([run1, run2])
+        helper._tft_client.should_receive("cancel").with_args("abc-123").once()
+        helper._tft_client.should_receive("cancel").with_args("def-456").once()
+
+        helper.cancel_running_tests()
+
+    def test_cancel_running_tests_noop_when_nothing_running(self):
+        helper = self._make_helper(identifier="full")
+        flexmock(helper).should_receive("get_running_jobs").and_return([])
+        helper._tft_client.should_receive("cancel").never()
+        helper.cancel_running_tests()


### PR DESCRIPTION
Consider test target and/or identifier when filtering test jobs to cancel, depending on the trigger.

Fixes: https://github.com/packit/packit-service/issues/3104