### PR TITLE
Fix MRTarget equality to compare branch values

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -90,7 +90,7 @@ class MRTarget(NamedTuple):
         if not isinstance(other, MRTarget):
             raise NotImplementedError()
 
-        return self.repo == other.repo and self.branch == self.branch
+        return self.repo == other.repo and self.branch == other.branch
 
 
 class ServiceConfig(Config):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -83,6 +83,14 @@ def test_parse_valid(service_config_valid):
     assert config.package_config_path_override is None
 
 
+def test_mr_target_membership_respects_branch(service_config_valid):
+    config = ServiceConfig.get_from_dict(service_config_valid)
+    assert MRTarget("redhat/centos-stream/src/.+", "c9s") in config.gitlab_mr_targets_handled
+    assert (
+        MRTarget("redhat/centos-stream/src/.+", "rawhide") not in config.gitlab_mr_targets_handled
+    )
+
+
 def test_parse_optional_values(service_config_valid):
     """When optional values are set, they are correctly parsed"""
     config = ServiceConfig.get_from_dict(


### PR DESCRIPTION
As described in #3173

`MRTarget.__eq__()` compared `self.branch` with itself instead of comparing it with `other.branch`, causing targets with the same repository but different branches to compare as equal.

Correct the comparison and add a regression test verifying that `gitlab_mr_targets_handled` membership respects the configured branch.

This ensures GitLab MR target matching does not incorrectly treat different branch patterns as the same target.

<!-- notes for reviewers -->

The `MRTarget.__eq__()` issue being corrected here has been present since the original implementation was introduced in [2021](https://github.com/packit/packit-service/commit/4d72a8101fe2082fa54f5e44c386aee325fbb5d9). It was noticed during a review of the code rather than as the result of a reported bug or observed production failure.

This correction aligns `MRTarget` equality with the behavior described by the original commit message: both the repository and branch are part of the target definition.

No specific production issue or crash has been attributed to this issue.
