### PR TITLE
Support identifiers when selecting OpenScanHub base builds

### DIFF
--- a/packit_service/worker/helpers/open_scan_hub.py
+++ b/packit_service/worker/helpers/open_scan_hub.py
@@ -208,10 +208,13 @@ class CoprOpenScanHubHelper(OpenScanHubHelper):
         """
         Find the job in the config that can provide the base build for the scan
         (with `commit` trigger and same branch configured as the target PR branch).
+        Prefer a base build with the same identifier as the configured job,
+        falling back to the first matching base build.
         """
         base_build_job = None
         target_branch = self.copr_build_helper.pull_request_object.target_branch
         default_branch = self.copr_build_helper.project.default_branch
+        configured_identifier = self.copr_build_helper.job_config.identifier
 
         for job in self.copr_build_helper.package_config.get_job_views():
             if (
@@ -222,8 +225,11 @@ class CoprOpenScanHubHelper(OpenScanHubHelper):
                     or (not job.branch and default_branch == target_branch)
                 )
             ):
-                base_build_job = job
-                break
+                if configured_identifier and job.identifier == configured_identifier:
+                    return job
+
+                if base_build_job is None:
+                    base_build_job = job
 
         return base_build_job
 

--- a/tests/unit/test_open_scan_hub.py
+++ b/tests/unit/test_open_scan_hub.py
@@ -182,6 +182,120 @@ def test_handle_scan(build_models):
     ).handle_scan()
 
 
+def test_find_base_build_job_prefers_matching_identifier():
+    qt6_job = flexmock(
+        type=JobType.copr_build,
+        trigger=JobConfigTriggerType.commit,
+        branch="main",
+        identifier="qt6",
+    )
+    qt5_job = flexmock(
+        type=JobType.copr_build,
+        trigger=JobConfigTriggerType.commit,
+        branch="main",
+        identifier="qt5",
+    )
+
+    package_config = flexmock(
+        get_job_views=lambda: [qt6_job, qt5_job],
+    )
+
+    pull_request = flexmock(target_branch="main")
+    project = flexmock(default_branch="main")
+
+    copr_build_helper = flexmock(
+        package_config=package_config,
+        pull_request_object=pull_request,
+        project=project,
+        job_config=flexmock(identifier="qt5"),
+    )
+
+    helper = CoprOpenScanHubHelper(
+        build=flexmock(),
+        copr_build_helper=copr_build_helper,
+    )
+
+    assert helper.find_base_build_job() is qt5_job
+
+
+def test_find_base_build_job_falls_back_to_first_matching_job():
+    qt6_job = flexmock(
+        type=JobType.copr_build,
+        trigger=JobConfigTriggerType.commit,
+        branch="main",
+        identifier="qt6",
+    )
+    qt5_job = flexmock(
+        type=JobType.copr_build,
+        trigger=JobConfigTriggerType.commit,
+        branch="main",
+        identifier="qt5",
+    )
+
+    package_config = flexmock(
+        get_job_views=lambda: [qt6_job, qt5_job],
+    )
+
+    pull_request = flexmock(target_branch="main")
+    project = flexmock(default_branch="main")
+
+    copr_build_helper = flexmock(
+        package_config=package_config,
+        pull_request_object=pull_request,
+        project=project,
+        job_config=flexmock(identifier="qt4"),
+    )
+
+    helper = CoprOpenScanHubHelper(
+        build=flexmock(),
+        copr_build_helper=copr_build_helper,
+    )
+
+    assert helper.find_base_build_job() is qt6_job
+
+
+def test_find_base_build_job_ignores_non_matching_jobs():
+    wrong_type_job = flexmock(
+        type=JobType.copr_build,
+        trigger=JobConfigTriggerType.pull_request,
+        branch="main",
+        identifier="qt6",
+    )
+    wrong_branch_job = flexmock(
+        type=JobType.copr_build,
+        trigger=JobConfigTriggerType.commit,
+        branch="develop",
+        identifier="qt5",
+    )
+    matching_job = flexmock(
+        type=JobType.copr_build,
+        trigger=JobConfigTriggerType.commit,
+        branch="main",
+        identifier="qt4",
+    )
+
+    package_config = flexmock(
+        get_job_views=lambda: [wrong_type_job, wrong_branch_job, matching_job],
+    )
+
+    pull_request = flexmock(target_branch="main")
+    project = flexmock(default_branch="main")
+
+    copr_build_helper = flexmock(
+        package_config=package_config,
+        pull_request_object=pull_request,
+        project=project,
+        job_config=flexmock(identifier=""),
+    )
+
+    helper = CoprOpenScanHubHelper(
+        build=flexmock(),
+        copr_build_helper=copr_build_helper,
+    )
+
+    assert helper.find_base_build_job() is matching_job
+
+
 @pytest.mark.parametrize(
     "job_config_type,job_config_trigger,job_config_targets,scan_status,num_of_handlers",
     [


### PR DESCRIPTION
Select a commit-triggered Copr build with the same configured identifier when determining the base build for an OpenScanHub differential scan.

Retain the existing fallback to the first matching base build when no identifier match is found.

This is important when multiple base builds are configured for the same branch but use different configurations. Without identifier-aware selection, an OpenScanHub differential scan can compare a pull request build against the wrong base build, resulting in an inaccurate comparison between different build configurations.

Supporting identifiers allows each differential scan job to use the corresponding base build and keeps the comparison between equivalent configurations.

Related: packit/packit#2763

<!-- TODO list -->

TODO:

- [x] Update or write new documentation in `packit/packit.dev`.