### PR TITLE
refactor: split allowlist module to prevent circular imports

### DIFF
--- a/packit_service/worker/allowlist.py
+++ b/packit_service/worker/allowlist.py
@@ -2,67 +2,31 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-from collections.abc import Iterable
-from typing import Any, Callable, Optional, Union
-from urllib.parse import urlparse
+from typing import Optional
 
 from fasjson_client import Client
 from fasjson_client.errors import APIError
-from ogr.abstract import GitProject
 from packit.api import PackitAPI
-from packit.config.job_config import JobConfig, JobType
-from packit.exceptions import PackitCommandFailedError, PackitException
+from packit.exceptions import PackitCommandFailedError
 
 from packit_service.config import ServiceConfig
 from packit_service.constants import (
-    DENIED_MSG,
-    DOCS_APPROVAL_URL,
     FASJSON_URL,
-    NAMESPACE_NOT_ALLOWED_MARKDOWN_DESCRIPTION,
-    NAMESPACE_NOT_ALLOWED_MARKDOWN_ISSUE_INSTRUCTIONS,
     NOTIFICATION_REPO,
 )
-from packit_service.events import (
-    abstract,
-    anitya,
-    copr,
-    forgejo,
-    github,
-    gitlab,
-    koji,
-    openscanhub,
-    pagure,
-    testing_farm,
-)
-from packit_service.events.event_data import EventData
 from packit_service.models import AllowlistModel, AllowlistStatus
-from packit_service.worker.helpers.build import CoprBuildJobHelper
-from packit_service.worker.helpers.testing_farm import TestingFarmJobHelper
-from packit_service.worker.reporting import BaseCommitStatus
 
 logger = logging.getLogger(__name__)
 
-UncheckedEvent = Union[
-    anitya.NewHotness,
-    copr.CoprBuild,
-    forgejo.push.Commit,
-    forgejo.pr.Action,
-    forgejo.pr.Comment,
-    forgejo.issue.Comment,
-    forgejo.action_run.Push,
-    forgejo.action_run.PullRequest,
-    github.check.Rerun,
-    github.installation.Installation,
-    koji.result.Task,
-    koji.result.Build,
-    pagure.pr.Comment,
-    pagure.pr.Action,
-    pagure.push.Commit,
-    testing_farm.Result,
-]
-
 
 class Allowlist:
+    """
+    Core allowlist functionality for managing namespace approval/denial.
+
+    This class provides static and instance methods for checking and managing
+    namespace allowlist entries without depending on job helpers or event handlers.
+    """
+
     def __init__(self, service_config: ServiceConfig):
         self.service_config = service_config
 
@@ -282,289 +246,6 @@ class Allowlist:
             List of namespaces that are denied.
         """
         return Allowlist.get_namespaces_by_status(AllowlistStatus.denied)
-
-    def _check_unchecked_event(
-        self,
-        event: UncheckedEvent,
-        project: GitProject,
-        job_configs: Iterable[JobConfig],
-    ) -> bool:
-        # Allowlist checks do not apply to CentOS (Pagure, GitLab) and distgit commit event.
-        logger.info(f"{type(event)} event does not require allowlist checks.")
-        return True
-
-    def _check_release_push_event(
-        self,
-        event: Union[github.release.Release, github.push.Commit, gitlab.push.Commit],
-        project: GitProject,
-        job_configs: Iterable[JobConfig],
-    ) -> bool:
-        # TODO: modify event hierarchy so we can use some abstract classes instead
-        project_url = self._strip_protocol_and_add_git(event.project_url)
-        if not project_url:
-            raise KeyError(f"Failed to get namespace from {type(event)!r}")
-        if self.is_namespace_or_parent_denied(project_url):
-            msg = f"{project_url} or parent namespaces denied!"
-            project.commit_comment(event.commit_sha, msg)
-            return False
-
-        if self.is_namespace_or_parent_approved(project_url):
-            return True
-
-        msg = (
-            f"Project {project_url} is not on our allowlist! "
-            "See https://packit.dev/docs/guide/#2-approval"
-        )
-        project.commit_comment(event.commit_sha, msg)
-        return False
-
-    def _check_pr_event(
-        self,
-        event: Union[
-            github.pr.Action,
-            github.pr.Comment,
-            gitlab.mr.Action,
-            gitlab.mr.Comment,
-        ],
-        project: GitProject,
-        job_configs: Iterable[JobConfig],
-    ) -> bool:
-        actor_name = event.actor
-        if not actor_name:
-            raise KeyError(f"Failed to get login of the actor from {type(event)}")
-
-        project_url = self._strip_protocol_and_add_git(event.project_url)
-        user_namespace = f"{urlparse(event.project_url).netloc}/{actor_name}"
-
-        if user_or_project_denied := Allowlist.is_denied(user_namespace):
-            msg = f"User namespace {actor_name} denied!"
-            short_msg = "User namespace denied!"
-        elif user_or_project_denied := self.is_namespace_or_parent_denied(project_url):
-            msg = f"{project_url} or parent namespaces denied!"
-            short_msg = "Project or its namespace denied!"
-        else:
-            namespace_approved = self.is_namespace_or_parent_approved(project_url)
-            user_approved = (
-                project.can_merge_pr(actor_name) or project.get_pr(event.pr_id).author == actor_name
-            )
-            # TODO: clear failing check when present
-            if namespace_approved and user_approved:
-                return True
-            msg = (
-                (
-                    f"Project {project_url} is not on our allowlist! "
-                    "See https://packit.dev/docs/guide/#2-approval"
-                )
-                if not namespace_approved
-                else f"Account {actor_name} has no write access nor is author of PR!"
-            )
-            short_msg = (
-                f"{project_url} not allowed!" if not namespace_approved else "User cannot trigger!"
-            )
-
-        logger.debug(msg)
-        if isinstance(
-            event,
-            (github.pr.Comment, gitlab.mr.Comment),
-        ):
-            project.get_pr(event.pr_id).comment(msg)
-        else:
-            self._check_pr_report_status(
-                job_configs=job_configs,
-                event=event,
-                project=project,
-                user_or_project_denied=user_or_project_denied,
-                short_msg=short_msg,
-            )
-        return False
-
-    def _check_pr_report_status(
-        self,
-        job_configs,
-        event,
-        project,
-        user_or_project_denied,
-        short_msg,
-    ):
-        for job_config in job_configs:
-            job_helper_kls: type[Union[TestingFarmJobHelper, CoprBuildJobHelper]]
-            if job_config.type == JobType.tests:
-                job_helper_kls = TestingFarmJobHelper
-            else:
-                job_helper_kls = CoprBuildJobHelper
-
-            job_helper = job_helper_kls(
-                service_config=self.service_config,
-                package_config=event.get_packages_config().get_package_config_for(
-                    job_config,
-                ),
-                project=project,
-                metadata=EventData.from_event_dict(event.get_dict()),
-                db_project_event=event.db_project_event,
-                job_config=job_config,
-                build_targets_override=event.build_targets_override,
-                tests_targets_override=event.tests_targets_override,
-            )
-            if user_or_project_denied:
-                url = None
-                markdown_content = DENIED_MSG
-            else:
-                issue_url = self.get_approval_issue(namespace=project.namespace)
-                url = issue_url or DOCS_APPROVAL_URL
-                markdown_content = NAMESPACE_NOT_ALLOWED_MARKDOWN_DESCRIPTION.format(
-                    instructions=(
-                        NAMESPACE_NOT_ALLOWED_MARKDOWN_ISSUE_INSTRUCTIONS.format(
-                            issue_url=issue_url,
-                        )
-                        if issue_url
-                        else ""
-                    ),
-                )
-            job_helper.report_status_to_configured_job(
-                description=short_msg,
-                state=BaseCommitStatus.neutral,
-                url=url,
-                markdown_content=markdown_content,
-            )
-
-    def _check_issue_comment_event(
-        self,
-        event: Union[github.issue.Comment, gitlab.issue.Comment],
-        project: GitProject,
-        job_configs: Iterable[JobConfig],
-    ) -> bool:
-        return self._check_issue_and_commit_comment_event(
-            event=event,
-            project=project,
-            comment_fn=lambda msg: project.get_issue(event.issue_id).comment(msg),
-        )
-
-    def _check_commit_comment_event(
-        self,
-        event: abstract.comment.Commit,
-        project: GitProject,
-        job_configs: Iterable[JobConfig],
-    ) -> bool:
-        return self._check_issue_and_commit_comment_event(
-            event=event,
-            project=project,
-            comment_fn=lambda msg: project.commit_comment(
-                commit=event.commit_sha,
-                body=msg,
-            ),
-        )
-
-    def _check_issue_and_commit_comment_event(
-        self,
-        event: Union[abstract.comment.Commit, github.issue.Comment, gitlab.issue.Comment],
-        project: GitProject,
-        comment_fn: Callable[[str], Any],
-    ) -> bool:
-        actor_name = event.actor
-        if not actor_name:
-            raise KeyError(f"Failed to get login of the actor from {type(event)}")
-        project_url = self._strip_protocol_and_add_git(event.project_url)
-        user_namespace = f"{urlparse(event.project_url).netloc}/{actor_name}"
-
-        if Allowlist.is_denied(user_namespace):
-            msg = f"User namespace {actor_name} denied!"
-        elif self.is_namespace_or_parent_denied(project_url):
-            msg = f"{project_url} or parent namespaces denied!"
-        else:
-            namespace_approved = self.is_namespace_or_parent_approved(project_url)
-            user_approved = project.can_merge_pr(actor_name)
-            if namespace_approved and user_approved:
-                return True
-            msg = (
-                (
-                    f"Project {project_url} is not on our allowlist! "
-                    "See https://packit.dev/docs/guide/#2-approval"
-                )
-                if not namespace_approved
-                else f"Account {actor_name} has no write access!"
-            )
-
-        logger.debug(msg)
-        comment_fn(msg)
-        return False
-
-    def check_and_report(
-        self,
-        event: Optional[Any],
-        project: GitProject,
-        job_configs: Iterable[JobConfig],
-    ) -> bool:
-        """
-        Check if account is approved and report status back in case of PR
-        :param event: PullRequest and Release TODO: handle more
-        :param project: GitProject
-        :param job_configs: iterable of jobconfigs - so we know how to update status of the PR
-        :return:
-        """
-        CALLBACKS: dict[
-            Union[type, tuple[Union[type, tuple[Any, ...]], ...]],
-            Callable,
-        ] = {
-            (  # events that are not checked against allowlist
-                # [XXX] dist-git Forgejo events are unchecked
-                # upstream Forgejo events would require authorization checking
-                forgejo.push.Commit,
-                forgejo.pr.Action,
-                forgejo.pr.Comment,
-                forgejo.issue.Comment,
-                forgejo.action_run.Push,
-                forgejo.action_run.PullRequest,
-                pagure.push.Commit,
-                pagure.pr.Action,
-                pagure.pr.Comment,
-                copr.CoprBuild,
-                testing_farm.Result,
-                github.installation.Installation,
-                koji.result.Task,
-                koji.result.Build,
-                koji.tag.Build,
-                github.check.Rerun,
-                anitya.NewHotness,
-                openscanhub.task.Started,
-                openscanhub.task.Finished,
-            ): self._check_unchecked_event,
-            (
-                github.release.Release,
-                gitlab.release.Release,
-                github.push.Commit,
-                gitlab.push.Commit,
-            ): self._check_release_push_event,
-            (
-                github.pr.Action,
-                github.pr.Comment,
-                gitlab.mr.Action,
-                gitlab.mr.Comment,
-            ): self._check_pr_event,
-            (
-                github.issue.Comment,
-                gitlab.issue.Comment,
-            ): self._check_issue_comment_event,
-            (abstract.comment.Commit,): self._check_commit_comment_event,
-        }
-
-        # Administrators
-        user_login = getattr(  # some old events with user_login can still be there
-            event,
-            "user_login",
-            None,
-        ) or getattr(event, "actor", None)
-
-        if user_login and user_login in self.service_config.admins:
-            logger.info(f"{user_login} is admin, you shall pass.")
-            return True
-
-        for related_events, callback in CALLBACKS.items():
-            if isinstance(event, related_events):
-                return callback(event, project, job_configs)
-
-        msg = f"Failed to validate account: Unrecognized event type {type(event)!r}."
-        logger.debug(msg)
-        raise PackitException(msg)
 
     def get_approval_issue(self, namespace) -> Optional[str]:
         for issue in self.service_config.get_project(

--- a/packit_service/worker/allowlist_checker.py
+++ b/packit_service/worker/allowlist_checker.py
@@ -1,0 +1,348 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+from collections.abc import Iterable
+from typing import Any, Callable, Optional, Union
+from urllib.parse import urlparse
+
+from ogr.abstract import GitProject
+from packit.config.job_config import JobConfig, JobType
+from packit.exceptions import PackitException
+
+from packit_service.constants import (
+    DENIED_MSG,
+    DOCS_APPROVAL_URL,
+    NAMESPACE_NOT_ALLOWED_MARKDOWN_DESCRIPTION,
+    NAMESPACE_NOT_ALLOWED_MARKDOWN_ISSUE_INSTRUCTIONS,
+)
+from packit_service.events import (
+    abstract,
+    anitya,
+    copr,
+    forgejo,
+    github,
+    gitlab,
+    koji,
+    openscanhub,
+    pagure,
+    testing_farm,
+)
+from packit_service.events.event_data import EventData
+from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.helpers.build import CoprBuildJobHelper
+from packit_service.worker.helpers.testing_farm import TestingFarmJobHelper
+from packit_service.worker.reporting import BaseCommitStatus
+
+logger = logging.getLogger(__name__)
+
+UncheckedEvent = Union[
+    anitya.NewHotness,
+    copr.CoprBuild,
+    forgejo.push.Commit,
+    forgejo.pr.Action,
+    forgejo.pr.Comment,
+    forgejo.issue.Comment,
+    forgejo.action_run.Push,
+    forgejo.action_run.PullRequest,
+    github.check.Rerun,
+    github.installation.Installation,
+    koji.result.Task,
+    koji.result.Build,
+    pagure.pr.Comment,
+    pagure.pr.Action,
+    pagure.push.Commit,
+    testing_farm.Result,
+]
+
+
+class AllowlistChecker(Allowlist):
+    """
+    Extends Allowlist with event checking and reporting functionality.
+
+    This class handles checking events against the allowlist and reporting
+    status back to PRs/commits. It depends on job helpers for status reporting.
+    """
+
+    def _check_unchecked_event(
+        self,
+        event: UncheckedEvent,
+        project: GitProject,
+        job_configs: Iterable[JobConfig],
+    ) -> bool:
+        # Allowlist checks do not apply to CentOS (Pagure, GitLab) and distgit commit event.
+        logger.info(f"{type(event)} event does not require allowlist checks.")
+        return True
+
+    def _check_release_push_event(
+        self,
+        event: Union[github.release.Release, github.push.Commit, gitlab.push.Commit],
+        project: GitProject,
+        job_configs: Iterable[JobConfig],
+    ) -> bool:
+        # TODO: modify event hierarchy so we can use some abstract classes instead
+        project_url = self._strip_protocol_and_add_git(event.project_url)
+        if not project_url:
+            raise KeyError(f"Failed to get namespace from {type(event)!r}")
+        if self.is_namespace_or_parent_denied(project_url):
+            msg = f"{project_url} or parent namespaces denied!"
+            project.commit_comment(event.commit_sha, msg)
+            return False
+
+        if self.is_namespace_or_parent_approved(project_url):
+            return True
+
+        msg = (
+            f"Project {project_url} is not on our allowlist! "
+            "See https://packit.dev/docs/guide/#2-approval"
+        )
+        project.commit_comment(event.commit_sha, msg)
+        return False
+
+    def _check_pr_event(
+        self,
+        event: Union[
+            github.pr.Action,
+            github.pr.Comment,
+            gitlab.mr.Action,
+            gitlab.mr.Comment,
+        ],
+        project: GitProject,
+        job_configs: Iterable[JobConfig],
+    ) -> bool:
+        actor_name = event.actor
+        if not actor_name:
+            raise KeyError(f"Failed to get login of the actor from {type(event)}")
+
+        project_url = self._strip_protocol_and_add_git(event.project_url)
+        user_namespace = f"{urlparse(event.project_url).netloc}/{actor_name}"
+
+        if user_or_project_denied := Allowlist.is_denied(user_namespace):
+            msg = f"User namespace {actor_name} denied!"
+            short_msg = "User namespace denied!"
+        elif user_or_project_denied := self.is_namespace_or_parent_denied(project_url):
+            msg = f"{project_url} or parent namespaces denied!"
+            short_msg = "Project or its namespace denied!"
+        else:
+            namespace_approved = self.is_namespace_or_parent_approved(project_url)
+            user_approved = (
+                project.can_merge_pr(actor_name) or project.get_pr(event.pr_id).author == actor_name
+            )
+            # TODO: clear failing check when present
+            if namespace_approved and user_approved:
+                return True
+            msg = (
+                (
+                    f"Project {project_url} is not on our allowlist! "
+                    "See https://packit.dev/docs/guide/#2-approval"
+                )
+                if not namespace_approved
+                else f"Account {actor_name} has no write access nor is author of PR!"
+            )
+            short_msg = (
+                f"{project_url} not allowed!" if not namespace_approved else "User cannot trigger!"
+            )
+
+        logger.debug(msg)
+        if isinstance(
+            event,
+            (github.pr.Comment, gitlab.mr.Comment),
+        ):
+            project.get_pr(event.pr_id).comment(msg)
+        else:
+            self._check_pr_report_status(
+                job_configs=job_configs,
+                event=event,
+                project=project,
+                user_or_project_denied=user_or_project_denied,
+                short_msg=short_msg,
+            )
+        return False
+
+    def _check_pr_report_status(
+        self,
+        job_configs,
+        event,
+        project,
+        user_or_project_denied,
+        short_msg,
+    ):
+        for job_config in job_configs:
+            job_helper_kls: type[Union[TestingFarmJobHelper, CoprBuildJobHelper]]
+            if job_config.type == JobType.tests:
+                job_helper_kls = TestingFarmJobHelper
+            else:
+                job_helper_kls = CoprBuildJobHelper
+
+            job_helper = job_helper_kls(
+                service_config=self.service_config,
+                package_config=event.get_packages_config().get_package_config_for(
+                    job_config,
+                ),
+                project=project,
+                metadata=EventData.from_event_dict(event.get_dict()),
+                db_project_event=event.db_project_event,
+                job_config=job_config,
+                build_targets_override=event.build_targets_override,
+                tests_targets_override=event.tests_targets_override,
+            )
+            if user_or_project_denied:
+                url = None
+                markdown_content = DENIED_MSG
+            else:
+                issue_url = self.get_approval_issue(namespace=project.namespace)
+                url = issue_url or DOCS_APPROVAL_URL
+                markdown_content = NAMESPACE_NOT_ALLOWED_MARKDOWN_DESCRIPTION.format(
+                    instructions=(
+                        NAMESPACE_NOT_ALLOWED_MARKDOWN_ISSUE_INSTRUCTIONS.format(
+                            issue_url=issue_url,
+                        )
+                        if issue_url
+                        else ""
+                    ),
+                )
+            job_helper.report_status_to_configured_job(
+                description=short_msg,
+                state=BaseCommitStatus.neutral,
+                url=url,
+                markdown_content=markdown_content,
+            )
+
+    def _check_issue_comment_event(
+        self,
+        event: Union[github.issue.Comment, gitlab.issue.Comment],
+        project: GitProject,
+        job_configs: Iterable[JobConfig],
+    ) -> bool:
+        return self._check_issue_and_commit_comment_event(
+            event=event,
+            project=project,
+            comment_fn=lambda msg: project.get_issue(event.issue_id).comment(msg),
+        )
+
+    def _check_commit_comment_event(
+        self,
+        event: abstract.comment.Commit,
+        project: GitProject,
+        job_configs: Iterable[JobConfig],
+    ) -> bool:
+        return self._check_issue_and_commit_comment_event(
+            event=event,
+            project=project,
+            comment_fn=lambda msg: project.commit_comment(
+                commit=event.commit_sha,
+                body=msg,
+            ),
+        )
+
+    def _check_issue_and_commit_comment_event(
+        self,
+        event: Union[abstract.comment.Commit, github.issue.Comment, gitlab.issue.Comment],
+        project: GitProject,
+        comment_fn: Callable[[str], Any],
+    ) -> bool:
+        actor_name = event.actor
+        if not actor_name:
+            raise KeyError(f"Failed to get login of the actor from {type(event)}")
+        project_url = self._strip_protocol_and_add_git(event.project_url)
+        user_namespace = f"{urlparse(event.project_url).netloc}/{actor_name}"
+
+        if Allowlist.is_denied(user_namespace):
+            msg = f"User namespace {actor_name} denied!"
+        elif self.is_namespace_or_parent_denied(project_url):
+            msg = f"{project_url} or parent namespaces denied!"
+        else:
+            namespace_approved = self.is_namespace_or_parent_approved(project_url)
+            user_approved = project.can_merge_pr(actor_name)
+            if namespace_approved and user_approved:
+                return True
+            msg = (
+                (
+                    f"Project {project_url} is not on our allowlist! "
+                    "See https://packit.dev/docs/guide/#2-approval"
+                )
+                if not namespace_approved
+                else f"Account {actor_name} has no write access!"
+            )
+
+        logger.debug(msg)
+        comment_fn(msg)
+        return False
+
+    def check_and_report(
+        self,
+        event: Optional[Any],
+        project: GitProject,
+        job_configs: Iterable[JobConfig],
+    ) -> bool:
+        """
+        Check if account is approved and report status back in case of PR
+        :param event: PullRequest and Release TODO: handle more
+        :param project: GitProject
+        :param job_configs: iterable of jobconfigs - so we know how to update status of the PR
+        :return:
+        """
+        CALLBACKS: dict[
+            Union[type, tuple[Union[type, tuple[Any, ...]], ...]],
+            Callable,
+        ] = {
+            (  # events that are not checked against allowlist
+                # [XXX] dist-git Forgejo events are unchecked
+                # upstream Forgejo events would require authorization checking
+                forgejo.push.Commit,
+                forgejo.pr.Action,
+                forgejo.pr.Comment,
+                forgejo.issue.Comment,
+                forgejo.action_run.Push,
+                forgejo.action_run.PullRequest,
+                pagure.push.Commit,
+                pagure.pr.Action,
+                pagure.pr.Comment,
+                copr.CoprBuild,
+                testing_farm.Result,
+                github.installation.Installation,
+                koji.result.Task,
+                koji.result.Build,
+                koji.tag.Build,
+                github.check.Rerun,
+                anitya.NewHotness,
+                openscanhub.task.Started,
+                openscanhub.task.Finished,
+            ): self._check_unchecked_event,
+            (
+                github.release.Release,
+                gitlab.release.Release,
+                github.push.Commit,
+                gitlab.push.Commit,
+            ): self._check_release_push_event,
+            (
+                github.pr.Action,
+                github.pr.Comment,
+                gitlab.mr.Action,
+                gitlab.mr.Comment,
+            ): self._check_pr_event,
+            (
+                github.issue.Comment,
+                gitlab.issue.Comment,
+            ): self._check_issue_comment_event,
+            (abstract.comment.Commit,): self._check_commit_comment_event,
+        }
+
+        # Administrators
+        user_login = getattr(  # some old events with user_login can still be there
+            event,
+            "user_login",
+            None,
+        ) or getattr(event, "actor", None)
+
+        if user_login and user_login in self.service_config.admins:
+            logger.info(f"{user_login} is admin, you shall pass.")
+            return True
+
+        for related_events, callback in CALLBACKS.items():
+            if isinstance(event, related_events):
+                return callback(event, project, job_configs)
+
+        msg = f"Failed to validate account: Unrecognized event type {type(event)!r}."
+        logger.debug(msg)
+        raise PackitException(msg)

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -48,7 +48,7 @@ from packit_service.utils import (
     get_packit_commands_from_comment,
     pr_labels_match_configuration,
 )
-from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.handlers import (
     CoprBuildHandler,
     GithubAppInstallationHandler,
@@ -770,7 +770,7 @@ class SteveJobs:
             )
             return []
 
-        allowlist = Allowlist(service_config=self.service_config)
+        allowlist = AllowlistChecker(service_config=self.service_config)
         processing_results: list[TaskResults] = []
 
         statuses_check_feedback: list[datetime] = []

--- a/tests/integration/test_commit_comment.py
+++ b/tests/integration/test_commit_comment.py
@@ -20,7 +20,7 @@ from packit_service.models import (
     ProjectEventModel,
     ProjectEventModelType,
 )
-from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.helpers.build import CoprBuildJobHelper
 from packit_service.worker.helpers.testing_farm import TestingFarmJobHelper
 from packit_service.worker.jobs import SteveJobs
@@ -82,7 +82,7 @@ def mock_commit_comment_functionality(request):
     ).and_return(db_project_object)
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(LocalProjectBuilder, _refresh_the_state=lambda *args: flexmock())
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -41,7 +41,7 @@ from packit_service.models import (
 )
 from packit_service.package_config_getter import PackageConfigGetter
 from packit_service.service.urls import get_propose_downstream_info_url
-from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.celery_task import CeleryTask
 from packit_service.worker.handlers import distgit
 from packit_service.worker.handlers.distgit import (
@@ -183,7 +183,7 @@ jobs:
     lp = flexmock(git_project=flexmock(default_branch="main"))
     lp.working_dir = ""
     flexmock(DistGit).should_receive("local_project").and_return(lp)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
     yield project_class, issue_comment_propose_downstream_event(forge)
 
@@ -467,7 +467,7 @@ def mock_repository_issue_retriggering():
     comment = flexmock()
     flexmock(issue).should_receive("get_comment").and_return(comment)
     flexmock(comment).should_receive("add_reaction").with_args(COMMENT_REACTION).once()
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     flexmock(group).should_receive("apply_async").once()
     flexmock(Pushgateway).should_receive("push").and_return()
 

--- a/tests/integration/test_new_hotness_update.py
+++ b/tests/integration/test_new_hotness_update.py
@@ -32,7 +32,7 @@ from packit_service.models import (
     SyncReleaseTargetStatus,
 )
 from packit_service.service.db_project_events import AddReleaseEventToDb
-from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.checker.run_condition import IsRunConditionSatisfied
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.monitoring import Pushgateway
@@ -223,7 +223,7 @@ def test_new_hotness_update(new_hotness_update, sync_release_model):
         ),
     )
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
     service_config = ServiceConfig().get_service_config()
     flexmock(service_config).should_receive("get_project").with_args(
@@ -331,7 +331,7 @@ def test_new_hotness_update_pre_check_fail(new_hotness_update):
         default_branch="main",
     )
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
     # Anitya event now always creates AnityaMultipleVersionsModel
     anitya_db_object = flexmock(
@@ -463,7 +463,7 @@ def test_new_hotness_update_non_git_multiple_versions(new_hotness_update):
     lp.git_project = distgit_project
     flexmock(DistGit).should_receive("local_project").and_return(lp)
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
     # Mock monitoring metadata to allow processing all versions
     flexmock(
@@ -663,7 +663,7 @@ def test_retry_pull_from_upstream_multi_version(new_hotness_update):
     lp.git_project = distgit_project
     flexmock(DistGit).should_receive("local_project").and_return(lp)
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
     flexmock(
         packit_service.worker.handlers.distgit,
@@ -827,7 +827,7 @@ def test_new_hotness_update_non_git(new_hotness_update, sync_release_model_non_g
     lp.git_project = project
     flexmock(DistGit).should_receive("local_project").and_return(lp)
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
     service_config = ServiceConfig().get_service_config()
     flexmock(service_config).should_receive("get_project").with_args(

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -70,7 +70,7 @@ from packit_service.service.urls import get_testing_farm_info_url
 from packit_service.utils import (
     get_packit_commands_from_comment,
 )
-from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.celery_task import CeleryTask
 from packit_service.worker.checker.run_condition import IsRunConditionSatisfied
 from packit_service.worker.handlers import distgit
@@ -217,7 +217,7 @@ def mock_pr_comment_functionality(request):
     ).and_return(db_project_object)
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(LocalProjectBuilder, _refresh_the_state=lambda *args: flexmock())
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
 
 def one_job_finished_with_msg(results: list[TaskResults], msg: str):
@@ -535,7 +535,7 @@ def test_pr_comment_production_build_handler(pr_production_build_comment_event):
         project_event,
     )
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
     flexmock(ProjectEventModel).should_receive("get_or_create").with_args(
         type=ProjectEventModelType.pull_request,
@@ -761,7 +761,7 @@ def test_pr_test_command_handler(
     )
     flexmock(Github, get_repo=lambda full_name_or_id: None)
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(
@@ -849,7 +849,7 @@ def test_pr_test_command_handler_identifiers(
     )
     flexmock(Github, get_repo=lambda full_name_or_id: None)
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(
         GithubProject,
@@ -1038,7 +1038,7 @@ def test_pr_test_command_handler_retries(
     urls.DASHBOARD_URL = "https://dashboard.localhost"
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(
@@ -1245,7 +1245,7 @@ def test_pr_test_command_handler_skip_build_option(
     ServiceConfig.get_service_config().testing_farm_secret = "secret-token"
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(
         GithubProject,
@@ -1455,7 +1455,7 @@ def test_pr_test_command_handler_compose_not_present(
         ranch="public",
     ).and_return(flexmock(grouped_targets=[test_run]))
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(
         GithubProject,
@@ -1583,7 +1583,7 @@ def test_pr_test_command_handler_composes_not_available(
         ranch="public",
     ).and_return(flexmock(grouped_targets=[test_run]))
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(
         GithubProject,
@@ -1679,7 +1679,7 @@ def test_pr_test_command_handler_not_allowed_external_contributor_on_internal_TF
     flexmock(Github, get_repo=lambda full_name_or_id: None)
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=9,
         namespace="packit-service",
@@ -1741,7 +1741,7 @@ def test_pr_build_command_handler_not_allowed_external_contributor_on_internal_T
     flexmock(Github, get_repo=lambda full_name_or_id: None)
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     flexmock(PullRequestModel).should_receive("get_or_create").with_args(
         pr_id=9,
         namespace="packit-service",
@@ -2001,7 +2001,7 @@ def test_pr_test_command_handler_skip_build_option_no_fmf_metadata(
     ServiceConfig.get_service_config().testing_farm_secret = "secret-token"
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
     pr_embedded_command_comment_event["comment"]["body"] = "/packit test"
     flexmock(
@@ -2193,7 +2193,7 @@ def test_pr_test_command_handler_multiple_builds(
     ServiceConfig.get_service_config().testing_farm_secret = "secret-token"
 
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     flexmock(
         GithubProject,
         get_files=lambda ref, recursive: ["foo.spec", ".packit.yaml"],
@@ -3000,7 +3000,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment(pagure_pr_comment_
 
     flexmock(GitUpstream).should_receive("get_last_tag").and_return("7.0.3")
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     flexmock(PackitAPIWithDownstreamMixin).should_receive("is_packager").and_return(
         True,
     )
@@ -3174,7 +3174,7 @@ def test_pull_from_upstream_retrigger_via_dist_git_pr_comment_non_git(
     flexmock(GithubService).should_receive("set_auth_method").with_args(
         AuthMethod.token,
     ).once()
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     flexmock(PackitAPIWithDownstreamMixin).should_receive("is_packager").and_return(
         True,
     )
@@ -3374,7 +3374,7 @@ def _run_pull_from_upstream_with_version(
     flexmock(GithubService).should_receive("set_auth_method").with_args(
         AuthMethod.token,
     ).once()
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     flexmock(PackitAPIWithDownstreamMixin).should_receive("is_packager").and_return(True)
 
     def _get_project(url, *_, **__):

--- a/tests/integration/test_pr_comment_monorepo.py
+++ b/tests/integration/test_pr_comment_monorepo.py
@@ -21,7 +21,7 @@ from packit_service.models import (
     ProjectEventModelType,
     PullRequestModel,
 )
-from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.helpers.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.helpers.testing_farm import TestingFarmJobHelper
 from packit_service.worker.jobs import SteveJobs
@@ -85,7 +85,7 @@ def mock_pr_comment_monorepo_functionality(request):
     ).and_return(db_project_object)
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(LocalProjectBuilder, _refresh_the_state=lambda *args: flexmock())
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -35,7 +35,7 @@ from packit_service.models import (
 )
 from packit_service.service.db_project_events import AddReleaseEventToDb
 from packit_service.service.urls import get_propose_downstream_info_url
-from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.handlers.distgit import AbstractSyncReleaseHandler
 from packit_service.worker.helpers.sync_release.propose_downstream import (
     ProposeDownstreamJobHelper,
@@ -210,7 +210,7 @@ def test_dist_git_push_release_handle(
         ),
     )
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url, required=True: project
     target_project = (
         flexmock(namespace="downstream-namespace", repo="downstream-repo")
@@ -354,7 +354,7 @@ def test_dist_git_push_release_handle_fast_forward_branches(
         ),
     )
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url, required=True: project
     target_project = (
         flexmock(namespace="downstream-namespace", repo="downstream-repo")
@@ -495,7 +495,7 @@ def test_dist_git_push_release_handle_multiple_branches(
         ),
     )
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url, required=True: project
 
     for model in propose_downstream_target_models:
@@ -645,7 +645,7 @@ def test_dist_git_push_release_handle_one_failed(
             ],
         ),
     )
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url, required=True: project
     failed_branch = fedora_branches[1]
 
@@ -845,7 +845,7 @@ def test_dist_git_push_release_handle_all_failed(
         ),
     )
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url, required=True: project
 
     flexmock(PackitAPI).should_receive("sync_release").and_raise(
@@ -959,7 +959,7 @@ def test_retry_propose_downstream_task(
         ),
     )
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url, required=True: project
 
     flexmock(AddReleaseEventToDb).should_receive("db_project_object").and_return(
@@ -1074,7 +1074,7 @@ def test_dont_retry_propose_downstream_task(
     lp.working_dir = ""
     flexmock(DistGit).should_receive("local_project").and_return(lp)
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url, required=True: project
 
     flexmock(AddReleaseEventToDb).should_receive("db_project_object").and_return(
@@ -1215,7 +1215,7 @@ def test_dist_git_push_release_failed_issue_creation_disabled(
         ),
     )
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     ServiceConfig().get_service_config().get_project = lambda url, required=True: project
 
     flexmock(AddReleaseEventToDb).should_receive("db_project_object").and_return(

--- a/tests/integration/test_vm_image_build.py
+++ b/tests/integration/test_vm_image_build.py
@@ -18,7 +18,7 @@ from packit_service.models import (
     PullRequestModel,
     VMImageBuildTargetModel,
 )
-from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.handlers.vm_image import VMImageBuildHandler
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.monitoring import Pushgateway
@@ -89,7 +89,7 @@ def test_vm_image_build(github_vm_image_build_comment):
             commit_sha="123456",
         ),
     )
-    flexmock(Allowlist).should_receive("check_and_report").and_return(True)
+    flexmock(AllowlistChecker).should_receive("check_and_report").and_return(True)
 
     flexmock(CoprBuildTargetModel).should_receive("get_all_by").and_return(
         [

--- a/tests/unit/test_allowlist.py
+++ b/tests/unit/test_allowlist.py
@@ -38,14 +38,15 @@ from packit_service.models import (
     AllowlistStatus,
 )
 from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.reporting import BaseCommitStatus, StatusReporter
 
 EXPECTED_TESTING_FARM_CHECK_NAME = "testing-farm:fedora-rawhide-x86_64"
 
 
 @pytest.fixture()
-def allowlist():
-    return Allowlist(service_config=ServiceConfig.get_service_config())
+def allowlist() -> AllowlistChecker:
+    return AllowlistChecker(service_config=ServiceConfig.get_service_config())
 
 
 @pytest.fixture(scope="module")
@@ -611,7 +612,7 @@ def events(request) -> Iterable[tuple[github.abstract.GithubEvent, bool, Iterabl
 )
 def test_check_and_report(
     add_pull_request_event_with_empty_sha,
-    allowlist: Allowlist,
+    allowlist: AllowlistChecker,
     allowlist_entries,
     events: Iterable[tuple[github.abstract.GithubEvent, bool, Iterable[str]]],
 ):

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -28,7 +28,7 @@ from packit_service.events import (
     vm_image,
 )
 from packit_service.models import TFTTestRunTargetModel
-from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.handlers import (
     CoprBuildEndHandler,
     CoprBuildHandler,
@@ -3631,7 +3631,7 @@ def test_unapproved_jobs():
         [None, None, None],
     )
     # TODO: »do not« mock the ‹Allowlist› directly!!!
-    flexmock(Allowlist).should_receive("check_and_report").and_return(False)
+    flexmock(AllowlistChecker).should_receive("check_and_report").and_return(False)
 
     results = jobs.process_jobs()
     assert results and len(results) == 3, "we have gotten exactly 3 results"

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -37,7 +37,7 @@ from packit_service.models import (
     SyncReleaseTargetStatus,
 )
 from packit_service.service.urls import get_propose_downstream_info_url
-from packit_service.worker.allowlist import Allowlist
+from packit_service.worker.allowlist_checker import AllowlistChecker
 from packit_service.worker.helpers.sync_release.propose_downstream import (
     ProposeDownstreamJobHelper,
 )
@@ -204,7 +204,7 @@ def test_process_message(event, private, enabled_private_namespaces, success):
     ).and_return((pr, {})).times(1 if success else 0)
     flexmock(shutil).should_receive("rmtree").with_args("")
 
-    flexmock(Allowlist, check_and_report=True)
+    flexmock(AllowlistChecker, check_and_report=True)
     flexmock(group).should_receive("apply_async").times(1 if success else 0)
 
     flexmock(ProposeDownstreamJobHelper).should_receive(


### PR DESCRIPTION
## Summary

Split the allowlist module into two separate modules to break the circular import chain that caused `ImportError` on Python 3.14. This is a cleaner alternative to the local import workaround in PR #3178.

## Root Cause

The circular import chain was:
```
allowlist.py → helpers/testing_farm.py → checker/testing_farm.py
→ handlers/__init__.py → handlers/forges.py → allowlist.py
```

The issue occurred because `allowlist.py` imported job helpers (`CoprBuildJobHelper`, `TestingFarmJobHelper`) which eventually led back to importing `allowlist.py` through the handlers chain.

## Changes

### Core module (`allowlist.py`)
- Removed job helper imports (breaks the circular dependency)
- Kept all core allowlist management methods:
  - Static methods for checking/managing namespaces
  - FAS authentication methods
  - Namespace approval/denial methods

### New event checker module (`allowlist_checker.py`)
- Created `AllowlistChecker` class extending `Allowlist`
- Moved all event checking methods that depend on job helpers:
  - `check_and_report()` and all `_check_*()` event methods
  - `_check_pr_report_status()` which uses job helpers
- Imports job helpers only in this module

### Updated imports
- `jobs.py`: now uses `AllowlistChecker` for `check_and_report()`
- Test files: updated to use `AllowlistChecker` where needed
- `handlers/forges.py`: continues to use `Allowlist` (core methods only)

## Benefits Over Local Imports (PR #3178)

1. **Cleaner separation of concerns**: Core allowlist logic is separated from event checking/reporting
2. **No runtime overhead**: Local imports are checked on every method call
3. **Better maintainability**: Clear dependency boundaries make the code easier to understand
4. **Future-proof**: Works with all Python versions, including 3.14+

## Testing

The test from PR #3178 (`test_no_circular_import_in_allowlist`) now passes without needing local imports. The `allowlist.py` module can be imported independently:

```python
from packit_service.worker.allowlist import Allowlist  # ✓ No circular import!
```

## Related

Fixes #3177
Alternative to #3178

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)