### PR TITLE
Update the epilog of the help comment

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -25,14 +25,16 @@ HELP_COMMENT_PROG_STG = "/packit-stg"
 HELP_COMMENT_PROG_FEDORA_CI = "/packit-ci"
 HELP_COMMENT_PROG_FEDORA_CI_STG = "/packit-ci-stg"
 HELP_COMMENT_DESCRIPTION = ""
-HELP_COMMENT_EPILOG = (
-    "**Please note**: \n - {note}\n\n"
+HELP_COMMENT_NOTE = "**Please note**: \n - {note_content}\n\n"
+HELP_COMMENT_CONTACT = (
     "**Contact**:\n"
     " - *Email*: hello@packit.dev\n"
     " - *Matrix*: #packit:fedora.im\n"
     " - *Mastodon*: @packit@fosstodon.org\n\n"
-    "**Documentation**: \n - {docs}"
 )
+HELP_COMMENT_DOCS = "**Documentation**: \n - {docs_url}"
+HELP_COMMENT_EPILOG = "{note}" + HELP_COMMENT_CONTACT + HELP_COMMENT_DOCS
+
 HELP_NOTE = (
     "`/packit` commands interact with the opt-in packit jobs "
     "(e.g. `propose-downstream`, `pull-from-upstream`). "

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -46,7 +46,7 @@ HELP_NOTE_FEDORA_CI = (
     "If you are looking for help on the opt-in packit jobs "
     "(e.g. `propose-downstream`, `pull-from-upstream`), "
     "refer to `/packit` or `/packit-stg`. "
-    "These assume a `.packit.yaml` configuration file is present in the repo."
+    "These assume a valid Packit configuration file is present in the repo."
 )
 
 KOJI_PRODUCTION_BUILDS_ISSUE = "https://pagure.io/releng/issue/9801"

--- a/packit_service/worker/handlers/forges.py
+++ b/packit_service/worker/handlers/forges.py
@@ -337,44 +337,39 @@ class GitCommentHelpHandler(
         pass
 
     def run(self) -> TaskResults:
-        if self.comment.startswith("/packit-ci-stg"):  # type: ignore
-            parser = get_comment_parser_fedora_ci(
-                prog=HELP_COMMENT_PROG_FEDORA_CI_STG,
-                description=HELP_COMMENT_DESCRIPTION,
-            )
-            epilog = HELP_COMMENT_EPILOG.format(
-                note=self.get_epilog_note_fedora_ci(), docs_url=DOCS_URL_FEDORA_CI
-            )
+        # Determine parameters based on comment prefix
+        comment = self.comment
 
-        elif self.comment.startswith("/packit-ci"):  # type: ignore
-            parser = get_comment_parser_fedora_ci(
-                prog=HELP_COMMENT_PROG_FEDORA_CI,
-                description=HELP_COMMENT_DESCRIPTION,
-            )
-            epilog = HELP_COMMENT_EPILOG.format(
-                note=self.get_epilog_note_fedora_ci(), docs_url=DOCS_URL_FEDORA_CI
-            )
-
-        elif self.comment.startswith("/packit-stg"):  # type: ignore
-            parser = get_comment_parser(
-                prog=HELP_COMMENT_PROG_STG,
-                description=HELP_COMMENT_DESCRIPTION,
-            )
-
-            epilog = HELP_COMMENT_EPILOG.format(note=self.get_epilog_note(), docs_url=DOCS_URL)
-
+        if comment.startswith("/packit-ci-stg"):  # type: ignore
+            prog = HELP_COMMENT_PROG_FEDORA_CI_STG
+            parser_func = get_comment_parser_fedora_ci
+            epilog_note = self.get_epilog_note_fedora_ci()
+            docs_url = DOCS_URL_FEDORA_CI
+        elif comment.startswith("/packit-ci"):  # type: ignore
+            prog = HELP_COMMENT_PROG_FEDORA_CI
+            parser_func = get_comment_parser_fedora_ci
+            epilog_note = self.get_epilog_note_fedora_ci()
+            docs_url = DOCS_URL_FEDORA_CI
+        elif comment.startswith("/packit-stg"):  # type: ignore
+            prog = HELP_COMMENT_PROG_STG
+            parser_func = get_comment_parser  # type: ignore[assignment]
+            epilog_note = self.get_epilog_note()
+            docs_url = DOCS_URL
         else:
-            parser = get_comment_parser(
-                prog=HELP_COMMENT_PROG,
-                description=HELP_COMMENT_DESCRIPTION,
-            )
+            prog = HELP_COMMENT_PROG
+            parser_func = get_comment_parser  # type: ignore[assignment]
+            epilog_note = self.get_epilog_note()
+            docs_url = DOCS_URL
 
-            epilog = HELP_COMMENT_EPILOG.format(note=self.get_epilog_note(), docs_url=DOCS_URL)
+        # Use determined parameters to create parser and epilog
+        parser = parser_func(prog=prog, description=HELP_COMMENT_DESCRIPTION)
+        epilog = HELP_COMMENT_EPILOG.format(note=epilog_note, docs_url=docs_url)
 
+        # Format and comment help message
         body = break_lines_in_text(
             parser.format_help(), sep=",", max_line_length=COMMENT_MAX_LINE_LENGTH
         )
-        # put message in code block to retain formatting
+        # Put body in code block to retain formatting
         help_message = f"```\n{body}\n```\n{epilog}"
         self.add_comment(body=help_message)
 

--- a/packit_service/worker/handlers/forges.py
+++ b/packit_service/worker/handlers/forges.py
@@ -10,6 +10,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Optional
 
+from ogr.services.pagure import PagureProject
 from packit.api import PackitAPI
 from packit.config import (
     Deployment,
@@ -25,6 +26,7 @@ from packit_service.constants import (
     DOCS_URL_FEDORA_CI,
     HELP_COMMENT_DESCRIPTION,
     HELP_COMMENT_EPILOG,
+    HELP_COMMENT_NOTE,
     HELP_COMMENT_PROG,
     HELP_COMMENT_PROG_FEDORA_CI,
     HELP_COMMENT_PROG_FEDORA_CI_STG,
@@ -340,28 +342,34 @@ class GitCommentHelpHandler(
                 prog=HELP_COMMENT_PROG_FEDORA_CI_STG,
                 description=HELP_COMMENT_DESCRIPTION,
             )
-            epilog = HELP_COMMENT_EPILOG.format(note=HELP_NOTE_FEDORA_CI, docs=DOCS_URL_FEDORA_CI)
+            epilog = HELP_COMMENT_EPILOG.format(
+                note=self.get_epilog_note_fedora_ci(), docs_url=DOCS_URL_FEDORA_CI
+            )
 
         elif self.comment.startswith("/packit-ci"):  # type: ignore
             parser = get_comment_parser_fedora_ci(
                 prog=HELP_COMMENT_PROG_FEDORA_CI,
                 description=HELP_COMMENT_DESCRIPTION,
             )
-            epilog = HELP_COMMENT_EPILOG.format(note=HELP_NOTE_FEDORA_CI, docs=DOCS_URL_FEDORA_CI)
+            epilog = HELP_COMMENT_EPILOG.format(
+                note=self.get_epilog_note_fedora_ci(), docs_url=DOCS_URL_FEDORA_CI
+            )
 
         elif self.comment.startswith("/packit-stg"):  # type: ignore
             parser = get_comment_parser(
                 prog=HELP_COMMENT_PROG_STG,
                 description=HELP_COMMENT_DESCRIPTION,
             )
-            epilog = HELP_COMMENT_EPILOG.format(note=HELP_NOTE, docs=DOCS_URL)
+
+            epilog = HELP_COMMENT_EPILOG.format(note=self.get_epilog_note(), docs_url=DOCS_URL)
 
         else:
             parser = get_comment_parser(
                 prog=HELP_COMMENT_PROG,
                 description=HELP_COMMENT_DESCRIPTION,
             )
-            epilog = HELP_COMMENT_EPILOG.format(note=HELP_NOTE, docs=DOCS_URL)
+
+            epilog = HELP_COMMENT_EPILOG.format(note=self.get_epilog_note(), docs_url=DOCS_URL)
 
         body = break_lines_in_text(
             parser.format_help(), sep=",", max_line_length=COMMENT_MAX_LINE_LENGTH
@@ -371,6 +379,16 @@ class GitCommentHelpHandler(
         self.add_comment(body=help_message)
 
         return TaskResults(success=True, details={"msg": help_message})
+
+    def get_epilog_note(self) -> str:
+        return (
+            HELP_COMMENT_NOTE.format(note_content=HELP_NOTE)
+            if isinstance(self.project, PagureProject)
+            else ""
+        )
+
+    def get_epilog_note_fedora_ci(self) -> str:
+        return HELP_COMMENT_NOTE.format(note_content=HELP_NOTE_FEDORA_CI)
 
 
 @reacts_to(event=github.pr.Comment)

--- a/packit_service/worker/handlers/forges.py
+++ b/packit_service/worker/handlers/forges.py
@@ -337,20 +337,28 @@ class GitCommentHelpHandler(
         pass
 
     def run(self) -> TaskResults:
+        if not self.comment:
+            msg = (
+                "GitCommentHelpHandler was run, but the triggering comment is missing."
+                "Won't post a comment in response."
+            )
+            logger.debug(msg)
+            return TaskResults(success=False, details={"msg": msg})
+
         # Determine parameters based on comment prefix
         comment = self.comment
 
-        if comment.startswith("/packit-ci-stg"):  # type: ignore
+        if comment.startswith("/packit-ci-stg"):
             prog = HELP_COMMENT_PROG_FEDORA_CI_STG
             parser_func = get_comment_parser_fedora_ci
             epilog_note = self.get_epilog_note_fedora_ci()
             docs_url = DOCS_URL_FEDORA_CI
-        elif comment.startswith("/packit-ci"):  # type: ignore
+        elif comment.startswith("/packit-ci"):
             prog = HELP_COMMENT_PROG_FEDORA_CI
             parser_func = get_comment_parser_fedora_ci
             epilog_note = self.get_epilog_note_fedora_ci()
             docs_url = DOCS_URL_FEDORA_CI
-        elif comment.startswith("/packit-stg"):  # type: ignore
+        elif comment.startswith("/packit-stg"):
             prog = HELP_COMMENT_PROG_STG
             parser_func = get_comment_parser  # type: ignore[assignment]
             epilog_note = self.get_epilog_note()


### PR DESCRIPTION
This PR introduces some small edits to the epilog of the help comment.

1. The epilog no longer references `.packit.yaml` and instead, uses a more generic term.
2. The note referencing `/packit-ci` is now only added when the user uses `/packit help` on Pagure. Many users of Packit don't know what Fedora CI even is, so mentioning it on GitHub and Gitlab made little sense.

I've tested the fixes on a local deployment, but am not currently able to test it after applying the latest refactoring changes as I am hitting a `Temporary failure in name resolution`. I'll re-test it once I am able to.
 
TODO:

- [x] Test on local deployment

<!-- release notes footer -->

Not sure if this is relevant enough to be mentioned in the blog post. If yes, here are the release notes below. Ignore this otherwise:

RELEASE NOTES BEGIN

In instances where the help comment (created in response to `/packit help`) would reference the need for a configuration file, Packit now uses a generic term, reflecting support for all valid configuration file names and replacing the previous specific mention of .packit.yaml. The help comment also no longer references `/packit-ci` commands on GitHub and Gitlab as these commands are not relevant to users on these platforms.

RELEASE NOTES END
