### PR TITLE
Skip test jobs for freshly branched Fedoras with missing composes if configured

### DIFF
--- a/packit_service/worker/helpers/testing_farm.py
+++ b/packit_service/worker/helpers/testing_farm.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Optional, Union
 from ogr.abstract import GitProject, PullRequest
 from ogr.utils import RequestResponse
 from packit.config import JobConfig, PackageConfig
+from packit.config.aliases import get_aliases
 from packit.exceptions import PackitConfigException
 from packit.utils import nested_get
 from packit.utils.koji_helper import KojiHelper
@@ -220,6 +221,13 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
     @property
     def skip_build(self) -> bool:
         return self.job_config.skip_build
+
+    @staticmethod
+    def is_freshly_branched_fedora(distro: str) -> bool:
+        aliases = get_aliases()
+        fedora_development = aliases.get("fedora-development", [])
+        branched = {d.namever for d in fedora_development[:-1]}
+        return distro in branched
 
     @property
     def custom_fmf(self) -> bool:
@@ -860,9 +868,34 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             msg = "Not supported architecture."
             return TaskResults(success=True, details={"msg": msg})
 
-        compose = self.tft_client.distro2compose(distro, report_error)
+        skip_if_branched = (
+            self.job_config.skip_missing_branched_composes
+            and self.is_freshly_branched_fedora(distro)
+        )
+        compose_not_found = False
+
+        def maybe_skip_error(description, markdown_content):
+            nonlocal compose_not_found
+            if skip_if_branched and markdown_content is not None:
+                compose_not_found = True
+                return
+            report_error(description, markdown_content)
+
+        compose = self.tft_client.distro2compose(distro, maybe_skip_error)
 
         if not compose:
+            if compose_not_found:
+                self.report_status_to_tests_for_test_target(
+                    state=BaseCommitStatus.neutral,
+                    description=f"Compose not yet available for {distro}. Skipping.",
+                    target=test_run.target,
+                )
+                return TaskResults(
+                    success=True,
+                    details={
+                        "msg": f"Skipped freshly branched {distro}, compose not available.",
+                    },
+                )
             msg = "We were not able to map distro to TF compose."
             return TaskResults(success=False, details={"msg": msg})
 

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -2440,3 +2440,43 @@ class TestGetRunningJobs:
         flexmock(helper).should_receive("get_running_jobs").and_return([])
         helper._tft_client.should_receive("cancel").never()
         helper.cancel_running_tests()
+
+
+class TestIsFreshlyBranchedFedora:
+    @pytest.fixture(autouse=True)
+    def _mock_aliases(self):
+        from packit.config.aliases import Distro
+
+        import packit_service.worker.helpers.testing_farm as tf_module
+
+        flexmock(tf_module).should_receive("get_aliases").and_return(
+            {
+                "fedora-development": [
+                    Distro("fedora-42", "f42"),
+                    Distro("fedora-rawhide", "rawhide"),
+                ],
+            },
+        )
+
+    def test_branched_release_detected(self):
+        assert TFJobHelper.is_freshly_branched_fedora("fedora-42") is True
+
+    def test_rawhide_not_detected(self):
+        assert TFJobHelper.is_freshly_branched_fedora("fedora-rawhide") is False
+
+    def test_unknown_distro_not_detected(self):
+        assert TFJobHelper.is_freshly_branched_fedora("fedora-99") is False
+
+    def test_stable_distro_not_detected(self):
+        assert TFJobHelper.is_freshly_branched_fedora("fedora-41") is False
+
+    def test_non_fedora_not_detected(self):
+        assert TFJobHelper.is_freshly_branched_fedora("centos-stream-9") is False
+
+    def test_empty_development_list(self):
+        import packit_service.worker.helpers.testing_farm as tf_module
+
+        flexmock(tf_module).should_receive("get_aliases").and_return(
+            {"fedora-development": []},
+        )
+        assert TFJobHelper.is_freshly_branched_fedora("fedora-42") is False


### PR DESCRIPTION
After Fedora branching, it takes some time before a corresponding Testing Farm compose is ready. If `skip_missing_branched_composes` is enabled, test jobs that would normally fail because a TF compose does not exist yet will now be skipped.

Fixes https://github.com/packit/packit-service/issues/2992.

Merge after https://github.com/packit/packit/pull/2746

RELEASE NOTES BEGIN

There is a new configuration option `skip_missing_branched_composes` that, when enabled, skips test jobs for freshly branched Fedora versions that don't have a corresponding Testing Farm compose yet.

RELEASE NOTES END
