### PR TITLE
Fix circular import preventing allowlist.py script execution

### DIFF
--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import argparse
 import itertools
 import logging
@@ -12,7 +14,7 @@ from io import StringIO
 from logging import StreamHandler
 from pathlib import Path
 from re import search
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import requests
@@ -20,6 +22,7 @@ from cachetools.func import ttl_cache
 from ogr.abstract import PullRequest
 from packit.config import JobConfig, PackageConfig, aliases
 from packit.config.aliases import Distro
+from packit.config.common_package_config import Deployment
 from packit.schema import JobConfigSchema, PackageConfigSchema
 from packit.utils import PackitFormatter
 
@@ -30,6 +33,9 @@ from packit_service.constants import (
     ELN_EXTRAS_PACKAGE_LIST,
     ELN_PACKAGE_LIST,
 )
+
+if TYPE_CHECKING:
+    from packit_service.config import ServiceConfig
 
 logger = logging.getLogger(__name__)
 
@@ -231,9 +237,9 @@ def get_packit_commands_from_comment(
 
 
 def _create_base_parser(
-    prog: Optional[str] = None,
-    description: Optional[str] = None,
-    epilog: Optional[str] = None,
+    prog: str | None = None,
+    description: str | None = None,
+    epilog: str | None = None,
 ) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog=prog,
@@ -247,9 +253,9 @@ def _create_base_parser(
 
 
 def get_comment_parser(
-    prog: Optional[str] = None,
-    description: Optional[str] = None,
-    epilog: Optional[str] = None,
+    prog: str | None = None,
+    description: str | None = None,
+    epilog: str | None = None,
 ) -> argparse.ArgumentParser:
     parser = _create_base_parser(prog, description, epilog)
 
@@ -333,9 +339,9 @@ def get_comment_parser(
 
 
 def get_comment_parser_fedora_ci(
-    prog: Optional[str] = None,
-    description: Optional[str] = None,
-    epilog: Optional[str] = None,
+    prog: str | None = None,
+    description: str | None = None,
+    epilog: str | None = None,
 ) -> argparse.ArgumentParser:
     parser = _create_base_parser(prog, description, epilog)
 
@@ -376,7 +382,7 @@ def get_comment_parser_fedora_ci(
     return parser
 
 
-def get_koji_task_id_and_url_from_stdout(stdout: str) -> tuple[Optional[int], Optional[str]]:
+def get_koji_task_id_and_url_from_stdout(stdout: str) -> tuple[int | None, str | None]:
     task_id, task_url = None, None
 
     task_id_match = search(pattern=r"Created task: (\d+)", string=stdout)
@@ -394,7 +400,7 @@ def get_koji_task_id_and_url_from_stdout(stdout: str) -> tuple[Optional[int], Op
 
 
 def pr_labels_match_configuration(
-    pull_request: Optional[PullRequest],
+    pull_request: PullRequest | None,
     configured_labels_present: list[str],
     configured_labels_absent: list[str],
 ) -> bool:
@@ -447,7 +453,7 @@ def check_url(url: str) -> bool:
         return False
 
 
-def check_content_type(content_type: Union[str, None], url: str) -> bool:
+def check_content_type(content_type: str | None, url: str) -> bool:
     """
     Verify that content_type is text/plain and log failures.
 
@@ -607,3 +613,8 @@ def break_lines_in_text(text: str, sep: str, max_line_length: int):
         split_text.append(line)
 
     return "\n".join(split_text)
+
+
+def get_check_name_prefix(service_config: ServiceConfig) -> str:
+    """Return the prefix for check names based on deployment environment."""
+    return "Packit-stg" if service_config.deployment == Deployment.stg else "Packit"

--- a/packit_service/worker/checker/testing_farm.py
+++ b/packit_service/worker/checker/testing_farm.py
@@ -22,6 +22,8 @@ from packit_service.worker.handlers.mixin import (
     GetCoprBuildMixin,
     GetGithubCommentEventMixin,
     GetKojiBuildFromTaskOrPullRequestMixin,
+)
+from packit_service.worker.helpers.testing_farm_mixin import (
     GetTestingFarmJobHelperMixin,
 )
 from packit_service.worker.reporting import BaseCommitStatus

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -21,7 +21,6 @@ from celery.canvas import Signature
 from ogr.abstract import GitProject
 from ogr.exceptions import OgrException
 from packit.config import JobConfig, JobType, PackageConfig
-from packit.config.common_package_config import Deployment
 from packit.constants import DATETIME_FORMAT
 from packit.exceptions import PackitConfigException
 
@@ -37,7 +36,11 @@ from packit_service.models import (
     AbstractProjectObjectDbType,
 )
 from packit_service.sentry_integration import push_scope_to_sentry
-from packit_service.utils import dump_job_config, dump_package_config
+from packit_service.utils import (
+    dump_job_config,
+    dump_package_config,
+    get_check_name_prefix,
+)
 from packit_service.worker.celery_task import CeleryTask
 from packit_service.worker.checker.abstract import Checker
 from packit_service.worker.mixin import (
@@ -626,7 +629,7 @@ class FedoraCIJobHandler(JobHandler):
     @staticmethod
     def get_check_name_prefix(service_config: ServiceConfig) -> str:
         """Return the prefix for check names based on deployment environment."""
-        return "Packit-stg" if service_config.deployment == Deployment.stg else "Packit"
+        return get_check_name_prefix(service_config)
 
     @classmethod
     def get_check_name(cls, service_config: ServiceConfig) -> str:

--- a/packit_service/worker/handlers/mixin.py
+++ b/packit_service/worker/handlers/mixin.py
@@ -35,10 +35,6 @@ from packit_service.worker.handlers.abstract import CeleryTask
 from packit_service.worker.helpers.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.helpers.build.koji_build import KojiBuildJobHelper
 from packit_service.worker.helpers.sidetag import Sidetag, SidetagHelper
-from packit_service.worker.helpers.testing_farm import (
-    DownstreamTestingFarmJobHelper,
-    TestingFarmJobHelper,
-)
 from packit_service.worker.mixin import Config, ConfigFromEventMixin, GetBranches
 from packit_service.worker.monitoring import Pushgateway
 
@@ -606,68 +602,6 @@ class GetCoprBuildJobHelperForIdMixin(
                 build_targets_override=build_targets_override,
             )
         return self._copr_build_helper
-
-
-class GetTestingFarmJobHelper(Protocol):
-    package_config: PackageConfig
-    job_config: JobConfig
-    celery_task: Optional[CeleryTask] = None
-
-    @property
-    @abstractmethod
-    def testing_farm_job_helper(self) -> TestingFarmJobHelper: ...
-
-
-class GetTestingFarmJobHelperMixin(
-    GetTestingFarmJobHelper,
-    GetCoprBuildMixin,
-    ConfigFromEventMixin,
-):
-    _testing_farm_job_helper: Optional[TestingFarmJobHelper] = None
-
-    @property
-    def testing_farm_job_helper(self) -> TestingFarmJobHelper:
-        if not self._testing_farm_job_helper:
-            self._testing_farm_job_helper = TestingFarmJobHelper(
-                service_config=self.service_config,
-                package_config=self.package_config,
-                project=self.project,
-                metadata=self.data,
-                db_project_event=self.db_project_event,
-                job_config=self.job_config,
-                build_targets_override=self.data.build_targets_override,
-                tests_targets_override=self.data.tests_targets_override,
-                celery_task=self.celery_task,
-            )
-        return self._testing_farm_job_helper
-
-
-class GetDownstreamTestingFarmJobHelper(Protocol):
-    celery_task: Optional[CeleryTask] = None
-
-    @property
-    @abstractmethod
-    def downstream_testing_farm_job_helper(self) -> DownstreamTestingFarmJobHelper: ...
-
-
-class GetDownstreamTestingFarmJobHelperMixin(
-    GetDownstreamTestingFarmJobHelper,
-    GetKojiBuildFromTaskOrPullRequestMixin,
-    ConfigFromEventMixin,
-):
-    _downstream_testing_farm_job_helper: Optional[DownstreamTestingFarmJobHelper] = None
-
-    @property
-    def downstream_testing_farm_job_helper(self) -> DownstreamTestingFarmJobHelper:
-        if not self._downstream_testing_farm_job_helper:
-            self._downstream_testing_farm_job_helper = DownstreamTestingFarmJobHelper(
-                service_config=self.service_config,
-                project=self.project,
-                metadata=self.data,
-                koji_build=self.koji_build,
-                celery_task=self.celery_task,
-            )
-        return self._downstream_testing_farm_job_helper
 
 
 class GetGithubCommentEvent(Protocol):

--- a/packit_service/worker/handlers/testing_farm.py
+++ b/packit_service/worker/handlers/testing_farm.py
@@ -80,13 +80,15 @@ from packit_service.worker.handlers.abstract import (
 )
 from packit_service.worker.handlers.mixin import (
     GetCoprBuildMixin,
-    GetDownstreamTestingFarmJobHelperMixin,
     GetGithubCommentEventMixin,
-    GetTestingFarmJobHelperMixin,
 )
 from packit_service.worker.helpers.testing_farm import (
     DownstreamTestingFarmJobHelper,
     TestingFarmJobHelper,
+)
+from packit_service.worker.helpers.testing_farm_mixin import (
+    GetDownstreamTestingFarmJobHelperMixin,
+    GetTestingFarmJobHelperMixin,
 )
 from packit_service.worker.mixin import PackitAPIWithDownstreamMixin
 from packit_service.worker.reporting import BaseCommitStatus

--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -39,9 +39,12 @@ from packit_service.models import (
 )
 from packit_service.sentry_integration import send_to_sentry
 from packit_service.service.urls import get_testing_farm_info_url
-from packit_service.utils import get_package_nvrs, get_packit_commands_from_comment
+from packit_service.utils import (
+    get_check_name_prefix,
+    get_package_nvrs,
+    get_packit_commands_from_comment,
+)
 from packit_service.worker.celery_task import CeleryTask
-from packit_service.worker.handlers.abstract import FedoraCIJobHandler
 from packit_service.worker.helpers.build import CoprBuildJobHelper
 from packit_service.worker.helpers.fedora_ci import FedoraCIHelper
 from packit_service.worker.helpers.testing_farm_client import TestingFarmClient
@@ -1394,7 +1397,7 @@ class DownstreamTestingFarmJobHelper:
     @staticmethod
     def get_check_name_from_config(test_name: str, service_config: ServiceConfig) -> str:
         """Static version for use in class methods."""
-        prefix = FedoraCIJobHandler.get_check_name_prefix(service_config)
+        prefix = get_check_name_prefix(service_config)
         return f"{prefix} - {test_name}"
 
     def report(

--- a/packit_service/worker/helpers/testing_farm_mixin.py
+++ b/packit_service/worker/helpers/testing_farm_mixin.py
@@ -1,0 +1,87 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+"""
+Mixins for Testing Farm job helpers.
+Separated from handlers/mixin.py to avoid circular imports.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Protocol
+
+from packit.config import JobConfig, PackageConfig
+
+from packit_service.worker.celery_task import CeleryTask
+from packit_service.worker.handlers.mixin import (
+    GetCoprBuildMixin,
+    GetKojiBuildFromTaskOrPullRequestMixin,
+)
+from packit_service.worker.helpers.testing_farm import (
+    DownstreamTestingFarmJobHelper,
+    TestingFarmJobHelper,
+)
+from packit_service.worker.mixin import ConfigFromEventMixin
+
+
+class GetTestingFarmJobHelper(Protocol):
+    package_config: PackageConfig
+    job_config: JobConfig
+    celery_task: CeleryTask | None = None
+
+    @property
+    @abstractmethod
+    def testing_farm_job_helper(self) -> TestingFarmJobHelper: ...
+
+
+class GetTestingFarmJobHelperMixin(
+    GetTestingFarmJobHelper,
+    GetCoprBuildMixin,
+    ConfigFromEventMixin,
+):
+    _testing_farm_job_helper: TestingFarmJobHelper | None = None
+
+    @property
+    def testing_farm_job_helper(self) -> TestingFarmJobHelper:
+        if not self._testing_farm_job_helper:
+            self._testing_farm_job_helper = TestingFarmJobHelper(
+                service_config=self.service_config,
+                package_config=self.package_config,
+                project=self.project,
+                metadata=self.data,
+                db_project_event=self.db_project_event,
+                job_config=self.job_config,
+                build_targets_override=self.data.build_targets_override,
+                tests_targets_override=self.data.tests_targets_override,
+                celery_task=self.celery_task,
+            )
+        return self._testing_farm_job_helper
+
+
+class GetDownstreamTestingFarmJobHelper(Protocol):
+    celery_task: CeleryTask | None = None
+
+    @property
+    @abstractmethod
+    def downstream_testing_farm_job_helper(self) -> DownstreamTestingFarmJobHelper: ...
+
+
+class GetDownstreamTestingFarmJobHelperMixin(
+    GetDownstreamTestingFarmJobHelper,
+    GetKojiBuildFromTaskOrPullRequestMixin,
+    ConfigFromEventMixin,
+):
+    _downstream_testing_farm_job_helper: DownstreamTestingFarmJobHelper | None = None
+
+    @property
+    def downstream_testing_farm_job_helper(self) -> DownstreamTestingFarmJobHelper:
+        if not self._downstream_testing_farm_job_helper:
+            self._downstream_testing_farm_job_helper = DownstreamTestingFarmJobHelper(
+                service_config=self.service_config,
+                project=self.project,
+                metadata=self.data,
+                koji_build=self.koji_build,
+                celery_task=self.celery_task,
+            )
+        return self._downstream_testing_farm_job_helper


### PR DESCRIPTION
The allowlist.py script failed with ImportError due to circular dependency.

Created packit_service/worker/helpers/testing_farm_mixin.py to separate Testing Farm-specific mixins from general handler mixins.

Extracted get_check_name_prefix() from FedoraCIJobHandler to packit_service/utils.py as a standalone utility function.

RELEASE NOTES BEGIN

Fix circular import that prevented the allowlist script from running.

RELEASE NOTES END
