### PR TITLE
Revert "Install gnome-srpm-macros on workers"

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -23,7 +23,6 @@
           - python3-sentry-sdk
           - python3-syslog-rfc5424-formatter # logging to Splunk
           - dnf-utils
-          - gnome-srpm-macros
           - make
           # for pip-installing sandcastle from git repo
           - git-core


### PR DESCRIPTION
This reverts commit 3b12810cc8f586d1f47e99fc862e7c7cb1356f7a.

gnome-srpm-macros is pulled in by redhat-rpm-config. I did check if it is a dependency, unfortunately I did the check on Fedora 42 :facepalm: