### PR TITLE
Improve content of help message

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -34,12 +34,19 @@ HELP_COMMENT_EPILOG = (
     "**Documentation**: \n - {docs}"
 )
 HELP_NOTE = (
-    "If using Fedora CI, refer to `/packit-ci help` instead. "
-    "Refer to `/packit-ci-stg help` if using the staging instance."
+    "`/packit` commands interact with the opt-in packit jobs "
+    "(e.g. `propose-downstream`, `pull-from-upstream`). "
+    "If you are looking for help on Fedora CI jobs "
+    "(e.g. `scratch-build`, `test rpminspect`, etc.), "
+    "refer to `/packit-ci` or `/packit-ci-stg`."
 )
 HELP_NOTE_FEDORA_CI = (
-    "For default Packit behaviour, refer to `/packit help` instead. "
-    "Refer to `/packit-stg help` if using the staging instance."
+    "`/packit-ci` commands interact with Fedora CI jobs "
+    "(e.g. `scratch-build`, `test rpminspect`, etc.). "
+    "If you are looking for help on the opt-in packit jobs "
+    "(e.g. `propose-downstream`, `pull-from-upstream`), "
+    "refer to `/packit` or `/packit-stg`. "
+    "These assume a `.packit.yaml` configuration file is present in the repo."
 )
 
 KOJI_PRODUCTION_BUILDS_ISSUE = "https://pagure.io/releng/issue/9801"

--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -241,15 +241,13 @@ def _create_base_parser(
     description: str | None = None,
     epilog: str | None = None,
 ) -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    return argparse.ArgumentParser(
         prog=prog,
         description=description,
         epilog=epilog,
         formatter_class=RawTextHelpFormatter,
         add_help=False,
     )
-    parser.add_argument("--package", help="specific package from monorepo to run job for")
-    return parser
 
 
 def get_comment_parser(
@@ -258,6 +256,7 @@ def get_comment_parser(
     epilog: str | None = None,
 ) -> argparse.ArgumentParser:
     parser = _create_base_parser(prog, description, epilog)
+    parser.add_argument("--package", help="specific package from monorepo to run job for")
 
     subparsers = parser.add_subparsers(
         dest="command",

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -273,9 +273,8 @@ class SteveJobs:
         try:
             args = parser.parse_args(commands)
             check_target = getattr(args, "check_target", None)
-            return ParsedComment(
-                command=args.command, package=args.package, check_target=check_target
-            )
+            package = getattr(args, "package", None)
+            return ParsedComment(command=args.command, package=package, check_target=check_target)
         except SystemExit:
             # tests expect invalid syntax comments be ignored
             logger.debug(


### PR DESCRIPTION
The previous version of help messages referred to the `--package` parameter, which is not supported in Fedora CI and should not be included in the corresponding help message. Also, the notes in the epilog of the message weren't worded the best way. This is now fixed.