### PR TITLE
Pin pre-commit repos to hashes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,14 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.6
+    rev: 6fec9b7edb08fd9989088709d864a7826dc74e80 # frozen: v0.15.12
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+  # 1.18.2 is the last mypy version compatible with Python 3.9
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2
+    rev: 9f70dc58c23dfcca1b97af99eaeee3140a807c7e # frozen: v1.18.2
     hooks:
       - id: mypy
         args: [
@@ -36,12 +37,12 @@ repos:
           ]
         exclude: files/scripts/
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
     hooks:
       - id: prettier
         exclude: tests_openshift/openshift_integration/test_data/
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -60,18 +61,18 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+    rev: 745eface02aef23e168a8afb6b5737818efbea95 # frozen: v0.11.0.1
     hooks:
       - id: shellcheck
   - repo: https://github.com/packit/pre-commit-hooks
-    rev: v1.3.0
+    rev: ce4b530e5913c1b8651127ace81996464975ef48 # frozen: v1.3.0
     hooks:
       - id: check-rebase
         args:
           - https://github.com/packit/packit-service.git
         stages: [manual, pre-push]
   - repo: https://github.com/packit/requre
-    rev: 0.9.1
+    rev: 5b8a0a853928a9bb6204f3a66c510a62cf53fcb7 # frozen: 0.9.1
     hooks:
       - id: requre-purge
         name: Requre response files cleanup
@@ -96,19 +97,19 @@ repos:
         files: /tests_openshift.*\.yaml$
         stages: [manual, pre-push]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.29.1
+    rev: 2ca41cc1372d1e939a6a879f18cdc19fc1cac1ce # frozen: v8.30.0
     hooks:
       - id: gitleaks
         # The hook runs 'gitleaks protect --staged' which parses output of
         # 'git diff --staged', i.e. always passes in pre-push/manual stage.
         stages: [pre-commit]
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.35.0
+    rev: 943377262562a12b57292fc98fabd7dbf81451fe # frozen: 0.37.2
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
+    rev: ad1b27d73581aa16cca06fc4a0761fc563ffe8e8 # frozen: v1.5.6
     hooks:
       - id: insert-license
         files: \.py$


### PR DESCRIPTION
Repos are now pinned to hashes, somewhat protection us against supply chain compromises.

Also updates the hoooks to new versions.