### PR TITLE
Pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/check-release-notes.yml
+++ b/.github/workflows/check-release-notes.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   check_release_notes:
     name: Notes are either written, or there are none
-    uses: packit/.github/.github/workflows/check-release-notes.yml@main
+    uses: packit/.github/.github/workflows/check-release-notes.yml@2837c96caf71966609451ad0323552ef4be11a23
     with:
       description: ${{ github.event.pull_request.body }}

--- a/.github/workflows/opened-prs-to-the-board.yml
+++ b/.github/workflows/opened-prs-to-the-board.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.3.0
+      - uses: actions/add-to-project@a9f041ddd462ed185893ea1024cec954f50dbe42 # v0.3.0
         with:
           project-url: https://github.com/orgs/packit/projects/14
           github-token: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}

--- a/.github/workflows/rebuild-and-push-images.yml
+++ b/.github/workflows/rebuild-and-push-images.yml
@@ -22,7 +22,7 @@ jobs:
             image: packit-service-tests
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install QEMU dependency
         run: |
@@ -50,7 +50,7 @@ jobs:
       - name: Build Image
         id: build-image
         # https://github.com/marketplace/actions/buildah-build
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
         with:
           dockerfiles: ${{ matrix.dockerfile }}
           image: ${{ matrix.image }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Push To Quay
         # https://github.com/marketplace/actions/push-to-registry
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}


### PR DESCRIPTION
Pin all actions to specific commit SHAs to prevent supply chain attacks and ensure reproducible builds.

Note: ossf-scorecard.yml already had actions pinned.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>