### PR TITLE
[WIP] Run custom tests as soon as relevant scratch build is available

### DIFF
--- a/packit_service/events/koji/abstract.py
+++ b/packit_service/events/koji/abstract.py
@@ -20,12 +20,14 @@ class KojiEvent(Result):
     def __init__(
         self,
         task_id: int,
+        parent: Optional[int] = None,
         rpm_build_task_ids: Optional[dict[str, int]] = None,
         start_time: Optional[Union[int, float, str]] = None,
         completion_time: Optional[Union[int, float, str]] = None,
     ):
         super().__init__()
         self.task_id = task_id
+        self.parent = parent
         # dictionary with archs and IDs, e.g. {"x86_64": 123}
         self.rpm_build_task_ids = rpm_build_task_ids
         self.start_time: Optional[Union[int, float, str]] = start_time

--- a/packit_service/events/koji/result.py
+++ b/packit_service/events/koji/result.py
@@ -151,6 +151,7 @@ class Task(KojiEvent):
         self,
         task_id: int,
         state: KojiTaskState,
+        parent: Optional[int] = None,
         old_state: Optional[KojiTaskState] = None,
         rpm_build_task_ids: Optional[dict[str, int]] = None,
         rpm_build_failed_arch_list: Optional[list[str]] = None,
@@ -158,6 +159,7 @@ class Task(KojiEvent):
         completion_time: Optional[Union[int, float, str]] = None,
     ):
         super().__init__(
+            parent=parent,
             task_id=task_id,
             rpm_build_task_ids=rpm_build_task_ids,
             start_time=start_time,

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -1444,6 +1444,18 @@ class Parser:
         start_time = nested_get(event, "info", "start_time")
         completion_time = nested_get(event, "info", "completion_time")
 
+        # Check if it is an early update to an archbuild
+        if nested_get(event, "info", "method") == "buildArch":
+            parent = nested_get(event, "info", "parent")
+            return koji.result.Task(
+                parent=parent,
+                task_id=task_id,
+                state=state_enum,
+                old_state=old_state,
+                start_time=start_time,
+                completion_time=completion_time,
+            )
+
         rpm_build_task_ids = {}
         rpm_build_failed_arch_list: list[str] = []
         for children in nested_get(event, "info", "children", default=[]):


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [ ] Detect `buildArch` task messages
- [ ] Link the `buildArch` messages to the parent? Not sure how/if this is needed
- [ ] Patch testing-farm helper to react early for `buildArch` messages for appropriate architecture
  - `custom` tests can run on the limited architecture
  - some tests need the full arches like `rpminspect`, others need only the spec file. Needs more thinking if this can be optimized :thinking:
- [ ] Depends on https://github.com/fedora-infra/koji-fedoramessaging/pull/166

RELEASE NOTES BEGIN

Fedora-CI custom tests now run as soon as the relevant architecture build has finished.
It no longer waits for the slower architecture scratch builds like `s390x`, `ppc64le`

RELEASE NOTES END
