### PR TITLE
Set commentary field when communicating with Log Detective API

### DIFF
--- a/packit_service/worker/helpers/logdetective.py
+++ b/packit_service/worker/helpers/logdetective.py
@@ -23,6 +23,14 @@ from packit_service.worker.monitoring import Pushgateway
 
 logger = logging.getLogger(__name__)
 
+LD_COMMENTARY = (
+    "Build was executed in downstream Koji using containerized environment provided by Mock."
+    "The build.log contains output of the package build, it is the most likely to contain messages,"
+    " indicating the root cause."
+    "The mock_output.log is a general log from Mock."
+    "The root.log is a log from creation of the chroot environment."
+)
+
 
 class LogDetectiveKojiTriggerHelper:
     """
@@ -113,6 +121,7 @@ class LogDetectiveKojiTriggerHelper:
         endpoint_url = f"{self.url}/analyze"
         request_json = {
             "artifacts": artifacts,
+            "build_metadata": {"commentary": LD_COMMENTARY},
             "target_build": str(build_arch_task_id),
             "build_system": LogDetectiveBuildSystem.koji.value,
             "commit_sha": self.data.commit_sha,

--- a/tests/unit/test_logdetective_koji_helper.py
+++ b/tests/unit/test_logdetective_koji_helper.py
@@ -18,6 +18,7 @@ from packit_service.models import (
     LogDetectiveRunModel,
 )
 from packit_service.worker.helpers.logdetective import (
+    LD_COMMENTARY,
     LogDetectiveKojiTriggerHelper,
     logger,
 )
@@ -86,6 +87,9 @@ def test_logdetective_koji_set_payload(mock_koji_task_failed_event, mock_event_d
             "mock_output.log": "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/mock_output.log",
             "build.log": "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/build.log",
         },
+        "build_metadata": {
+            "commentary": LD_COMMENTARY,
+        },
         "target_build": "12345",
         "build_system": "koji",
         "commit_sha": "abc123",
@@ -129,6 +133,9 @@ def test_logdetective_koji_success(
                 "root.log": "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/root.log",
                 "mock_output.log": "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/mock_output.log",
                 "build.log": "https://kojipkgs.fedoraproject.org//work/tasks/2345/12345/build.log",
+            },
+            "build_metadata": {
+                "commentary": LD_COMMENTARY,
             },
             "target_build": "12345",
             "build_system": LogDetectiveBuildSystem.koji.value,


### PR DESCRIPTION
<!-- release notes footer -->

RELEASE NOTES BEGIN

Supply additional information to Log Detective when asking for analysis.

RELEASE NOTES END
