### PR TITLE
fix(log-detective): do not log missing run as error

### DIFF
--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1922,7 +1922,7 @@ class Parser:
             analysis_id=analysis_id
         )
         if not log_detective_run:
-            logger.error(
+            logger.info(
                 f"Received results Log Detective analysis: '{analysis_id}' "
                 "but no analysis with this id was requested."
             )


### PR DESCRIPTION
I have to admit, I don't really like the fact that we're touching **database** from within the **parser**. Parser should be totally stateless… I would move this check to the beginning of the handler, if there are no objections to it.

Fixes #3135

Cc @Jany26